### PR TITLE
chore(ci): standardize the fmt, clippy and test invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       run: cargo build --workspace --verbose
 
     - name: Run tests
-      run: cargo test --workspace --verbose
+      run: cargo test --workspace
 
     - name: Build release
       run: cargo build --workspace --release --verbose


### PR DESCRIPTION
Aligns the fmt, clippy and test invocations across all 14 Rust repos.

The one combination that actually mattered: four repos (`Bridge-Dealer-Service`, `bridge-solver-service`, `bridge-table-service`, `pbn-to-pdf`) ran `cargo clippy -- -D warnings` **without `--all-targets`**, so their test code was never linted. Verified rather than assumed — planting a `needless_range_loop` inside a `#[cfg(test)]` block in bridge-solver-service gave **0 errors** with the old command and **2** with `--all-targets`.

Now everywhere:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```

`--workspace`/`--all` are no-ops for single-crate repos and correct for the workspaces, so one form fits all.

**No toolchain pinning** — drift gets fixed as it appears rather than saved up for one large repin later.

All four repos that gained `--all-targets` were run locally first and pass, so this turns nothing red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)