### PR TITLE
feat: harden --input-deals with stdin, tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ echo "hcp(north) >= 0" | dealer -E S8743,HA9,D642,CQT64 -W SQ965,HK63,DAQJT,CA5 
 - `--vulnerable VULN` - Vulnerability (None/NS/EW/All)
 - `-T TEXT, --title TEXT` - Title metadata for PBN output
 
+### Deal Input
+- `--input-deals SOURCE` - Read deals from a file instead of generating them; use `-` for stdin
+
 ### Export
 - `-C FILE, --CSV FILE` - CSV export file
 
@@ -69,6 +72,36 @@ echo "hcp(north) >= 0" | dealer -E S8743,HA9,D642,CQT64 -W SQ965,HK63,DAQJT,CA5 
 - `-m, --progress` - Show progress meter
 - `-V, --version` - Show version information
 - `-h, --help` - Show help message
+
+## Filtering Existing Deals
+
+`--input-deals` reads deals from a file instead of generating them, then applies the
+script's constraints as usual. PBN and oneline formats are auto-detected.
+
+```bash
+# Filter an existing PBN file
+dealer filter.dlr --input-deals hands.pbn -f pbn
+
+# Read deals from stdin (script must be a file argument, since stdin is taken)
+cat hands.pbn | dealer filter.dlr --input-deals - -f oneline
+
+# Check how many deals in a file satisfy a constraint
+echo "hcp(north) >= 15" > strong.dlr
+dealer strong.dlr --input-deals hands.pbn -q -X
+```
+
+This makes filter behaviour reproducible independently of the RNG, which is how
+dealer3's regression tests compare constraint evaluation against dealer.exe.
+
+Notes:
+
+- `--seed` is ignored — the deals are supplied, not generated.
+- It cannot be combined with predeal, since predeal only applies to generation.
+- `-p` and `-g` still apply: `-p` stops once that many deals match, `-g` caps how many
+  are read. Running out of input before `-p` is satisfied is not an error.
+- Lines that are not recognised as deals are ignored, so PBN metadata and previous
+  stats output can be piped straight in. Check the reported `Generated N hands` count
+  to confirm every deal you expected was actually read.
 
 ## Constraint Language
 

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -102,6 +102,10 @@ struct Args {
 
     /// Read deals from a file instead of generating random ones.
     /// Supports PBN and oneline formats (auto-detected).
+    /// Use '-' to read deals from stdin (requires the script as a file argument).
+    /// Lines that are not recognised as deals are ignored, so PBN metadata and
+    /// stats output can be fed in directly; check the reported count to confirm
+    /// every expected deal was read.
     #[arg(long = "input-deals", value_name = "SOURCE")]
     input_deals: Option<String>,
 
@@ -728,10 +732,20 @@ fn main() {
         || fast_predeal_config.predeal_count(Position::West) > 0;
 
     // Validate --input-deals conflicts
-    if args.input_deals.is_some() {
+    if let Some(ref source) = args.input_deals {
         if has_predeal {
             eprintln!(
                 "Error: --input-deals cannot be combined with predeal (command-line or script)"
+            );
+            std::process::exit(1);
+        }
+        // `--input-deals -` reads deals from stdin, but stdin is already consumed by the
+        // script when no script file argument is given. Require an explicit script file.
+        if source == "-" && args.input_file.is_none() {
+            eprintln!(
+                "Error: --input-deals - reads deals from stdin, but the script is also being \
+                 read from stdin.\n       Pass the script as a file argument instead, e.g.: \
+                 dealer script.dlr --input-deals -"
             );
             std::process::exit(1);
         }
@@ -895,18 +909,33 @@ fn main() {
 
     // Choose execution mode: input-deals, legacy, or fast (parallel)
     if let Some(ref input_deals_source) = args.input_deals {
-        // Input-deals mode: read deals from file, apply filter
+        // Input-deals mode: read deals from a file or stdin, apply filter
         use bridge_encodings::DealReader;
-        use std::io::BufReader;
+        use std::io::{BufRead, BufReader};
 
-        let file = std::fs::File::open(input_deals_source).unwrap_or_else(|e| {
-            eprintln!(
-                "Error opening input deals file '{}': {}",
-                input_deals_source, e
-            );
-            std::process::exit(1);
-        });
-        let deal_reader = DealReader::new(BufReader::new(file));
+        // `-` means stdin; the guard above guarantees the script came from a file.
+        let source: Box<dyn BufRead> = if input_deals_source == "-" {
+            Box::new(BufReader::new(io::stdin()))
+        } else {
+            let file = std::fs::File::open(input_deals_source).unwrap_or_else(|e| {
+                eprintln!(
+                    "Error opening input deals file '{}': {}",
+                    input_deals_source, e
+                );
+                std::process::exit(1);
+            });
+            Box::new(BufReader::new(file))
+        };
+        let deal_reader = DealReader::new(source);
+
+        // DealReader silently ignores lines it does not recognise as deals, which is
+        // what lets PBN metadata and stats output be fed in directly. It only yields
+        // Err for I/O failures (e.g. invalid UTF-8 mid-stream). Those are recoverable,
+        // so skip rather than abort, and report the total at exit. Because unreadable
+        // *content* is indistinguishable from metadata, callers that need to know every
+        // deal arrived should compare the reported count against an expected total.
+        let mut skipped: usize = 0;
+        const MAX_SKIP_WARNINGS: usize = 10;
 
         for deal_result in deal_reader {
             // Check timeout every 1000 deals
@@ -927,8 +956,17 @@ fn main() {
             let bt_deal = match deal_result {
                 Ok(d) => d,
                 Err(e) => {
-                    eprintln!("Error reading deal: {}", e);
-                    std::process::exit(1);
+                    skipped += 1;
+                    if skipped <= MAX_SKIP_WARNINGS {
+                        eprintln!("Warning: skipping unreadable deal: {}", e);
+                        if skipped == MAX_SKIP_WARNINGS {
+                            eprintln!(
+                                "Warning: further malformed-deal warnings suppressed; \
+                                 total will be reported at exit"
+                            );
+                        }
+                    }
+                    continue;
                 }
             };
 
@@ -976,6 +1014,10 @@ fn main() {
             if generated >= max_generate {
                 break;
             }
+        }
+
+        if skipped > 0 {
+            eprintln!("Warning: skipped {} unreadable deal(s) from input", skipped);
         }
     } else if args.legacy {
         // Legacy mode: single-threaded with gnurandom for exact dealer.exe compatibility

--- a/dealer/tests/input_deals.rs
+++ b/dealer/tests/input_deals.rs
@@ -1,0 +1,384 @@
+//! Integration tests for `--input-deals`.
+//!
+//! These drive the real `dealer` binary so that argument parsing, the reader
+//! wiring and the filter path are all exercised together.
+//!
+//! The deal corpus below is fixed rather than generated, so the tests are
+//! hermetic: they do not depend on the RNG and will keep passing when the
+//! generator changes. North's HCP are noted per deal so the expected results of
+//! `hcp(north) >= 13` are checkable by hand.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// Six deals in oneline format. North HCP, in order: 11, 12, 12, 14, 8, 13.
+/// So `hcp(north) >= 13` matches exactly two of them (deals 4 and 6).
+const ONELINE_CORPUS: &str = "\
+n Q9.AJ5.8762.AT72 e KT432.Q84.J3.KQ8 s J85.762.AT94.J54 w A76.KT93.KQ5.963
+n QT4.QJ82.82.T763 e AJ83.A9.AK753.J5 s K962.65.Q9.AQ942 w 75.KT743.JT64.K8
+n AT2.A86.J942.K52 e 94.KJ.AKQ87.JT87 s J653.Q94.653.Q63 w KQ87.T7532.T.A94
+n AQ87532.T.KQ85.K e .K98752.AT74.Q85 s KJ94.A4.J3.A9642 w T6.QJ63.962.JT73
+n K6.J85.QT97642.5 e 84.Q94.K3.QJ9763 s AJ753.T.AJ8.AKT4 w QT92.AK7632.5.82
+n A9854.54.KT93.AQ e K73.QT872.A6.K54 s QJT62.J9.87.9832 w .AK63.QJ542.JT76
+";
+
+const FILTER: &str = "hcp(north) >= 13\n";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_dealer")
+}
+
+/// Write `contents` to a uniquely named temp file and return its path.
+fn temp_file(tag: &str, contents: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "dealer3-test-{}-{}-{:?}",
+        tag,
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::write(&path, contents).expect("failed to write temp file");
+    path
+}
+
+struct Output {
+    stdout: String,
+    stderr: String,
+    success: bool,
+}
+
+/// Run the binary with `args`, optionally piping `stdin_data` in.
+fn run(args: &[&str], stdin_data: Option<&str>) -> Output {
+    let mut child = Command::new(bin())
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn dealer");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin unavailable");
+        if let Some(data) = stdin_data {
+            stdin.write_all(data.as_bytes()).expect("write to stdin");
+        }
+    }
+    // Dropping stdin closes it, so the child sees EOF.
+    drop(child.stdin.take());
+
+    let out = child.wait_with_output().expect("failed to wait for dealer");
+    Output {
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        success: out.status.success(),
+    }
+}
+
+/// Count deal lines in oneline output (they all start with "n ").
+fn count_deals(stdout: &str) -> usize {
+    stdout.lines().filter(|l| l.starts_with("n ")).count()
+}
+
+#[test]
+fn reads_oneline_deals_from_file_and_applies_filter() {
+    let corpus = temp_file("oneline", ONELINE_CORPUS);
+    let script = temp_file("script-oneline", FILTER);
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        None,
+    );
+
+    assert!(out.success, "expected success, stderr: {}", out.stderr);
+    assert_eq!(
+        count_deals(&out.stdout),
+        2,
+        "expected 2 matching deals, got:\n{}",
+        out.stdout
+    );
+    assert!(
+        out.stdout.contains("Generated 6 hands"),
+        "expected all 6 deals to be read, got:\n{}",
+        out.stdout
+    );
+}
+
+#[test]
+fn reads_deals_from_stdin_with_dash() {
+    let script = temp_file("script-stdin", FILTER);
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            "-",
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        Some(ONELINE_CORPUS),
+    );
+
+    assert!(out.success, "expected success, stderr: {}", out.stderr);
+    assert_eq!(count_deals(&out.stdout), 2, "stdout:\n{}", out.stdout);
+    assert!(out.stdout.contains("Generated 6 hands"));
+}
+
+#[test]
+fn dash_without_script_file_is_rejected() {
+    // The script would also come from stdin, so this cannot work. It must fail
+    // with a clear message rather than silently consuming the wrong input.
+    let out = run(&["--input-deals", "-", "-f", "oneline"], Some(FILTER));
+
+    assert!(
+        !out.success,
+        "expected failure, stdout:\n{}\nstderr:\n{}",
+        out.stdout, out.stderr
+    );
+    assert!(
+        out.stderr.contains("also being read from stdin"),
+        "expected an explanatory error, stderr:\n{}",
+        out.stderr
+    );
+}
+
+#[test]
+fn reads_pbn_deal_tags() {
+    // Two PBN deals surrounded by metadata, which must be ignored.
+    let pbn = "\
+[Event \"Test\"]
+[Site \"Nowhere\"]
+[Board \"1\"]
+[Deal \"N:AQ87532.T.KQ85.K .K98752.AT74.Q85 KJ94.A4.J3.A9642 T6.QJ63.962.JT73\"]
+
+[Event \"Test\"]
+[Board \"2\"]
+[Deal \"N:Q9.AJ5.8762.AT72 KT432.Q84.J3.KQ8 J85.762.AT94.J54 A76.KT93.KQ5.963\"]
+";
+    let corpus = temp_file("pbn", pbn);
+    let script = temp_file("script-pbn", FILTER);
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        None,
+    );
+
+    assert!(out.success, "expected success, stderr: {}", out.stderr);
+    assert!(
+        out.stdout.contains("Generated 2 hands"),
+        "expected 2 deals read past the metadata, got:\n{}",
+        out.stdout
+    );
+    // Only the 14-HCP deal clears the filter.
+    assert_eq!(count_deals(&out.stdout), 1, "stdout:\n{}", out.stdout);
+}
+
+#[test]
+fn unrecognised_lines_are_ignored() {
+    // DealReader skips anything it cannot parse as a deal, which is what allows
+    // PBN metadata and stats output to be piped in. Interleave junk with deals
+    // and confirm only the real deals are counted.
+    let mut mixed = String::new();
+    for (i, line) in ONELINE_CORPUS.lines().enumerate() {
+        mixed.push_str(line);
+        mixed.push('\n');
+        if i == 1 {
+            mixed.push_str("this is not a deal at all\n");
+            mixed.push_str("Generated 999 hands\n");
+        }
+    }
+    let corpus = temp_file("mixed", &mixed);
+    let script = temp_file("script-mixed", FILTER);
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        None,
+    );
+
+    assert!(out.success, "expected success, stderr: {}", out.stderr);
+    assert!(
+        out.stdout.contains("Generated 6 hands"),
+        "junk lines should not affect the deal count, got:\n{}",
+        out.stdout
+    );
+    assert_eq!(count_deals(&out.stdout), 2, "stdout:\n{}", out.stdout);
+}
+
+#[test]
+fn empty_input_produces_nothing() {
+    let corpus = temp_file("empty", "");
+    let script = temp_file("script-empty", FILTER);
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        None,
+    );
+
+    assert!(out.success, "expected success, stderr: {}", out.stderr);
+    assert_eq!(count_deals(&out.stdout), 0);
+    assert!(
+        out.stdout.contains("Generated 0 hands"),
+        "stdout:\n{}",
+        out.stdout
+    );
+}
+
+#[test]
+fn produce_limit_stops_early() {
+    // Filter matches everything; -p 3 must stop after 3 deals.
+    let corpus = temp_file("produce", ONELINE_CORPUS);
+    let script = temp_file("script-produce", "hcp(north) >= 0\n");
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-p",
+            "3",
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        None,
+    );
+
+    assert!(out.success, "expected success, stderr: {}", out.stderr);
+    assert_eq!(count_deals(&out.stdout), 3, "stdout:\n{}", out.stdout);
+    assert!(
+        out.stdout.contains("Produced 3 hands"),
+        "stdout:\n{}",
+        out.stdout
+    );
+}
+
+#[test]
+fn generate_limit_caps_deals_read() {
+    // -g 2 must stop reading after 2 deals even though 6 are available.
+    let corpus = temp_file("generate", ONELINE_CORPUS);
+    let script = temp_file("script-generate", "hcp(north) >= 0\n");
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-g",
+            "2",
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        None,
+    );
+
+    assert!(out.success, "expected success, stderr: {}", out.stderr);
+    assert!(
+        out.stdout.contains("Generated 2 hands"),
+        "stdout:\n{}",
+        out.stdout
+    );
+}
+
+#[test]
+fn input_exhausted_before_produce_target_is_not_an_error() {
+    // Only 2 deals match, but -p 40 is requested. Running out of input should
+    // exit cleanly with what was found, not hang or fail.
+    let corpus = temp_file("exhausted", ONELINE_CORPUS);
+    let script = temp_file("script-exhausted", FILTER);
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-p",
+            "40",
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        None,
+    );
+
+    assert!(out.success, "expected success, stderr: {}", out.stderr);
+    assert_eq!(count_deals(&out.stdout), 2, "stdout:\n{}", out.stdout);
+    assert!(
+        out.stdout.contains("Produced 2 hands"),
+        "stdout:\n{}",
+        out.stdout
+    );
+}
+
+#[test]
+fn predeal_conflict_is_rejected() {
+    let corpus = temp_file("predeal", ONELINE_CORPUS);
+    let script = temp_file("script-predeal", FILTER);
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-N",
+            "SA,HK",
+        ],
+        None,
+    );
+
+    assert!(!out.success, "expected failure, stdout:\n{}", out.stdout);
+    assert!(
+        out.stderr.contains("cannot be combined with predeal"),
+        "stderr:\n{}",
+        out.stderr
+    );
+}
+
+#[test]
+fn missing_input_file_is_reported() {
+    let script = temp_file("script-missing", FILTER);
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            "/nonexistent/path/to/deals.pbn",
+        ],
+        None,
+    );
+
+    assert!(!out.success, "expected failure, stdout:\n{}", out.stdout);
+    assert!(
+        out.stderr.contains("Error opening input deals file"),
+        "stderr:\n{}",
+        out.stderr
+    );
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--input-deals -` now reads deals from stdin, so deals can be piped in without a
+  temporary file. Requires the script to be passed as a file argument, since stdin is
+  otherwise consumed by the script itself; a clear error is emitted if both would
+  contend for stdin.
+- Integration test coverage for `--input-deals` (PBN, oneline, stdin, limits, conflicts)
+
+### Changed
+- Unreadable deals encountered while reading `--input-deals` are now skipped with a
+  warning and a total reported at exit, rather than aborting the run
+- Documented `--input-deals` in the README and CLI design notes
+
 ## [0.4.0] - 2026-01-21
 
 ### Added

--- a/docs/CLI_DESIGN.md
+++ b/docs/CLI_DESIGN.md
@@ -71,6 +71,20 @@ dealer [OPTIONS] [inputfile]
 - Pre-generated deal library feature
 - Default: None
 
+**`--input-deals SOURCE`** - Read deals instead of generating them
+- Reads deals from `SOURCE` and applies the script's constraints to each
+- PBN and oneline formats are auto-detected
+- `-` reads from stdin; the script must then be given as a file argument, since
+  stdin is otherwise consumed by the script itself
+- `--seed` is ignored, and predeal is rejected as a conflict — both only apply to
+  generation
+- `-p` stops after that many matches; `-g` caps how many deals are read; exhausting
+  the input before `-p` is satisfied exits cleanly
+- Unrecognised lines are skipped, so PBN metadata and stats output can be piped in
+  directly. Because unreadable content is indistinguishable from metadata, callers
+  needing certainty should compare the reported deal count against an expected total
+- Default: Off (deals are generated)
+
 ### Help & Info
 
 **`-h`, `-?`** - Help


### PR DESCRIPTION
Second of five PRs implementing #3. Independent of #4 — branched from `main`, so they can merge in either order.

## Why

`--input-deals` was already implemented but had **zero tests and zero documentation**. It is about to become the foundation of the Tier 1 regression corpus, so it needs to be trustworthy first.

## Changes

**stdin support.** `--input-deals -` reads deals from stdin. This needed a guard: when no script file argument is given, the script itself is read from stdin, so both would contend for the same handle. That case now fails with an explanatory message rather than silently consuming the wrong input:

```
$ echo "hcp(north) >= 13" | dealer --input-deals -
Error: --input-deals - reads deals from stdin, but the script is also being read from stdin.
       Pass the script as a file argument instead, e.g.: dealer script.dlr --input-deals -
```

**Unreadable deals no longer abort the run.** Previously any read error called `std::process::exit(1)`. Now they are skipped with a warning (capped at 10 to avoid flooding) and a total reported at exit.

**11 integration tests** in `dealer/tests/input_deals.rs`, driving the real binary via `CARGO_BIN_EXE_dealer`. The corpus is fixed rather than generated, so the tests are hermetic and will survive RNG changes — North's HCP are documented per deal so expected results are checkable by hand.

Covered: oneline input, PBN `[Deal ...]` tags surrounded by metadata, stdin, the stdin-conflict guard, unrecognised lines, empty input, `-p` limit, `-g` limit, input exhausted before `-p` is satisfied, predeal conflict, missing file.

**Docs** in `README.md` (new "Filtering Existing Deals" section) and `docs/CLI_DESIGN.md`.

## Worth knowing: reader semantics

`DealReader` **silently ignores** lines it cannot parse as deals — see [`reader.rs:141`](https://github.com/bridge-craftwork/bridge-encodings/blob/main/src/reader.rs) — which is exactly what allows PBN metadata and prior stats output to be piped in. It only yields `Err` for I/O failures.

The consequence: unreadable *content* is indistinguishable from metadata, so a truncated or corrupted corpus reads short **silently**. That matters for Tier 1, where a short read could make a test pass for the wrong reason.

Rather than fight the library's contract (it lives in another repo and the behaviour is right for PBN), the mitigation is at the caller: the docs direct anyone needing certainty to check the reported `Generated N hands` count, and the Tier 1 manifest in PR 3 will carry the expected count so `corpus_replay` can assert on it.

## Verification

- 193 tests pass (182 on `main` + 11 new)
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- Manually smoke-tested file input, stdin input, the conflict guard, and mixed metadata

Refs #3