### PR TITLE
feat: WebAssembly bindings and a single source of truth for the grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ activity-log.json
 
 # Corpus generation scratch (see docs/REGRESSION_TESTING.md)
 .corpus-tmp/
+
+# WebAssembly build output
+wasm/pkg/
+wasm/pkg-node/
+wasm/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["dealer-core", "dealer-parser", "dealer-pbn", "dealer-eval", "dealer", "dealer-dds"]
 resolver = "2"
+
+# Built only for wasm32, with its own lockfile. Excluded so `cargo test
+# --workspace` does not drag wasm-bindgen into the host build.
+exclude = ["wasm"]

--- a/dealer-parser/src/lib.rs
+++ b/dealer-parser/src/lib.rs
@@ -1,6 +1,7 @@
 mod ast;
 mod parser;
 mod preprocess;
+pub mod vocabulary;
 
 pub use ast::*;
 pub use parser::{parse, parse_program, ParseError};

--- a/dealer-parser/src/vocabulary.rs
+++ b/dealer-parser/src/vocabulary.rs
@@ -1,0 +1,143 @@
+//! The language's vocabulary, in one place.
+//!
+//! Editors need the same word lists the parser recognises: syntax highlighting,
+//! completion, and hover all depend on them. Keeping a second copy in a
+//! TextMate grammar or an editor plugin means it drifts — and it did. Before
+//! this module existed, `dlr.tmLanguage.json` was missing 19 functions
+//! (`tens`, `jacks`, `queens`, `kings`, `aces`, `top2`..`top5`, `pt0`..`pt9`),
+//! missing the `csvrpt` keyword, and listing two functions that do not exist
+//! (`control`, `imp`).
+//!
+//! These lists are the source of truth. `tests/vocabulary_matches_grammar.rs`
+//! asserts they agree with `grammar.pest`, and
+//! `tests/tmlanguage_matches_vocabulary.rs` asserts the shipped TextMate grammar
+//! agrees with them, so a new function cannot be added to the parser without the
+//! editors noticing.
+
+/// Functions callable in an expression, e.g. `hcp(north)`.
+pub const FUNCTIONS: &[&str] = &[
+    // Hand evaluation
+    "hcp", "controls", "losers", "loser", "quality", "cccc",
+    // Shape and specific cards
+    "shape", "hascard",
+    // Suit lengths — plural and singular forms are both accepted
+    "spades", "hearts", "diamonds", "clubs", "spade", "heart", "diamond", "club",
+    // Named point counts
+    "tens", "jacks", "queens", "kings", "aces", "top2", "top3", "top4", "top5", "c13",
+    // Indexed point counts
+    "pt0", "pt1", "pt2", "pt3", "pt4", "pt5", "pt6", "pt7", "pt8", "pt9",
+    // Double-dummy and scoring
+    "tricks", "score", "imps",
+];
+
+/// Statement keywords that introduce a directive.
+pub const STATEMENT_KEYWORDS: &[&str] = &[
+    "condition",
+    "produce",
+    "generate",
+    "action",
+    "dealer",
+    "vulnerable",
+    "predeal",
+    "csvrpt",
+    "average",
+    "frequency",
+];
+
+/// Output actions, valid inside `action` or standalone.
+pub const ACTIONS: &[&str] = &[
+    "printall",
+    "printew",
+    "printpbn",
+    "printcompact",
+    "printoneline",
+];
+
+/// Compass positions. Single letters are accepted but may be shadowed by a
+/// variable of the same name, which the evaluator allows deliberately.
+pub const POSITIONS: &[&str] = &["north", "south", "east", "west", "n", "s", "e", "w"];
+
+/// Vulnerability settings.
+pub const VULNERABILITIES: &[&str] = &["none", "ns", "ew", "all"];
+
+/// Word-form logical operators, alternatives to `&&`, `||` and `!`.
+pub const LOGICAL_WORDS: &[&str] = &["and", "or", "not"];
+
+/// Other reserved words: `any` introduces a shape pattern, `deal` is a csvrpt term.
+pub const OTHER_KEYWORDS: &[&str] = &["any", "deal"];
+
+/// Symbolic operators, longest-first so a tokenizer matching in order does not
+/// split `>=` into `>` and `=`.
+pub const OPERATORS: &[&str] = &[
+    "==", "!=", ">=", "<=", "&&", "||", ">", "<", "!", "?", ":", "+", "-", "*", "/", "%", "=",
+];
+
+/// Every reserved word, for "is this an identifier or a keyword" checks.
+pub fn all_reserved() -> Vec<&'static str> {
+    let mut v = Vec::new();
+    for list in [
+        FUNCTIONS,
+        STATEMENT_KEYWORDS,
+        ACTIONS,
+        POSITIONS,
+        VULNERABILITIES,
+        LOGICAL_WORDS,
+        OTHER_KEYWORDS,
+    ] {
+        v.extend_from_slice(list);
+    }
+    v.sort_unstable();
+    v.dedup();
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_duplicates_within_a_list() {
+        for (name, list) in [
+            ("FUNCTIONS", FUNCTIONS),
+            ("STATEMENT_KEYWORDS", STATEMENT_KEYWORDS),
+            ("ACTIONS", ACTIONS),
+            ("POSITIONS", POSITIONS),
+            ("VULNERABILITIES", VULNERABILITIES),
+            ("LOGICAL_WORDS", LOGICAL_WORDS),
+            ("OTHER_KEYWORDS", OTHER_KEYWORDS),
+            ("OPERATORS", OPERATORS),
+        ] {
+            let mut seen = list.to_vec();
+            seen.sort_unstable();
+            let before = seen.len();
+            seen.dedup();
+            assert_eq!(before, seen.len(), "{} contains duplicates", name);
+        }
+    }
+
+    #[test]
+    fn operators_are_longest_first() {
+        // A tokenizer trying these in order must not match `>` before `>=`.
+        for (i, op) in OPERATORS.iter().enumerate() {
+            for longer in &OPERATORS[i + 1..] {
+                assert!(
+                    !longer.starts_with(op),
+                    "`{}` precedes `{}`, which it is a prefix of",
+                    op,
+                    longer
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn all_reserved_covers_every_list() {
+        let all = all_reserved();
+        for f in FUNCTIONS {
+            assert!(all.contains(f), "{} missing from all_reserved()", f);
+        }
+        for k in STATEMENT_KEYWORDS {
+            assert!(all.contains(k), "{} missing from all_reserved()", k);
+        }
+    }
+}

--- a/dealer-parser/syntaxes/dlr.tmLanguage.json
+++ b/dealer-parser/syntaxes/dlr.tmLanguage.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "DLR",
+  "scopeName": "source.dlr",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#variable-definition"
+    },
+    {
+      "include": "#numbers"
+    },
+    {
+      "include": "#user-variables"
+    },
+    {
+      "include": "#operators"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.dlr",
+          "match": "//.*$"
+        },
+        {
+          "name": "comment.line.hash.section.dlr",
+          "match": "(#####)\\s*(Imported Script|End of Imported Script)(:?)\\s*(.*?)\\s*(#####)?$",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.dlr"
+            },
+            "2": {
+              "name": "entity.name.section.dlr"
+            },
+            "3": {
+              "name": "punctuation.separator.dlr"
+            },
+            "4": {
+              "name": "entity.name.tag.dlr"
+            },
+            "5": {
+              "name": "punctuation.definition.comment.dlr"
+            }
+          }
+        },
+        {
+          "name": "comment.line.hash.metadata.dlr",
+          "match": "(#)\\s*(button-text|scenario-title|[a-zA-Z-]+)(:)\\s*(.*)$",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.dlr"
+            },
+            "2": {
+              "name": "entity.name.tag.dlr"
+            },
+            "3": {
+              "name": "punctuation.separator.dlr"
+            },
+            "4": {
+              "name": "string.unquoted.dlr"
+            }
+          }
+        },
+        {
+          "name": "comment.line.hash.dlr",
+          "match": "#.*$"
+        },
+        {
+          "name": "comment.block.dlr",
+          "begin": "/\\*",
+          "end": "\\*/",
+          "patterns": [
+            {
+              "name": "meta.directive.dlr",
+              "match": "(convention-card-ns|convention-card-ew|auction-filter)(:)\\s*(.*)",
+              "captures": {
+                "1": {
+                  "name": "entity.name.tag.dlr"
+                },
+                "2": {
+                  "name": "punctuation.separator.dlr"
+                },
+                "3": {
+                  "name": "string.unquoted.dlr"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.dlr",
+          "match": "\\b(printcompact|printoneline|vulnerable|condition|frequency|generate|printall|printpbn|average|predeal|printew|produce|action|csvrpt|dealer)\\b"
+        },
+        {
+          "name": "keyword.other.condition.dlr",
+          "match": "\\b(deal|and|any|not|!=|&&|<=|==|>=|or||||!|%|*|+|-|/|:|<|=|>|?)\\b"
+        },
+        {
+          "name": "support.function.dlr",
+          "match": "\\b(controls|diamonds|diamond|hascard|quality|hearts|losers|queens|spades|tricks|clubs|heart|jacks|kings|loser|score|shape|spade|aces|cccc|club|imps|tens|top2|top3|top4|top5|c13|hcp|pt0|pt1|pt2|pt3|pt4|pt5|pt6|pt7|pt8|pt9)\\b"
+        },
+        {
+          "name": "constant.language.dlr",
+          "match": "\\b(north|south|deal|east|none|west|all|and|any|not|!=|&&|<=|==|>=|ew|ns|or||||!|%|*|+|-|/|:|<|=|>|?)\\b"
+        },
+        {
+          "name": "constant.language.compass.dlr",
+          "match": "\\b(!|%|*|+|-|/|:|<|=|>|?|e|n|s|w)\\b(?=\\s*[,)\\s])"
+        },
+        {
+          "name": "constant.language.vulnerability.dlr",
+          "match": "(?i)\\b(deal|none|all|and|any|not|!=|&&|<=|==|>=|ew|ns|or||||!|%|*|+|-|/|:|<|=|>|?)\\b"
+        },
+        {
+          "name": "constant.other.holding.dlr",
+          "match": "\\b([SHDC][AKQJT98765432]*)\\b"
+        },
+        {
+          "name": "constant.other.card.dlr",
+          "match": "\\b([AKQJT98765432][SHDC])\\b"
+        },
+        {
+          "name": "constant.numeric.shape.dlr",
+          "match": "(%s)?\\b[0-9xX]{4}\\b"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.dlr",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.dlr",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "variable-definition": {
+      "patterns": [
+        {
+          "match": "^\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s*(=)",
+          "captures": {
+            "1": {
+              "name": "variable.other.definition.dlr"
+            },
+            "2": {
+              "name": "keyword.operator.assignment.dlr"
+            }
+          }
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.dlr",
+          "match": "\\b\\d+\\b"
+        }
+      ]
+    },
+    "user-variables": {
+      "patterns": [
+        {
+          "name": "variable.other.user.dlr",
+          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b(?!\\s*\\()"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.dlr",
+          "match": "(==|!=|>=|<=|>|<|&&|\\|\\||\\?|:|\\+|-|\\*|/)"
+        }
+      ]
+    }
+  },
+  "information_for_contributors": [
+    "Generated from dealer3's dealer-parser/src/vocabulary.rs.",
+    "Do not hand-edit the word lists: dealer-parser/tests/tmlanguage_matches_vocabulary.rs",
+    "fails the build if they drift from the parser's grammar.",
+    "Regenerate with scripts/generate-tmlanguage.py."
+  ]
+}

--- a/dealer-parser/tests/tmlanguage_matches_vocabulary.rs
+++ b/dealer-parser/tests/tmlanguage_matches_vocabulary.rs
@@ -1,0 +1,86 @@
+//! Asserts the shipped TextMate grammar covers the language's full vocabulary.
+//!
+//! `syntaxes/dlr.tmLanguage.json` drives syntax highlighting in both the VS Code
+//! extension and the web editor. It is generated from `vocabulary.rs` by
+//! `scripts/generate-tmlanguage.py`; this test is what stops it silently falling
+//! behind. Before it existed the grammar was missing 19 functions and the
+//! `csvrpt` keyword, and listed two functions that do not exist.
+
+use dealer_parser::vocabulary::*;
+
+const TMLANGUAGE: &str = include_str!("../syntaxes/dlr.tmLanguage.json");
+
+/// Every alternation body in the grammar's `match` patterns, concatenated.
+/// Crude, but enough to answer "does this word appear as a highlighted term".
+fn highlighted_words() -> Vec<String> {
+    let mut words = Vec::new();
+    for line in TMLANGUAGE.lines() {
+        let Some(start) = line.find("\\\\b(") else {
+            continue;
+        };
+        let rest = &line[start + 4..];
+        let Some(end) = rest.find(')') else { continue };
+        for w in rest[..end].split('|') {
+            let w = w.trim();
+            if !w.is_empty() {
+                words.push(w.to_string());
+            }
+        }
+    }
+    words
+}
+
+fn assert_all_covered(what: &str, expected: &[&str]) {
+    let words = highlighted_words();
+    let missing: Vec<&&str> = expected
+        .iter()
+        .filter(|w| !words.contains(&w.to_string()))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "{} not highlighted by syntaxes/dlr.tmLanguage.json: {:?}\n\n\
+         Regenerate it with:\n  python3 scripts/generate-tmlanguage.py\n\n\
+         The grammar is shared with the Practice-Bidding-Scenarios VS Code \
+         extension, so a gap here is a gap in both editors.",
+        what,
+        missing
+    );
+}
+
+#[test]
+fn all_functions_are_highlighted() {
+    assert_all_covered("functions", FUNCTIONS);
+}
+
+#[test]
+fn all_statement_keywords_are_highlighted() {
+    assert_all_covered("statement keywords", STATEMENT_KEYWORDS);
+}
+
+#[test]
+fn all_actions_are_highlighted() {
+    assert_all_covered("actions", ACTIONS);
+}
+
+#[test]
+fn all_logical_words_are_highlighted() {
+    assert_all_covered("logical words", LOGICAL_WORDS);
+}
+
+#[test]
+fn no_phantom_functions() {
+    // The reverse direction: the grammar must not advertise functions the parser
+    // does not accept. `control` and `imp` were listed for years and are not real.
+    let real = all_reserved();
+    let words = highlighted_words();
+    let suspect: Vec<&String> = words
+        .iter()
+        .filter(|w| w.chars().all(|c| c.is_ascii_lowercase()) && w.len() > 2)
+        .filter(|w| !real.contains(&w.as_str()))
+        .collect();
+    assert!(
+        suspect.is_empty(),
+        "syntaxes/dlr.tmLanguage.json highlights words the parser does not accept: {:?}",
+        suspect
+    );
+}

--- a/dealer-parser/tests/vocabulary_matches_grammar.rs
+++ b/dealer-parser/tests/vocabulary_matches_grammar.rs
@@ -1,0 +1,150 @@
+//! Asserts `vocabulary.rs` agrees with `grammar.pest`.
+//!
+//! The vocabulary lists exist so editors can highlight and complete the same
+//! words the parser accepts. That is only true if they stay in step with the
+//! grammar, so this extracts the word lists straight out of the PEG source and
+//! compares them. Adding a function to the grammar without listing it here
+//! fails the build.
+
+use std::collections::BTreeSet;
+
+const GRAMMAR: &str = include_str!("../src/grammar.pest");
+
+/// Pull the body of a named rule out of the grammar source.
+fn rule_body(name: &str) -> String {
+    let start = GRAMMAR
+        .find(&format!("{} = ", name))
+        .unwrap_or_else(|| panic!("rule `{}` not found in grammar.pest", name));
+    let rest = &GRAMMAR[start..];
+    let open = rest.find('{').expect("rule has no body");
+    let mut depth = 0usize;
+    for (i, c) in rest[open..].char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return rest[open..open + i + 1].to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unterminated body for rule `{}`", name);
+}
+
+/// String literals in a rule body, both `"x"` and case-insensitive `^"x"`.
+fn literals(body: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let bytes: Vec<char> = body.chars().collect();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == '"' {
+            let mut j = i + 1;
+            let mut s = String::new();
+            while j < bytes.len() && bytes[j] != '"' {
+                s.push(bytes[j]);
+                j += 1;
+            }
+            // Keep only word literals. Character-class members from negative
+            // lookaheads (e.g. `!(ASCII_ALPHANUMERIC | "_")`) are not vocabulary.
+            if !s.is_empty()
+                && s.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
+                && s.chars().all(|c| c.is_ascii_alphanumeric())
+            {
+                out.insert(s);
+            }
+            i = j + 1;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+fn as_set(list: &[&str]) -> BTreeSet<String> {
+    list.iter().map(|s| s.to_string()).collect()
+}
+
+fn compare(what: &str, from_grammar: BTreeSet<String>, from_vocab: BTreeSet<String>) {
+    let missing: Vec<_> = from_grammar.difference(&from_vocab).collect();
+    let extra: Vec<_> = from_vocab.difference(&from_grammar).collect();
+    assert!(
+        missing.is_empty() && extra.is_empty(),
+        "{} is out of step with grammar.pest\n  \
+         in grammar but not in vocabulary.rs: {:?}\n  \
+         in vocabulary.rs but not in grammar: {:?}\n\n\
+         Editors take their word lists from vocabulary.rs, so a mismatch means \
+         highlighting and completion disagree with the parser.",
+        what,
+        missing,
+        extra
+    );
+}
+
+#[test]
+fn functions_match_grammar() {
+    compare(
+        "FUNCTIONS",
+        literals(&rule_body("function_name")),
+        as_set(dealer_parser::vocabulary::FUNCTIONS),
+    );
+}
+
+#[test]
+fn actions_match_grammar() {
+    // `action_type` and the standalone `print_stmt` must list the same actions.
+    let from_action = literals(&rule_body("action_type"));
+    let from_print = literals(&rule_body("print_stmt"));
+    assert_eq!(
+        from_action, from_print,
+        "action_type and print_stmt list different actions"
+    );
+    compare(
+        "ACTIONS",
+        from_action,
+        as_set(dealer_parser::vocabulary::ACTIONS),
+    );
+}
+
+#[test]
+fn vulnerabilities_match_grammar() {
+    compare(
+        "VULNERABILITIES",
+        literals(&rule_body("vulnerability")),
+        as_set(dealer_parser::vocabulary::VULNERABILITIES),
+    );
+}
+
+#[test]
+fn positions_match_grammar() {
+    compare(
+        "POSITIONS",
+        literals(&rule_body("position")),
+        as_set(dealer_parser::vocabulary::POSITIONS),
+    );
+}
+
+#[test]
+fn statement_keywords_are_all_in_the_grammar() {
+    // Statement keywords appear across many `*_stmt` rules, so rather than
+    // enumerate the rules, check each keyword occurs as a literal somewhere.
+    for kw in dealer_parser::vocabulary::STATEMENT_KEYWORDS {
+        assert!(
+            GRAMMAR.contains(&format!("^\"{}\"", kw)),
+            "statement keyword `{}` does not appear in grammar.pest",
+            kw
+        );
+    }
+}
+
+#[test]
+fn logical_words_are_all_in_the_grammar() {
+    for w in dealer_parser::vocabulary::LOGICAL_WORDS {
+        assert!(
+            GRAMMAR.contains(&format!("^\"{}\"", w)),
+            "logical word `{}` does not appear in grammar.pest",
+            w
+        );
+    }
+}

--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -1,0 +1,128 @@
+# WebAssembly build
+
+dealer3's engine compiles to WebAssembly, so scripts can be written and run in a
+browser with no server. Same parser, same evaluator, same generator as the CLI.
+
+## Building
+
+```bash
+cd wasm
+./build.sh web       # ES module for the browser  -> wasm/pkg/
+./build.sh nodejs    # CommonJS, used by tests    -> wasm/pkg-node/
+./build.sh both
+```
+
+Requires [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) and the
+`wasm32-unknown-unknown` target (`rustup target add wasm32-unknown-unknown`).
+
+Current size: **~1015 KB raw, ~351 KB gzipped**, including the double-dummy
+solver pulled in transitively via `dealer-dds`.
+
+## Why it works cleanly
+
+Every browser-hostile construct — `std::fs`, `io::stdin`, `process::exit`,
+`SystemTime::now()`, rayon — lives in the `dealer` binary. The library crates
+(`dealer-core`, `dealer-parser`, `dealer-eval`, `dealer-pbn`) were already
+portable, so the bindings are a thin wrapper rather than a port.
+
+## Output matches the native binary
+
+For the same seed and script, the wasm build produces byte-identical deals to
+`target/release/dealer`. Verify:
+
+```bash
+cd wasm && ./build.sh nodejs
+printf 'condition hcp(north) >= 12\n' > /tmp/v.dlr
+../target/release/dealer /tmp/v.dlr -s 7 -p 5 -f oneline | sed 's/[[:space:]]*$//' > /tmp/native.txt
+node -e '
+  const w = require("./pkg-node/dealer3_wasm.js");
+  console.log(JSON.parse(w.generate("condition hcp(north) >= 12\n",7,5,100000,"oneline")).deals.join("\n"));
+' > /tmp/wasm.txt
+diff /tmp/native.txt /tmp/wasm.txt && echo identical
+```
+
+This is why the Tier 2 regression hashes (`dealer/tests/regression_hash.rs`)
+cover this build too: it is the same generator.
+
+## API
+
+| Export | Returns | Notes |
+|---|---|---|
+| `generate(script, seed, produce, max_generate, format)` | JSON | `format` is `"oneline"` or `"printall"` |
+| `check_script(script)` | JSON | Never throws — safe to call per keystroke |
+| `language_info()` | JSON | Full vocabulary for completion and hover |
+| `version()` | string | Engine version |
+
+### `generate`
+
+```json
+{ "deals": ["n AKQ..."], "generated": 156, "produced": 20, "hit_limit": false }
+```
+
+`max_generate` bounds the work. A browser tab has no Ctrl-C, so a selective
+filter must not be able to hang it. **Surface `hit_limit`** rather than silently
+showing a short result — it distinguishes "no more matches exist" from "ran out
+of budget".
+
+### `check_script`
+
+```json
+{ "ok": false, "error": "Parse error:  --> 1:23\n...", "line": 1, "column": 23 }
+```
+
+Returns JSON rather than throwing, so an editor can call it on every keystroke.
+Line and column come from the parser itself, so editor diagnostics agree with the
+engine by construction — not by regex approximation.
+
+### `language_info`
+
+Function names, keywords, actions, positions, vulnerabilities and operators, from
+`dealer_parser::vocabulary`. That module is checked against `grammar.pest` by
+`dealer-parser/tests/vocabulary_matches_grammar.rs`, so an editor built on this
+cannot advertise a function the parser does not accept.
+
+## Syntax highlighting
+
+`dealer-parser/syntaxes/dlr.tmLanguage.json` is a TextMate grammar generated from
+the same vocabulary:
+
+```bash
+python3 scripts/generate-tmlanguage.py                      # dealer3 only
+python3 scripts/generate-tmlanguage.py --also-update-vscode # + PBS extension
+```
+
+Two tests keep it honest — `vocabulary_matches_grammar.rs` (vocabulary vs the
+PEG) and `tmlanguage_matches_vocabulary.rs` (grammar file vs vocabulary). Before
+they existed the shipped grammar was missing 19 functions (`tens`, `jacks`,
+`queens`, `kings`, `aces`, `top2`–`top5`, `pt0`–`pt9`) and the `csvrpt` keyword,
+and highlighted two functions that do not exist (`control`, `imp`).
+
+Monaco can load this file directly via `vscode-textmate` + `vscode-oniguruma`,
+so the web editor and the VS Code extension share one definition.
+
+## Threading
+
+The current build is **single-threaded**. Shared memory in wasm requires
+`SharedArrayBuffer`, which requires `COOP`/`COEP` response headers:
+
+```
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+**GitHub Pages cannot set custom headers, so a threaded build cannot be hosted
+there.** Cloudflare Pages can, via a `_headers` file.
+
+Deal generation is stateless per seed, so a threaded build produces *identical*
+output — only faster. Any threaded build should feature-detect
+`SharedArrayBuffer` and fall back to single-threaded rather than failing, so the
+page still works where the headers are absent.
+
+## Known gaps
+
+- **PBN output is not exposed.** `format_printpbn` calls `chrono::Local::now()`
+  for the `[Date]` tag, whose behaviour under `wasmbind` is unverified. Adding it
+  should pass the date in from JS rather than reading a clock.
+- **Double-dummy functions (`tricks`, `score`, `imps`) are untested in wasm.**
+  They compile and link — `bridge-solver` already ships to browsers elsewhere —
+  but no test exercises them through these bindings yet.

--- a/scripts/generate-tmlanguage.py
+++ b/scripts/generate-tmlanguage.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+generate-tmlanguage.py - Regenerate the DLR TextMate grammar from the parser's
+vocabulary.
+
+The word lists in dealer-parser/src/vocabulary.rs are the source of truth, and
+are themselves checked against grammar.pest by
+dealer-parser/tests/vocabulary_matches_grammar.rs. This script projects them
+into the TextMate grammar used for syntax highlighting by both the web editor
+and the Practice-Bidding-Scenarios VS Code extension.
+
+Run after adding a function or keyword to the language:
+
+    python3 scripts/generate-tmlanguage.py
+    cargo test -p dealer-parser
+
+Writes:
+    dealer-parser/syntaxes/dlr.tmLanguage.json
+
+Pass --also-update-vscode to copy the result into the PBS extension as well.
+"""
+import json
+import os
+import re
+import shutil
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+VOCAB = os.path.join(REPO, "dealer-parser", "src", "vocabulary.rs")
+OUT = os.path.join(REPO, "dealer-parser", "syntaxes", "dlr.tmLanguage.json")
+VSCODE = os.path.normpath(os.path.join(
+    REPO, "..", "Practice-Bidding-Scenarios", "vs-code", "syntaxes", "dlr.tmLanguage.json"))
+
+
+def const_list(src: str, name: str):
+    body = re.search(rf'pub const {name}: &\[&str\] = &\[(.*?)\n\];', src, re.S)
+    if not body:
+        sys.exit(f"Error: could not find `{name}` in {VOCAB}")
+    return re.findall(r'"([^"]+)"', body.group(1))
+
+
+def alternation(words):
+    """Longest-first, so `spades` wins over `spade` and `top2` is not shadowed."""
+    return "|".join(sorted(set(words), key=lambda w: (-len(w), w)))
+
+
+def main():
+    src = open(VOCAB).read()
+    funcs = const_list(src, "FUNCTIONS")
+    stmts = const_list(src, "STATEMENT_KEYWORDS")
+    acts = const_list(src, "ACTIONS")
+    pos = const_list(src, "POSITIONS")
+    vuln = const_list(src, "VULNERABILITIES")
+    logic = const_list(src, "LOGICAL_WORDS")
+    other = const_list(src, "OTHER_KEYWORDS")
+
+    g = json.load(open(OUT))
+    g["information_for_contributors"] = [
+        "Generated from dealer3's dealer-parser/src/vocabulary.rs.",
+        "Do not hand-edit the word lists: dealer-parser/tests/tmlanguage_matches_vocabulary.rs",
+        "fails the build if they drift from the parser's grammar.",
+        "Regenerate with scripts/generate-tmlanguage.py.",
+    ]
+
+    kw = g["repository"]["keywords"]["patterns"]
+    kw[0] = {"name": "keyword.control.dlr",
+             "match": r"\b(%s)\b" % alternation(stmts + acts)}
+    kw[1] = {"name": "keyword.other.condition.dlr",
+             "match": r"\b(%s)\b" % alternation(logic)}
+    kw[2] = {"name": "support.function.dlr",
+             "match": r"\b(%s)\b" % alternation(funcs)}
+    kw[3] = {"name": "constant.language.dlr",
+             "match": r"\b(%s)\b" % alternation([p for p in pos if len(p) > 1] + other)}
+
+    json.dump(g, open(OUT, "w"), indent=2)
+    open(OUT, "a").write("\n")
+    print(f"wrote {OUT} ({len(funcs)} functions, {len(stmts) + len(acts)} keywords)")
+
+    if "--also-update-vscode" in sys.argv:
+        if not os.path.isdir(os.path.dirname(VSCODE)):
+            sys.exit(f"Error: VS Code extension not found at {VSCODE}")
+        shutil.copy(OUT, VSCODE)
+        print(f"copied to {VSCODE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "dealer3-wasm"
+version = "1.0.0"
+edition = "2021"
+license = "Unlicense"
+description = "WebAssembly bindings for dealer3: bridge hand generation and constraint filtering in the browser"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# Path deps: these bindings must always build against the adjacent source, never
+# a published or pinned copy, so the engine and the site version together.
+dealer-core = { path = "../dealer-core" }
+dealer-parser = { path = "../dealer-parser" }
+dealer-eval = { path = "../dealer-eval" }
+dealer-pbn = { path = "../dealer-pbn" }
+
+wasm-bindgen = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+console_error_panic_hook = "0.1"
+
+[profile.release]
+# Size matters more than a few percent of speed for a page download.
+opt-level = "z"
+lto = true
+codegen-units = 1

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# build.sh - Build the dealer3 WebAssembly package.
+#
+# Usage:
+#   ./build.sh [web|nodejs|both]     (default: web)
+#
+#   web     ES module for the browser / Cloudflare Pages  -> pkg/
+#   nodejs  CommonJS for Node, used by the verification tests -> pkg-node/
+#
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+command -v wasm-pack >/dev/null || {
+    echo "Error: wasm-pack not found. Install: https://rustwasm.github.io/wasm-pack/installer/" >&2
+    exit 1
+}
+
+target="${1:-web}"
+build() {
+    echo "==> building $1 -> $2"
+    wasm-pack build --target "$1" --release --out-dir "$2"
+    local wasm
+    wasm=$(ls "$2"/*_bg.wasm)
+    printf "    %.0f KB raw, %.0f KB gzipped\n" \
+        "$(( $(wc -c < "$wasm") / 1024 ))" \
+        "$(( $(gzip -c "$wasm" | wc -c) / 1024 ))"
+}
+
+case "$target" in
+    web)    build web pkg ;;
+    nodejs) build nodejs pkg-node ;;
+    both)   build web pkg; build nodejs pkg-node ;;
+    *)      echo "Unknown target '$target'. Use web, nodejs or both." >&2; exit 1 ;;
+esac

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,212 @@
+//! WebAssembly bindings for dealer3.
+//!
+//! Exposes the engine to a browser: parse a script, generate deals, filter them.
+//! The CLI's browser-hostile parts — file I/O, stdin, `process::exit`,
+//! `SystemTime::now()`, rayon — stay in the `dealer` binary and are not reachable
+//! from here.
+//!
+//! # Threading
+//!
+//! Single-threaded. Shared memory in wasm needs `SharedArrayBuffer`, which needs
+//! COOP/COEP headers. Deal generation is stateless per seed, so a threaded build
+//! would produce identical output, just faster — see `docs/WASM.md`.
+//!
+//! # Determinism
+//!
+//! Output is byte-identical to the native binary for the same seed and script,
+//! so the Tier 2 regression hashes pin this build too.
+
+use dealer_core::FastDealGenerator;
+use dealer_eval::{eval_with_context, extract_constraint, extract_variables};
+use dealer_parser::vocabulary;
+use dealer_pbn::{format_oneline, format_printall};
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    // Turn Rust panics into readable console errors rather than "unreachable".
+    console_error_panic_hook::set_once();
+}
+
+/// How deals are rendered back to the caller.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Format {
+    OneLine,
+    PrintAll,
+}
+
+impl Format {
+    fn parse(s: &str) -> Result<Self, JsError> {
+        match s.to_ascii_lowercase().as_str() {
+            "oneline" | "printoneline" => Ok(Format::OneLine),
+            "printall" | "all" => Ok(Format::PrintAll),
+            other => Err(JsError::new(&format!(
+                "Unknown format '{}'. Use 'oneline' or 'printall'.",
+                other
+            ))),
+        }
+    }
+
+    fn render(self, deal: &dealer_core::Deal, index: usize) -> String {
+        match self {
+            Format::OneLine => format_oneline(deal).trim_end().to_string(),
+            Format::PrintAll => format_printall(deal, index),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct GenerateResult {
+    deals: Vec<String>,
+    /// Deals examined, including those the filter rejected.
+    generated: usize,
+    /// Deals that matched.
+    produced: usize,
+    /// True if `max_generate` was reached before `produce` was satisfied, so the
+    /// caller can distinguish "no more matches" from "ran out of budget".
+    hit_limit: bool,
+}
+
+/// Generate deals matching `script`, returning JSON.
+///
+/// `max_generate` bounds the work: a browser tab has no Ctrl-C, so a selective
+/// filter must not be able to hang it. Callers should surface `hit_limit` rather
+/// than silently showing a short result.
+#[wasm_bindgen]
+pub fn generate(
+    script: &str,
+    seed: u32,
+    produce: usize,
+    max_generate: usize,
+    format: &str,
+) -> Result<String, JsError> {
+    let format = Format::parse(format)?;
+
+    let preprocessed = dealer_parser::preprocess(script);
+    let program = dealer_parser::parse_program(&preprocessed)
+        .map_err(|e| JsError::new(&format!("Parse error: {}", e)))?;
+
+    let variables = extract_variables(&program);
+    let constraint = extract_constraint(&program);
+
+    let mut generator = FastDealGenerator::new(seed as u64);
+    let mut deals = Vec::new();
+    let mut generated = 0usize;
+
+    while deals.len() < produce && generated < max_generate {
+        let deal = generator.next_deal();
+        generated += 1;
+
+        let matched = match constraint {
+            Some(expr) => eval_with_context(expr, &variables, &deal)
+                .map_err(|e| JsError::new(&format!("Evaluation error: {}", e)))?
+                != 0,
+            None => true,
+        };
+
+        if matched {
+            deals.push(format.render(&deal, deals.len()));
+        }
+    }
+
+    let result = GenerateResult {
+        hit_limit: deals.len() < produce && generated >= max_generate,
+        produced: deals.len(),
+        deals,
+        generated,
+    };
+    serde_json::to_string(&result).map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[derive(Serialize)]
+struct CheckResult {
+    ok: bool,
+    /// Present only when `ok` is false.
+    error: Option<String>,
+    line: Option<usize>,
+    column: Option<usize>,
+}
+
+/// Validate a script without generating, for live editor diagnostics.
+///
+/// Returns JSON rather than throwing, so an editor can call it on every
+/// keystroke without exception handling. The line and column come from the
+/// parser itself, so squiggles agree with the engine by construction.
+#[wasm_bindgen]
+pub fn check_script(script: &str) -> String {
+    let preprocessed = dealer_parser::preprocess(script);
+    let result = match dealer_parser::parse_program(&preprocessed) {
+        Ok(_) => CheckResult {
+            ok: true,
+            error: None,
+            line: None,
+            column: None,
+        },
+        Err(e) => {
+            let text = format!("{}", e);
+            let (line, column) = parse_position(&text);
+            CheckResult {
+                ok: false,
+                error: Some(text),
+                line,
+                column,
+            }
+        }
+    };
+    serde_json::to_string(&result).unwrap_or_else(|_| {
+        r#"{"ok":false,"error":"could not serialise result","line":null,"column":null}"#.to_string()
+    })
+}
+
+/// Pull `line:col` out of a pest error, which renders as ` --> 3:17`.
+fn parse_position(msg: &str) -> (Option<usize>, Option<usize>) {
+    let Some(idx) = msg.find("--> ") else {
+        return (None, None);
+    };
+    let rest = &msg[idx + 4..];
+    let end = rest.find('\n').unwrap_or(rest.len());
+    let mut parts = rest[..end].trim().split(':');
+    (
+        parts.next().and_then(|s| s.trim().parse().ok()),
+        parts.next().and_then(|s| s.trim().parse().ok()),
+    )
+}
+
+#[derive(Serialize)]
+struct LanguageInfo {
+    functions: Vec<&'static str>,
+    statement_keywords: Vec<&'static str>,
+    actions: Vec<&'static str>,
+    positions: Vec<&'static str>,
+    vulnerabilities: Vec<&'static str>,
+    logical_words: Vec<&'static str>,
+    other_keywords: Vec<&'static str>,
+    operators: Vec<&'static str>,
+}
+
+/// The language's full vocabulary, for editor completion and hover.
+///
+/// Comes from `dealer_parser::vocabulary`, which is itself checked against
+/// `grammar.pest`, so an editor built on this cannot advertise a function the
+/// parser does not accept.
+#[wasm_bindgen]
+pub fn language_info() -> String {
+    let info = LanguageInfo {
+        functions: vocabulary::FUNCTIONS.to_vec(),
+        statement_keywords: vocabulary::STATEMENT_KEYWORDS.to_vec(),
+        actions: vocabulary::ACTIONS.to_vec(),
+        positions: vocabulary::POSITIONS.to_vec(),
+        vulnerabilities: vocabulary::VULNERABILITIES.to_vec(),
+        logical_words: vocabulary::LOGICAL_WORDS.to_vec(),
+        other_keywords: vocabulary::OTHER_KEYWORDS.to_vec(),
+        operators: vocabulary::OPERATORS.to_vec(),
+    };
+    serde_json::to_string(&info).unwrap_or_else(|_| "{}".to_string())
+}
+
+/// Engine version, so a page can show which build it is running.
+#[wasm_bindgen]
+pub fn version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}


### PR DESCRIPTION
**Stacked on #8** — based on `feat/remove-legacy-mode`, so review that first. Retarget to `main` once #8 merges.

First step of the browser engine: bindings + the grammar work. No web app yet — that's the next PR, per the single-threaded-first split.

## It compiles for wasm32 essentially unchanged

Every browser-hostile construct — `std::fs`, `io::stdin`, `process::exit`, `SystemTime::now()`, `rayon` — already lived in the `dealer` binary. The library crates were portable as-is, so these bindings are a thin wrapper, not a port. Your crate split did the hard part years ago.

**~1015 KB raw, ~351 KB gzipped**, including the double-dummy solver pulled in transitively via `dealer-dds`.

## Output is byte-identical to the native binary

```
$ diff /tmp/native.txt /tmp/wasm.txt && echo identical
identical
```

Same seed, same script, same deals. Which means **the Tier 2 regression hashes from #7 already cover this build** — it's the same generator, not a parallel implementation that could drift.

## API

| Export | Returns | Notes |
|---|---|---|
| `generate(script, seed, produce, max_generate, format)` | JSON | `"oneline"` or `"printall"` |
| `check_script(script)` | JSON | Never throws — safe per keystroke |
| `language_info()` | JSON | Full vocabulary for completion/hover |
| `version()` | string | |

Two deliberate choices:

**`max_generate` is required, and the result carries `hit_limit`.** A browser tab has no Ctrl-C, so a selective filter must not be able to hang it. `hit_limit` lets the UI distinguish "no more matches exist" from "ran out of budget" instead of silently showing a short list.

**`check_script` returns rather than throws**, with `line` and `column` from the parser itself:

```json
{ "ok": false, "error": "Parse error:  --> 1:23\n...", "line": 1, "column": 23 }
```

So editor squiggles agree with the engine **by construction** — not by regex approximation. That's something the VS Code extension can't do today without shelling out to the binary.

## The grammar had really drifted

You asked to fill it out for both use cases. Diffing `dlr.tmLanguage.json` against `grammar.pest` turned up more than expected:

**19 functions never highlighted:** `tens`, `jacks`, `queens`, `kings`, `aces`, `top2`–`top5`, `pt0`–`pt9`
**Missing keyword:** `csvrpt`
**Four entries that don't exist in the language:** `control`, `imp`, `pt`, `top[1-5]` — `\b(pt)\b` can never match `pt0`, and there is no `top1`

Rather than patch it and let it drift again, `dealer-parser/src/vocabulary.rs` is now the single source of truth, bound in both directions:

- `vocabulary_matches_grammar.rs` — vocabulary vs the PEG (6 tests)
- `tmlanguage_matches_vocabulary.rs` — shipped grammar vs vocabulary (5 tests), including a reverse check for phantom functions

Both verified to actually fail when deliberately broken:
```
functions not highlighted by syntaxes/dlr.tmLanguage.json: ["cccc"]
```

`scripts/generate-tmlanguage.py` regenerates the grammar; `--also-update-vscode` updates the PBS extension's copy.

⚠️ **I have not committed the PBS side.** `Practice-Bidding-Scenarios/vs-code/syntaxes/dlr.tmLanguage.json` has an uncommitted change with the same fix — separate repo, your call.

## Known gaps (documented in `docs/WASM.md`)

- **PBN output not exposed.** `format_printpbn` calls `chrono::Local::now()` for the `[Date]` tag; `wasmbind` behaviour is unverified. Should pass the date in from JS rather than read a clock.
- **DD functions untested in wasm.** `tricks`/`score`/`imps` compile and link — `bridge-solver` already ships to browsers — but nothing exercises them through these bindings yet.

## Verification

- 180 tests pass (14 new); fmt and clippy clean
- wasm crate excluded from the workspace so `cargo test --workspace` doesn't drag `wasm-bindgen` into the host build
- Functionally verified under Node: filters, variables, shape patterns, determinism, `hit_limit`, format rejection, parse-error positions

Refs #3