### PR TITLE
feat(wasm): return statistics, timing, and honour predeal

### DIFF
--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -56,13 +56,56 @@ cover this build too: it is the same generator.
 ### `generate`
 
 ```json
-{ "deals": ["n AKQ..."], "generated": 156, "produced": 20, "hit_limit": false }
+{
+  "deals": ["n AKQ..."],
+  "generated": 78,
+  "produced": 3,
+  "seconds": 0.011,
+  "hit_limit": false,
+  "averages": [ { "label": "Avg  ", "value": 33.333333333333336, "count": 3 } ],
+  "frequencies": [
+    {
+      "label": "HCP South ",
+      "min": 14, "max": 18,
+      "bins": [ {"value":14,"count":0}, {"value":15,"count":1} ],
+      "below": 0, "above": 0, "total": 3
+    }
+  ]
+}
 ```
+
+`generated`, `produced` and `seconds` correspond to the CLI's trailing stats
+block. Scripts also declare `average` and `frequency` statements, and those
+results come back as **data, not the CLI's ASCII table**, so a page can render a
+real chart:
+
+```
+Frequency HCP South :        ->   bins: [{value:14,count:0},{value:15,count:1},…]
+   14           0
+   15           1
+```
+
+`below` and `above` are the CLI's `Low` and `High` rows — observations outside a
+declared range. **Show them.** They are easy to omit when drawing a chart from
+`bins` alone, and a script whose range is too narrow otherwise looks like it
+simply produced fewer deals.
+
+`bins` is contiguous and zero-filled across the range, so it can be plotted
+directly without filling gaps.
+
+Averages are returned at full `f64` precision rather than the CLI's `%g`
+rounding, so the page chooses its own formatting. `count` is the number of deals
+contributing, for showing "over N deals" or greying out a small sample.
 
 `max_generate` bounds the work. A browser tab has no Ctrl-C, so a selective
 filter must not be able to hang it. **Surface `hit_limit`** rather than silently
 showing a short result — it distinguishes "no more matches exist" from "ran out
 of budget".
+
+At most `MAX_RETURNED_DEALS` (500) deals are returned, since a script may ask for
+tens of thousands to build a histogram and a page cannot show them all.
+Statistics still accumulate over every matching deal, so `produced` can exceed
+`deals.length`.
 
 ### `check_script`
 
@@ -117,6 +160,21 @@ Deal generation is stateless per seed, so a threaded build produces *identical*
 output — only faster. Any threaded build should feature-detect
 `SharedArrayBuffer` and fall back to single-threaded rather than failing, so the
 page still works where the headers are absent.
+
+## Verifying against the CLI
+
+The bindings re-implement the CLI's generate loop — filter, predeal, averages,
+frequencies — so they can drift from it. `wasm/verify.mjs` runs both over the
+same scripts and seeds and diffs deals and statistics:
+
+```bash
+cd wasm && ./build.sh nodejs && node verify.mjs
+```
+
+This is not theoretical: it caught predeal being silently ignored in the wasm
+path, which produced plausible-looking deals that simply did not honour the
+script's `predeal` lines. Run it after changing either the bindings or the CLI's
+generation loop.
 
 ## Known gaps
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -18,6 +18,9 @@ dealer-eval = { path = "../dealer-eval" }
 dealer-pbn = { path = "../dealer-pbn" }
 
 wasm-bindgen = "0.2"
+# For a wall-clock reading: std::time::SystemTime::now() panics on
+# wasm32-unknown-unknown. js_sys::Date works in both the browser and Node.
+js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 console_error_panic_hook = "0.1"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -16,12 +16,20 @@
 //! Output is byte-identical to the native binary for the same seed and script,
 //! so the Tier 2 regression hashes pin this build too.
 
-use dealer_core::FastDealGenerator;
-use dealer_eval::{eval_with_context, extract_constraint, extract_variables};
+use dealer_core::{FastDealConfig, FastDealGenerator, Position};
+use dealer_eval::{eval, eval_with_context, extract_constraint, extract_variables, EvalContext};
 use dealer_parser::vocabulary;
+use dealer_parser::{Expr, Statement};
 use dealer_pbn::{format_oneline, format_printall};
 use serde::Serialize;
+use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
+
+/// Upper bound on deals returned to the caller. A script may ask for tens of
+/// thousands of deals to build a histogram; serialising them all would blow up
+/// the JSON for no benefit, since a page cannot show them either. Statistics are
+/// still accumulated over every matching deal.
+const MAX_RETURNED_DEALS: usize = 500;
 
 #[wasm_bindgen(start)]
 pub fn start() {
@@ -56,6 +64,45 @@ impl Format {
     }
 }
 
+/// One `average "label" expr` result.
+#[derive(Serialize)]
+struct AverageResult {
+    label: Option<String>,
+    /// Mean over matching deals, or 0 when nothing matched.
+    value: f64,
+    /// Deals contributing, so a caller can show "over N deals" or grey out an
+    /// average computed from too small a sample.
+    count: usize,
+}
+
+/// One bucket of a frequency histogram.
+#[derive(Serialize)]
+struct FrequencyBin {
+    value: i32,
+    count: usize,
+}
+
+/// One `frequency "label" (expr, min, max)` result.
+///
+/// Returned as data rather than the CLI's ASCII table so the page can draw a
+/// real chart. `below` and `above` correspond to the CLI's `Low` and `High`
+/// rows: values outside a declared range, which would otherwise vanish.
+#[derive(Serialize)]
+struct FrequencyResult {
+    label: Option<String>,
+    /// Declared range, if the script gave one.
+    min: Option<i32>,
+    max: Option<i32>,
+    /// Contiguous buckets across the range, zero-filled — the caller can plot
+    /// these directly without filling gaps itself.
+    bins: Vec<FrequencyBin>,
+    /// Counts falling outside a declared range.
+    below: usize,
+    above: usize,
+    /// Every observation, including `below` and `above`.
+    total: usize,
+}
+
 #[derive(Serialize)]
 struct GenerateResult {
     deals: Vec<String>,
@@ -66,6 +113,18 @@ struct GenerateResult {
     /// True if `max_generate` was reached before `produce` was satisfied, so the
     /// caller can distinguish "no more matches" from "ran out of budget".
     hit_limit: bool,
+    /// Results of the script's `average` statements, in declaration order.
+    averages: Vec<AverageResult>,
+    /// Results of the script's `frequency` statements, in declaration order.
+    frequencies: Vec<FrequencyResult>,
+    /// Wall-clock seconds spent generating, matching the CLI's "Time needed".
+    seconds: f64,
+}
+
+/// Wall-clock milliseconds. `std::time::SystemTime::now()` panics on
+/// wasm32-unknown-unknown, so read the clock through JS instead.
+fn now_ms() -> f64 {
+    js_sys::Date::now()
 }
 
 /// Generate deals matching `script`, returning JSON.
@@ -82,6 +141,7 @@ pub fn generate(
     format: &str,
 ) -> Result<String, JsError> {
     let format = Format::parse(format)?;
+    let started = now_ms();
 
     let preprocessed = dealer_parser::preprocess(script);
     let program = dealer_parser::parse_program(&preprocessed)
@@ -90,11 +150,63 @@ pub fn generate(
     let variables = extract_variables(&program);
     let constraint = extract_constraint(&program);
 
-    let mut generator = FastDealGenerator::new(seed as u64);
+    // `average` and `frequency` accumulate over matching deals only, mirroring
+    // the CLI. Collected up front so the per-deal loop stays a tight walk.
+    let mut averages: Vec<(Option<String>, Expr, f64, usize)> = Vec::new();
+    let mut freqs: Vec<(Option<String>, Expr, HashMap<i32, usize>, Option<(i32, i32)>)> =
+        Vec::new();
+    for statement in &program.statements {
+        if let Statement::Action {
+            averages: avg_specs,
+            frequencies: freq_specs,
+            ..
+        } = statement
+        {
+            for a in avg_specs {
+                averages.push((a.label.clone(), a.expr.clone(), 0.0, 0));
+            }
+            for f in freq_specs {
+                freqs.push((f.label.clone(), f.expr.clone(), HashMap::new(), f.range));
+            }
+        }
+    }
+    let collecting_stats = !averages.is_empty() || !freqs.is_empty();
+
+    // Predeal fixes cards before shuffling. Missing this silently produced deals
+    // that ignored the script's `predeal` lines, which verify.mjs caught by
+    // diffing against the CLI.
+    let mut predeal_config = FastDealConfig::new();
+    let mut has_predeal = false;
+    for statement in &program.statements {
+        if let Statement::Predeal { position, cards } = statement {
+            predeal_config
+                .predeal(*position, cards)
+                .map_err(|e| JsError::new(&format!("Predeal error: {}", e)))?;
+            has_predeal = true;
+        }
+    }
+    debug_assert!(
+        !has_predeal
+            || [
+                Position::North,
+                Position::East,
+                Position::South,
+                Position::West
+            ]
+            .iter()
+            .any(|p| predeal_config.predeal_count(*p) > 0)
+    );
+
+    let mut generator = if has_predeal {
+        FastDealGenerator::with_config(seed as u64, predeal_config)
+    } else {
+        FastDealGenerator::new(seed as u64)
+    };
     let mut deals = Vec::new();
     let mut generated = 0usize;
+    let mut produced = 0usize;
 
-    while deals.len() < produce && generated < max_generate {
+    while produced < produce && generated < max_generate {
         let deal = generator.next_deal();
         generated += 1;
 
@@ -104,17 +216,89 @@ pub fn generate(
                 != 0,
             None => true,
         };
-
-        if matched {
-            deals.push(format.render(&deal, deals.len()));
+        if !matched {
+            continue;
         }
+
+        if collecting_stats {
+            let ctx = EvalContext::with_variables(&deal, &variables);
+            for (_, expr, sum, count) in averages.iter_mut() {
+                let v = eval(expr, &ctx)
+                    .map_err(|e| JsError::new(&format!("Average evaluation error: {}", e)))?;
+                *sum += v as f64;
+                *count += 1;
+            }
+            for (_, expr, histogram, _) in freqs.iter_mut() {
+                let v = eval(expr, &ctx)
+                    .map_err(|e| JsError::new(&format!("Frequency evaluation error: {}", e)))?;
+                *histogram.entry(v).or_insert(0) += 1;
+            }
+        }
+
+        // Deals are capped independently of `produced` so a large `produce` used
+        // purely to gather statistics does not have to ship every deal to JS.
+        if deals.len() < MAX_RETURNED_DEALS {
+            deals.push(format.render(&deal, produced));
+        }
+        produced += 1;
     }
 
+    let averages = averages
+        .into_iter()
+        .map(|(label, _, sum, count)| AverageResult {
+            label,
+            value: if count > 0 { sum / count as f64 } else { 0.0 },
+            count,
+        })
+        .collect();
+
+    let frequencies = freqs
+        .into_iter()
+        .map(|(label, _, histogram, range)| {
+            let total: usize = histogram.values().sum();
+            let (lo, hi) = match range {
+                Some((lo, hi)) => (lo, hi),
+                None => (
+                    histogram.keys().copied().min().unwrap_or(0),
+                    histogram.keys().copied().max().unwrap_or(0),
+                ),
+            };
+            let bins = (lo..=hi)
+                .map(|value| FrequencyBin {
+                    value,
+                    count: histogram.get(&value).copied().unwrap_or(0),
+                })
+                .collect();
+            let below = histogram
+                .iter()
+                .filter(|(&k, _)| k < lo)
+                .map(|(_, &v)| v)
+                .sum();
+            let above = histogram
+                .iter()
+                .filter(|(&k, _)| k > hi)
+                .map(|(_, &v)| v)
+                .sum();
+            FrequencyResult {
+                label,
+                min: range.map(|(lo, _)| lo),
+                max: range.map(|(_, hi)| hi),
+                bins,
+                below,
+                above,
+                total,
+            }
+        })
+        .collect();
+
     let result = GenerateResult {
-        hit_limit: deals.len() < produce && generated >= max_generate,
-        produced: deals.len(),
+        hit_limit: produced < produce && generated >= max_generate,
+        produced,
         deals,
         generated,
+        averages,
+        frequencies,
+        seconds: (now_ms() - started) / 1000.0,
     };
     serde_json::to_string(&result).map_err(|e| JsError::new(&e.to_string()))
 }

--- a/wasm/verify.mjs
+++ b/wasm/verify.mjs
@@ -1,0 +1,109 @@
+// Verify the wasm bindings against the native CLI.
+//
+// The bindings re-implement the CLI's generate loop — filter, averages,
+// frequencies — so they can drift from it. This runs both over the same scripts
+// and seeds and compares deals and statistics.
+//
+//   cd wasm && ./build.sh nodejs && node verify.mjs
+//
+// Requires a release build of the CLI: ./dev-build.sh build --release
+
+import { createRequire } from 'module'
+import { execFileSync } from 'child_process'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const w = createRequire(import.meta.url)('./pkg-node/dealer3_wasm.js')
+const CLI = join(here, '..', 'target', 'release', 'dealer')
+const tmp = mkdtempSync(join(tmpdir(), 'dealer3-verify-'))
+
+const CASES = [
+  { name: 'simple filter', seed: 1, produce: 5, script: 'condition hcp(north) >= 15\n' },
+  { name: 'shape + variables', seed: 42, produce: 4,
+    script: 'bal = shape(north, any 4333 + any 4432 + any 5332)\ncondition bal && hcp(north) >= 12\n' },
+  { name: 'averages', seed: 7, produce: 6,
+    script: 'condition hcp(north) >= 10\naction printoneline,\n  average "N HCP" hcp(north),\n  average "S HCP" hcp(south)\n' },
+  { name: 'frequency with range', seed: 3, produce: 8,
+    script: 'condition hcp(north) >= 8\naction printoneline,\n  frequency "NHCP" (hcp(north), 10, 16)\n' },
+  { name: 'frequency out of range', seed: 11, produce: 10,
+    script: 'condition hcp(north) >= 0\naction printoneline,\n  frequency "Narrow" (hcp(north), 11, 13)\n' },
+  { name: 'predeal', seed: 5, produce: 4,
+    script: 'predeal north SAKQ,HAK\ncondition hcp(south) >= 8\n' },
+]
+
+// The CLI prints "Label: value" then "Frequency Label:" tables then stats.
+function parseCli(out) {
+  const deals = [], averages = [], frequencies = []
+  let generated = null, produced = null, current = null
+  for (const raw of out.split('\n')) {
+    const line = raw.trimEnd()
+    if (line.startsWith('n ')) { deals.push(line); continue }
+    let m
+    if ((m = line.match(/^Generated (\d+) hands$/))) { generated = +m[1]; current = null; continue }
+    if ((m = line.match(/^Produced (\d+) hands$/)))  { produced = +m[1];  current = null; continue }
+    if ((m = line.match(/^Frequency (.*):$/)))       { current = { label: m[1], bins: [], below: 0, above: 0 }; frequencies.push(current); continue }
+    if (current) {
+      if ((m = line.match(/^Low\s+(\d+)$/)))  { current.below = +m[1]; continue }
+      if ((m = line.match(/^High\s+(\d+)$/))) { current.above = +m[1]; continue }
+      if ((m = line.match(/^\s*(-?\d+)\s+(\d+)$/))) { current.bins.push({ value: +m[1], count: +m[2] }); continue }
+    }
+    if ((m = line.match(/^(.*?): (-?[\d.e+-]+)$/)) && !line.startsWith('Time')) {
+      averages.push({ label: m[1], value: parseFloat(m[2]) }); continue
+    }
+  }
+  return { deals, generated, produced, averages, frequencies }
+}
+
+let failures = 0
+const fail = (c, msg) => { failures++; console.log(`  ✗ ${c}: ${msg}`) }
+
+for (const c of CASES) {
+  const path = join(tmp, `${c.name.replace(/\W+/g, '_')}.dlr`)
+  writeFileSync(path, c.script)
+
+  const cli = parseCli(execFileSync(CLI,
+    [path, '-s', String(c.seed), '-p', String(c.produce), '-f', 'oneline', '-X'],
+    { encoding: 'utf8' }))
+  const wasm = JSON.parse(w.generate(c.script, c.seed, c.produce, 500000, 'oneline'))
+
+  if (JSON.stringify(cli.deals) !== JSON.stringify(wasm.deals)) {
+    fail(c.name, `deals differ (cli ${cli.deals.length}, wasm ${wasm.deals.length})`)
+    continue
+  }
+  if (cli.generated !== wasm.generated) fail(c.name, `generated ${cli.generated} vs ${wasm.generated}`)
+  if (cli.produced !== wasm.produced)   fail(c.name, `produced ${cli.produced} vs ${wasm.produced}`)
+
+  if (cli.averages.length !== wasm.averages.length) {
+    fail(c.name, `average count ${cli.averages.length} vs ${wasm.averages.length}`)
+  } else {
+    cli.averages.forEach((a, i) => {
+      // The CLI prints %g (6 significant digits); wasm returns full f64.
+      if (Math.abs(a.value - wasm.averages[i].value) > 1e-4) {
+        fail(c.name, `average "${a.label}" ${a.value} vs ${wasm.averages[i].value}`)
+      }
+    })
+  }
+
+  if (cli.frequencies.length !== wasm.frequencies.length) {
+    fail(c.name, `frequency count ${cli.frequencies.length} vs ${wasm.frequencies.length}`)
+  } else {
+    cli.frequencies.forEach((f, i) => {
+      const g = wasm.frequencies[i]
+      if (JSON.stringify(f.bins) !== JSON.stringify(g.bins)) {
+        fail(c.name, `frequency "${f.label}" bins differ\n      cli:  ${JSON.stringify(f.bins)}\n      wasm: ${JSON.stringify(g.bins)}`)
+      }
+      if (f.below !== g.below) fail(c.name, `frequency "${f.label}" below ${f.below} vs ${g.below}`)
+      if (f.above !== g.above) fail(c.name, `frequency "${f.label}" above ${f.above} vs ${g.above}`)
+    })
+  }
+
+  if (!failures) console.log(`  ✓ ${c.name} (generated=${wasm.generated} produced=${wasm.produced})`)
+}
+
+console.log(failures
+  ? `\n${failures} mismatch(es) between wasm and the native CLI`
+  : `\nall ${CASES.length} cases match the native CLI`)
+process.exit(failures ? 1 : 0)


### PR DESCRIPTION
`generate()` returned only deals, silently dropping everything else a script produces.

## What was missing

Scripts declare `average` and `frequency` statements, and the CLI prints those plus the generated/produced/time block. None of it reached the browser:

```
Minimum     : 33.3333          ← dropped
Frequency HCP South :          ← dropped
   14           0
   15           1
Generated 78 hands             ← dropped
```

## Now returned

```json
{
  "deals": ["n AKQ..."],
  "generated": 78, "produced": 3, "seconds": 0.011, "hit_limit": false,
  "averages": [ { "label": "Avg  ", "value": 33.333333333333336, "count": 3 } ],
  "frequencies": [
    { "label": "HCP South ", "min": 14, "max": 18,
      "bins": [ {"value":14,"count":0}, {"value":15,"count":1} ],
      "below": 0, "above": 0, "total": 3 }
  ]
}
```

**Frequencies come back as data, not the CLI's ASCII table**, so the page can draw a real chart. `bins` is contiguous and zero-filled across the range — plottable directly, no gap-filling.

`below`/`above` are the CLI's `Low`/`High` rows: observations outside a declared range. Worth surfacing in the UI — they're easy to omit when charting from `bins` alone, and a script whose range is too narrow otherwise just looks like it produced fewer deals.

Averages return full `f64` rather than `%g` rounding, so the page formats as it likes. `count` supports "over N deals" or greying out a small sample.

`seconds` reads the clock via `js_sys::Date` — `std::time::SystemTime::now()` panics on wasm32-unknown-unknown.

Deals to JS are capped at **500**: a script may ask for tens of thousands to build a histogram, and a page can't show them anyway. Statistics still accumulate over *every* matching deal, so `produced` may exceed `deals.length`.

## The verification script earned its keep immediately

`wasm/verify.mjs` runs the same scripts and seeds through both the bindings and the native CLI, diffing deals, counts, averages and frequency bins:

```bash
cd wasm && ./build.sh nodejs && node verify.mjs
```

First run:

```
  ✓ simple filter        ✓ shape + variables      ✓ averages
  ✓ frequency with range ✓ frequency out of range
  ✗ predeal: deals differ

1 mismatch(es) between wasm and the native CLI
```

**`generate()` was ignoring `predeal` entirely.** It built a `FastDealGenerator` without applying the script's predeal statements, so it produced valid-looking deals that quietly disregarded them — exactly the kind of thing that would surface later as "dealer3 is broken in the browser". Now fixed; all six cases match.

The bindings re-implement the CLI's generate loop, so they can drift from it. Worth running after touching either side.

## Verification

- 180 workspace tests pass; fmt and clippy clean
- All 6 verify.mjs cases match the native CLI
- Confirmed against real PBS script `1N.dlr`: averages and both frequency tables identical to CLI output
- 1028 KB raw / 358 KB gzipped (+7 KB for `js-sys`)

Refs #3