### PR TITLE
feat(web): browser app for writing and running dealer scripts

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,121 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dealer-core/**'
+      - 'dealer-parser/**'
+      - 'dealer-eval/**'
+      - 'dealer-pbn/**'
+      - 'dealer-dds/**'
+      - 'wasm/**'
+      - 'web/**'
+      - 'Cargo.toml'
+      # The hosting half of the deploy: a change to the headers or the Pages
+      # config has to redeploy too, or the site would keep serving the old ones.
+      - 'wrangler.jsonc'
+      - '.github/workflows/pages.yml'
+  # Lets the site be redeployed without a code change.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Latest wins: a superseded deploy has nothing worth finishing.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # Read here rather than inside the step so the step's `if` can test them. The
+  # site should still build and reach GitHub Pages before the Cloudflare secrets
+  # exist, rather than failing on a credential it was never given.
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: wasm
+
+      - uses: actions/setup-node@v4
+        with:
+          # Vite 7 wants 20.19+ or 22.12+; 22 resolves to the latest 22.x.
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: latest
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+
+      # Before the site build: Vite bundles the generated module as an asset, so
+      # it has to exist on disk first.
+      - name: Build the WebAssembly bundle
+        working-directory: web
+        run: npm run wasm
+
+      - name: Run the site tests
+        working-directory: web
+        run: npm test
+
+      - name: Build the site
+        working-directory: web
+        run: npm run build
+
+      # A missing wasm asset produces a page that loads, shows the editor, and
+      # then fails to generate anything — so fail here instead of shipping it.
+      - name: Check the bundle landed
+        working-directory: web
+        run: |
+          test -f dist/index.html
+          ls dist/assets/*.wasm
+          ls dist/assets/*.js
+          # _headers is copied verbatim out of public/; without it the COOP/COEP
+          # a threaded build will need would silently not be sent.
+          test -f dist/_headers
+          du -sh dist
+
+      # Cloudflare, from the same build GitHub Pages is about to get, so the two
+      # hosts cannot drift. Only Cloudflare can send the COOP/COEP headers a
+      # threaded wasm build will need, which is why it is the primary host.
+      #
+      # Skipped when the token is absent, so the site still reaches GitHub Pages
+      # before the secrets are set. `--commit-dirty` because the checkout carries
+      # the generated wasm module, which wrangler would otherwise refuse to
+      # deploy from as an unclean tree.
+      - name: Deploy to Cloudflare Pages
+        if: env.CLOUDFLARE_API_TOKEN != ''
+        run: npx --yes wrangler@4 pages deploy --commit-dirty=true
+
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ activity-log.json
 wasm/pkg/
 wasm/pkg-node/
 wasm/target/
+
+# Web app
+web/node_modules/
+web/dist/
+web/src/wasm/

--- a/dealer-parser/src/grammar.pest
+++ b/dealer-parser/src/grammar.pest
@@ -186,10 +186,24 @@ predeal_card = @{
 rank = { "A" | "K" | "Q" | "J" | "T" | "9" | "8" | "7" | "6" | "5" | "4" | "3" | "2" }
 suit_char = { "S" | "H" | "D" | "C" }
 
+// Words that introduce a statement. Kept out of bare-identifier position: a
+// malformed statement otherwise backtracks into `expr` and parses as bare
+// identifiers the evaluator ignores, so `dealer soudfsfd` was silently accepted
+// where dealer.exe reports "syntax error".
+//
+// Referenced only from `ident`, which is atomic, so no implicit whitespace is
+// inserted before the boundary lookahead. The trailing `!(ALNUM | "_")` keeps
+// names like `conditionMet` from matching the bare keyword.
+statement_keyword = @{
+    (^"condition" | ^"produce" | ^"generate" | ^"action" | ^"dealer"
+     | ^"vulnerable" | ^"predeal" | ^"csvrpt" | ^"average" | ^"frequency")
+    ~ !(ASCII_ALPHANUMERIC | "_")
+}
+
 // Identifiers (for variables)
 // Allow any alphanumeric identifier - the parser will try more specific rules first
 // Variables like "spadeFit" or "heartCount" must be allowed even though they start with keywords
-ident = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
+ident = @{ !statement_keyword ~ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Shape patterns: any 4333 + 54xx - any 0xxx
 // Spaces can act as implicit "+" (addition) between shape specs

--- a/dealer-parser/tests/vocabulary_matches_grammar.rs
+++ b/dealer-parser/tests/vocabulary_matches_grammar.rs
@@ -148,3 +148,54 @@ fn logical_words_are_all_in_the_grammar() {
         );
     }
 }
+
+/// A statement keyword must not be reachable as a bare variable reference.
+///
+/// Without this, a malformed statement backtracks into `expr` and parses as
+/// bare identifiers the evaluator ignores — so `dealer soudfsfd` was accepted
+/// silently, where dealer.exe reports "line 1: syntax error".
+#[test]
+fn malformed_statements_are_rejected() {
+    let cases = [
+        "dealer soudfsfd\n",
+        "dealer\n",
+        "vulnerable xyz\n",
+        "produce abc\n",
+        "generate abc\n",
+        "predeal north XX\n",
+        "condition\n",
+    ];
+    for script in cases {
+        let pre = dealer_parser::preprocess(script);
+        assert!(
+            dealer_parser::parse_program(&pre).is_err(),
+            "should have been rejected: {:?}",
+            script
+        );
+    }
+}
+
+/// The fix must not reject anything valid.
+#[test]
+fn well_formed_statements_still_parse() {
+    let cases = [
+        "dealer south\ncondition hcp(north) >= 1\n",
+        "vulnerable ns\ncondition hcp(north) >= 1\n",
+        "produce 5\ncondition hcp(north) >= 1\n",
+        "generate 100\ncondition hcp(north) >= 1\n",
+        "predeal north SAKQ\ncondition hcp(south) >= 1\n",
+        "condition hcp(north) >= 1\n",
+        // A variable may still be named after a function or a position.
+        "spadeFit = spades(north) + spades(south)\ncondition spadeFit >= 8\n",
+        "n = hcp(north)\ncondition n >= 10\n",
+    ];
+    for script in cases {
+        let pre = dealer_parser::preprocess(script);
+        assert!(
+            dealer_parser::parse_program(&pre).is_ok(),
+            "should have parsed: {:?}\n{:?}",
+            script,
+            dealer_parser::parse_program(&pre).err()
+        );
+    }
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -19,8 +19,8 @@
 use dealer_core::{FastDealConfig, FastDealGenerator, Position};
 use dealer_eval::{eval, eval_with_context, extract_constraint, extract_variables, EvalContext};
 use dealer_parser::vocabulary;
-use dealer_parser::{Expr, Statement};
-use dealer_pbn::{format_oneline, format_printall};
+use dealer_parser::{Expr, Statement, VulnerabilityType};
+use dealer_pbn::{format_oneline, format_printall, format_printpbn, Vulnerability};
 use serde::Serialize;
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
@@ -42,6 +42,8 @@ pub fn start() {
 enum Format {
     OneLine,
     PrintAll,
+    /// Full PBN, suitable for saving and opening elsewhere.
+    Pbn,
 }
 
 impl Format {
@@ -49,17 +51,29 @@ impl Format {
         match s.to_ascii_lowercase().as_str() {
             "oneline" | "printoneline" => Ok(Format::OneLine),
             "printall" | "all" => Ok(Format::PrintAll),
+            "pbn" | "printpbn" => Ok(Format::Pbn),
             other => Err(JsError::new(&format!(
-                "Unknown format '{}'. Use 'oneline' or 'printall'.",
+                "Unknown format '{}'. Use 'oneline', 'printall' or 'pbn'.",
                 other
             ))),
         }
     }
 
-    fn render(self, deal: &dealer_core::Deal, index: usize) -> String {
+    fn render(self, deal: &dealer_core::Deal, index: usize, ctx: &OutputContext) -> String {
         match self {
             Format::OneLine => format_oneline(deal).trim_end().to_string(),
             Format::PrintAll => format_printall(deal, index),
+            // Board numbers, dealer and vulnerability all belong in the PBN
+            // tags; a file without them is far less useful to whatever opens it.
+            Format::Pbn => format_printpbn(
+                deal,
+                index,
+                ctx.dealer,
+                ctx.vulnerability,
+                None,
+                Some(ctx.seed),
+                None,
+            ),
         }
     }
 }
@@ -121,6 +135,13 @@ struct GenerateResult {
     seconds: f64,
 }
 
+/// Script settings that affect output but not generation.
+struct OutputContext {
+    dealer: Option<Position>,
+    vulnerability: Option<Vulnerability>,
+    seed: u32,
+}
+
 /// Wall-clock milliseconds. `std::time::SystemTime::now()` panics on
 /// wasm32-unknown-unknown, so read the clock through JS instead.
 fn now_ms() -> f64 {
@@ -171,6 +192,28 @@ pub fn generate(
         }
     }
     let collecting_stats = !averages.is_empty() || !freqs.is_empty();
+
+    // `dealer` and `vulnerable` statements do not affect which deals are
+    // produced, only how they are labelled in PBN output.
+    let mut output = OutputContext {
+        dealer: None,
+        vulnerability: None,
+        seed,
+    };
+    for statement in &program.statements {
+        match statement {
+            Statement::Dealer(pos) => output.dealer = Some(*pos),
+            Statement::Vulnerable(v) => {
+                output.vulnerability = Some(match v {
+                    VulnerabilityType::None => Vulnerability::None,
+                    VulnerabilityType::NS => Vulnerability::NS,
+                    VulnerabilityType::EW => Vulnerability::EW,
+                    VulnerabilityType::All => Vulnerability::All,
+                })
+            }
+            _ => {}
+        }
+    }
 
     // Predeal fixes cards before shuffling. Missing this silently produced deals
     // that ignored the script's `predeal` lines, which verify.mjs caught by
@@ -238,7 +281,7 @@ pub fn generate(
         // Deals are capped independently of `produced` so a large `produce` used
         // purely to gather statistics does not have to ship every deal to JS.
         if deals.len() < MAX_RETURNED_DEALS {
-            deals.push(format.render(&deal, produced));
+            deals.push(format.render(&deal, produced, &output));
         }
         produced += 1;
     }

--- a/web/README.md
+++ b/web/README.md
@@ -77,6 +77,12 @@ table — clickable cards, a selector popup, per-card marks, dynamic fit — and
 almost none of that applies to a static grid. The primitives were the reusable
 part.
 
+Averages and frequencies both render as bars. Averages share one scale set by
+the largest value shown, so they compare against each other rather than each
+filling its own row. A negative average gets no bar rather than a misleading
+one — these are arbitrary script expressions and `100 * (x - y)` can legitimately
+go below zero — but the number is always shown.
+
 **Save PBN** and **Save text** download the results. Selecting text out of the
 page is clumsy (a select-all takes the whole document), and a long run is
 thousands of lines. Saving re-runs the generator rather than reformatting what is

--- a/web/README.md
+++ b/web/README.md
@@ -22,10 +22,10 @@ src/
 ├── lib/
 │   ├── engine.js         wasm loader and typed wrapper
 │   ├── pbsScenarios.js   PBS manifest + script access (vendored)
-│   └── dlrLanguage.js    Monaco language, built from the engine's vocabulary
+│   └── dlrLanguage.js    CodeMirror language, built from the engine's vocabulary
 └── components/
     ├── ScenarioPicker.vue  340+ PBS scenarios, grouped and searchable
-    ├── ScriptEditor.vue    Monaco, with diagnostics from the real parser
+    ├── ScriptEditor.vue    CodeMirror 6, diagnostics from the real parser
     └── ResultsPanel.vue    deals, averages, frequency charts
 ```
 
@@ -35,7 +35,7 @@ src/
 pest parser the CLI uses, so a squiggle means the engine will reject the script,
 and the line and column are the parser's own.
 
-**Highlighting is derived, not duplicated.** The Monaco tokenizer is built at
+**Highlighting is derived, not duplicated.** The CodeMirror tokenizer is built at
 runtime from `language_info()`, which comes from `dealer_parser::vocabulary` —
 the same list checked against `grammar.pest` by two tests. Highlighting cannot
 advertise a function the parser rejects, or miss one it accepts. That is the bug
@@ -58,11 +58,28 @@ npx wrangler pages deploy
 Pages rather than GitHub Pages because it can send the COOP/COEP headers a
 threaded wasm build will need. `public/_headers` already sets them.
 
+## Editor choice
+
+CodeMirror 6, not Monaco. Monaco was tried first, on the assumption that loading
+`dlr.tmLanguage.json` directly was the way to share one definition with VS Code.
+Once the tokenizer was derived from `language_info()` instead — a stronger
+guarantee, since it comes from the parser rather than a parallel file — Monaco's
+advantage disappeared and only its size remained:
+
+| | gzipped |
+|---|---|
+| Monaco | 590 kB, plus 66 kB CSS and a 231 kB worker |
+| CodeMirror 6 | **114 kB**, no separate CSS or worker |
+
+Both drive off the same vocabulary, so the choice is presentation only.
+
 ## Tests
 
 ```bash
 npm test
 ```
 
-Covers the manifest parsing and the language derivation. The Vue components are
-not covered yet.
+24 cases covering manifest parsing and the language derivation — tokenizer
+classification, longest-first matching, case-insensitivity, and completion shape.
+The Vue components are not covered by unit tests; they are exercised by the
+browser smoke checks instead.

--- a/web/README.md
+++ b/web/README.md
@@ -92,6 +92,14 @@ matches what was shown.
 
 PBN output carries the script's `dealer` and `vulnerable` settings in its tags.
 
+## Editor appearance
+
+The editor is dark (One Dark) on an otherwise light page. Syntax palettes are
+designed for dark grounds, and the same colours that read clearly there are
+washed out on white — which is how CodeMirror's default highlight style looked
+here. The editor's border and status strip are matched to it (`--editor-bg`,
+`--editor-line`) so it reads as one component rather than a hole in the page.
+
 ## Editor choice
 
 CodeMirror 6, not Monaco. Monaco was tried first, on the assumption that loading

--- a/web/README.md
+++ b/web/README.md
@@ -22,10 +22,13 @@ src/
 ├── lib/
 │   ├── engine.js         wasm loader and typed wrapper
 │   ├── pbsScenarios.js   PBS manifest + script access (vendored)
-│   └── dlrLanguage.js    CodeMirror language, built from the engine's vocabulary
+│   ├── cardFormatting.js card/suit primitives and oneline parsing (vendored)
+│   ├── dlrLanguage.js    CodeMirror language, built from the engine's vocabulary
+│   └── download.js       saving results as PBN or text
 └── components/
     ├── ScenarioPicker.vue  340+ PBS scenarios, grouped and searchable
     ├── ScriptEditor.vue    CodeMirror 6, diagnostics from the real parser
+    ├── DealGrid.vue        deals as bridge hands, with HCP
     └── ResultsPanel.vue    deals, averages, frequency charts
 ```
 
@@ -57,6 +60,31 @@ npx wrangler pages deploy
 
 Pages rather than GitHub Pages because it can send the COOP/COEP headers a
 threaded wasm build will need. `public/_headers` already sets them.
+
+## Viewing and saving
+
+Deals show as **hands** by default — a compass grid with per-hand HCP and
+partnership totals — because a one-line string is far harder to read than a
+layout. Toggle to **Text** for the raw output.
+
+The grid only applies to the one-line format: `printall` is already a visual
+layout and PBN is a record format, so those offer Text instead rather than an
+empty grid.
+
+`cardFormatting.js` is vendored from `Bridge-Classroom/src/utils/cardFormatting.js`.
+Its `HandDisplay.vue` was **not**: at 521 lines it is built for an interactive
+table — clickable cards, a selector popup, per-card marks, dynamic fit — and
+almost none of that applies to a static grid. The primitives were the reusable
+part.
+
+**Save PBN** and **Save text** download the results. Selecting text out of the
+page is clumsy (a select-all takes the whole document), and a long run is
+thousands of lines. Saving re-runs the generator rather than reformatting what is
+on screen: the displayed deals are capped at 500, and PBN needs the engine's own
+formatter. Generation is deterministic for a given seed, so the saved file
+matches what was shown.
+
+PBN output carries the script's `dealer` and `vulnerable` settings in its tags.
 
 ## Editor choice
 

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,68 @@
+# dealer3 web
+
+Write and run dealer scripts in the browser. The engine is dealer3 compiled to
+WebAssembly, so nothing — script, deal or keystroke — leaves the machine.
+
+## Running it
+
+```bash
+npm install
+npm run dev        # builds the wasm, then starts Vite
+```
+
+`npm run build:all` produces a deployable `dist/`. `npm run build` skips the wasm
+step, for when only the front end changed.
+
+Requires [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/).
+
+## Layout
+
+```
+src/
+├── lib/
+│   ├── engine.js         wasm loader and typed wrapper
+│   ├── pbsScenarios.js   PBS manifest + script access (vendored)
+│   └── dlrLanguage.js    Monaco language, built from the engine's vocabulary
+└── components/
+    ├── ScenarioPicker.vue  340+ PBS scenarios, grouped and searchable
+    ├── ScriptEditor.vue    Monaco, with diagnostics from the real parser
+    └── ResultsPanel.vue    deals, averages, frequency charts
+```
+
+## Three things worth knowing
+
+**Diagnostics come from the parser, not a regex.** `check_script()` is the same
+pest parser the CLI uses, so a squiggle means the engine will reject the script,
+and the line and column are the parser's own.
+
+**Highlighting is derived, not duplicated.** The Monaco tokenizer is built at
+runtime from `language_info()`, which comes from `dealer_parser::vocabulary` —
+the same list checked against `grammar.pest` by two tests. Highlighting cannot
+advertise a function the parser rejects, or miss one it accepts. That is the bug
+that left 19 functions uncoloured in the VS Code extension for years.
+
+**Scenarios are fetched, not bundled.** `pbsScenarios.js` reads the manifest that
+Practice-Bidding-Scenarios CI builds, straight from raw.githubusercontent.com,
+which serves permissive CORS. No backend, no build-time copy, and the list is
+never stale. Vendored from `Bridge-Classroom/src/utils/pbsScenarios.js`.
+
+## Deploying
+
+Cloudflare Pages, configured in `../wrangler.jsonc`:
+
+```bash
+npm run build:all
+npx wrangler pages deploy
+```
+
+Pages rather than GitHub Pages because it can send the COOP/COEP headers a
+threaded wasm build will need. `public/_headers` already sets them.
+
+## Tests
+
+```bash
+npm test
+```
+
+Covers the manifest parsing and the language derivation. The Vue components are
+not covered yet.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>dealer3 — bridge hand generator</title>
+    <meta
+      name="description"
+      content="Write and run bridge dealer scripts in the browser. Nothing leaves your machine."
+    />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,1828 @@
+{
+  "name": "dealer3-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dealer3-web",
+      "version": "1.0.0",
+      "dependencies": {
+        "monaco-editor": "0.52.2",
+        "vue": "3.5.40"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "6.0.8",
+        "vite": "7.3.6",
+        "vitest": "3.2.7"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.0.tgz",
+      "integrity": "sha512-70TeIFezKKy65LgAVyQh+w94/gjWhvPWaLaGGeMEgVrPkQhuj/M5bAYYZzIFUj9Y69oHyTm5Um/R6gcLh4A8JA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.0.tgz",
+      "integrity": "sha512-YC86tYIHK6M1IV+wbzO+Bxk8RCBr6ZyWYgWxUCzaZD8mc8rrFoIJDNzDrkHBYRc/wKdrsIXmm6/F7NzrAO+OrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.0.tgz",
+      "integrity": "sha512-oI+ECtUcli0y0fi4xpW82GdPIXdTkI8G8DSjG2LRuw09fPAGykaWYH/hXxiKuTxiAjiPSTIIuYUqof5Z2hShWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.0.tgz",
+      "integrity": "sha512-NwV+1s7TiKrMe4owHyKB/dTLD7ZJD0YEBEhIz+hvav1Cu1GReJjF+rsdNwjzENQeIAbE/CoNiaAc5Vz2h5DPAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.0.tgz",
+      "integrity": "sha512-tWtHBTu5gOPK4u4Urtk4qAHW3zZ9rQAmbssO8gp7ELvGTGI3aCiq6NqyTQ0PCIg7KbHJF2UkGDDs77YZGxfjCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.0.tgz",
+      "integrity": "sha512-2qPoJiwTvtHQ27NnYvTnsgk8laXWYuVmNESG8WFZBcEPKLfZ3I27qBJarjVRQtwGeYyRfq5ZowHXih9lm2BItw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.0.tgz",
+      "integrity": "sha512-FQwsTRvLNuHoTdICABJQfbPUSEueISGmnpT06tXTMpfprf5NiKLSXKA0A+w45wJnCmZAnzgqBwbt6ARFuyOi5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.0.tgz",
+      "integrity": "sha512-BBVTXziw8mY1a4ZbWME9tZyfzqXCDPqaC7Z3heQ29p5dkvXzwL0NwelO8zLa8c3RBKvl3YTuSnBgsBhYBtwjIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.0.tgz",
+      "integrity": "sha512-w2Iyy9+RqKwx3d9qWMKsJg0FfRBsY0/pXNv0mCQ3ueRvJI6+QAScfD4nrMlzFLs2HNVW6Ew+mtZfDl9b7Ew5/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.0.tgz",
+      "integrity": "sha512-YK++KtrFRHYE0P6/RtYEAy9t8F37znP+K03RrIuLPYOL6SVlObRumf/0OE4V/h63xL9DwkWbNssZfmA9hawuDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.0.tgz",
+      "integrity": "sha512-aBfOG6fP7YkkPmTqPwufRJeFyz7WPpECv9XNbnsk9+vg7rxdih0lbtEel7jcRng4LZrrmU3FfitCFyEj4BWDWg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.0.tgz",
+      "integrity": "sha512-LGaHEOeHNAag9VuS1Crs5DFg4RrU9MPi2nVnNJk9DTePx/B6RRYKVmrIXt2h7YOJlwjaFJ6lwtFDliZxScTLrQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.0.tgz",
+      "integrity": "sha512-jClvk+J0FC3b7Udvegiw5/4hErbHtmsNsQgENnKXDWtNCJXsJYZH5WURvu7imDOO38xYml24eeh5x3A04ppwCw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.0.tgz",
+      "integrity": "sha512-0OJlaGK+8+B777Ql5okIpD7ua5Ro9+VB9Ve0OKa28OQJZ1RbuUBVNHK/e3pr4BROqsyPl1JrPO1ZxJseCNffcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Ygsx+HoNH7afwi1bTIXbnTvVnsO+zurPLSYxybV1hHFVU72OWOCl6v05ql/z0hkpAPx+DK7Kn9Bi7MayCcjLTA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.0.tgz",
+      "integrity": "sha512-pDQxtMGb+OvG3fLwR2OkZlSd47hW+kWg4BYMG/++sR6RqorQccwPTDsxda5hPwiIeIErAnCF9ma3SAU06bdQtQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.0.tgz",
+      "integrity": "sha512-0BnUG9mS8I4SSHr3XsxVhuCMEiu+rX61xxZF5vujso4LaiAGFZFxvDjg6Xn6tLPNTUAfuCvQYas4LMQMVsKRSQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Adu/VttB1dpPNW+FEacrZ+xVm9tFty84+RrFzsqlFaPxoJB+9XXyDGtp5dCOoBwGBIEVH0To7lExFXEx0BIF4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.0.tgz",
+      "integrity": "sha512-NQ3bDvjUbFKmP23671xUlXtKmqVsUBd6M4PQCvbmNtOy06hnQIdKHy8oG/6S3R/S6He1JgPk6A5VT+prAJMYEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.0.tgz",
+      "integrity": "sha512-u2eDAl4+0aFvA13GxlGBtTI3SS3sdgwgtV0HyjZ0QaQVCgNE+jqNGey+GtxWiq+wxr/UycAx/OnfJzApCFamvA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.0.tgz",
+      "integrity": "sha512-XvRb5vfW3wAZQ+ZUG21AnHHDKtNcw99eigzEhjr//NZ3u7SoBaPP0seSc7FgP7p1epAEdAoZckMW9WY/+4w70w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.0.tgz",
+      "integrity": "sha512-iZPmniy4kNBf5yo2RezbkYNNK5HPbXE9+g+twnbqSng7dtLEJy1SKoxiE/ni4FDacjyuZpEeb9U054N4EoKHYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.0.tgz",
+      "integrity": "sha512-mFBBd+LF37fnE8JnYUOH+imj0aPFPK30vpar4ehJkgnLj9sZn8ZxiRENmLtgIwxK7TC8klF6N57fxdNBwQoqOA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-ujeqEY3B+zbGn3Z4Q03cUBG/LGWnBJncVT36WER31LcOsQk9+1dmINKKtvmmfChUvRbK1G0R8OhMWFgHgaZtAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.0.tgz",
+      "integrity": "sha512-hncn90N4sOky0L2LKE5oESKLbxCPeVo4eLA2LSMoDzM+879ml4WSr+Rr4DWknNIVVvS1Hirkc9hx02W6YxS8rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz",
+      "integrity": "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
+      "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.40",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
+      "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
+      "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.40",
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/shared": "3.5.40",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
+      "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
+      "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
+      "integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
+      "integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.40",
+        "@vue/runtime-core": "3.5.40",
+        "@vue/shared": "3.5.40",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
+      "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
+      "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.0.tgz",
+      "integrity": "sha512-T5vnZ2y4QqC3/4P+w2+JO+Q/OVdnPsv4XcSYJYMEn0R9/jjl5AgLwO9LAZMzP2lN71O6pypn91rB7lDstUkfrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.0",
+        "@rollup/rollup-android-arm64": "4.63.0",
+        "@rollup/rollup-darwin-arm64": "4.63.0",
+        "@rollup/rollup-darwin-x64": "4.63.0",
+        "@rollup/rollup-freebsd-arm64": "4.63.0",
+        "@rollup/rollup-freebsd-x64": "4.63.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.0",
+        "@rollup/rollup-linux-arm64-musl": "4.63.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.0",
+        "@rollup/rollup-linux-loong64-musl": "4.63.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-musl": "4.63.0",
+        "@rollup/rollup-openbsd-x64": "4.63.0",
+        "@rollup/rollup-openharmony-arm64": "4.63.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.0",
+        "@rollup/rollup-win32-x64-gnu": "4.63.0",
+        "@rollup/rollup-win32-x64-msvc": "4.63.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
+      "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-sfc": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/server-renderer": "3.5.40",
+        "@vue/shared": "3.5.40"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,13 @@
       "name": "dealer3-web",
       "version": "1.0.0",
       "dependencies": {
-        "monaco-editor": "0.52.2",
+        "@codemirror/autocomplete": "^6.20.3",
+        "@codemirror/commands": "^6.11.0",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.9",
+        "@lezer/highlight": "^1.2.3",
         "vue": "3.5.40"
       },
       "devDependencies": {
@@ -61,6 +67,76 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.11.0.tgz",
+      "integrity": "sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.9.tgz",
+      "integrity": "sha512-sTuUzTpPMFebRhg6dawChoKKgndIwfjmJgKVxBefPElcU2NwQ6AFroupk0SFqEerQyZOGRfDNnSN8Dw/lMAsXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -509,6 +585,36 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.4.tgz",
+      "integrity": "sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
@@ -1199,6 +1305,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1369,12 +1481,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1553,6 +1659,12 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1806,6 +1918,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "@codemirror/language": "^6.12.4",
         "@codemirror/lint": "^6.9.7",
         "@codemirror/state": "^6.7.1",
+        "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.43.9",
         "@lezer/highlight": "^1.2.3",
         "vue": "3.5.40"
@@ -125,6 +126,18 @@
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "@codemirror/language": "^6.12.4",
     "@codemirror/lint": "^6.9.7",
     "@codemirror/state": "^6.7.1",
+    "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.9",
     "@lezer/highlight": "^1.2.3",
     "vue": "3.5.40"

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dealer3-web",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Write and run bridge dealer scripts in the browser",
+  "scripts": {
+    "wasm": "wasm-pack build ../wasm --release --target web --out-dir ../web/src/wasm --no-typescript",
+    "dev": "npm run wasm && vite",
+    "build": "vite build",
+    "build:all": "npm run wasm && vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "monaco-editor": "0.52.2",
+    "vue": "3.5.40"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "6.0.8",
+    "vite": "7.3.6",
+    "vitest": "3.2.7"
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "monaco-editor": "0.52.2",
+    "@codemirror/autocomplete": "^6.20.3",
+    "@codemirror/commands": "^6.11.0",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/lint": "^6.9.7",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.9",
+    "@lezer/highlight": "^1.2.3",
     "vue": "3.5.40"
   },
   "devDependencies": {

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,0 +1,33 @@
+# Cloudflare Pages response headers.
+#
+# Vite copies everything in `web/public/` into the build output verbatim, so
+# this file lands at the root of the deploy where Pages looks for it.
+
+/*
+  X-Content-Type-Options: nosniff
+  # A script can travel in the query string (`?script=`), and a script is the
+  # user's own work. Never hand it to a third party via the referrer.
+  Referrer-Policy: no-referrer
+
+# COOP/COEP are what `SharedArrayBuffer` needs, and `SharedArrayBuffer` is what a
+# threaded wasm build needs. The current build is single-threaded and does not
+# require these, but they are set now because they are the reason this site is on
+# Cloudflare Pages rather than GitHub Pages, which cannot send custom headers.
+#
+# They are not free: `require-corp` blocks cross-origin subresources that do not
+# opt in via CORP/CORS. Everything this page loads is same-origin except the PBS
+# manifest and scripts, which come from raw.githubusercontent.com over CORS and
+# are therefore unaffected.
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+
+# Vite content-hashes everything under `assets/` — the wasm binary, JS, CSS. A
+# hashed name cannot mean different bytes, so it is safe to cache forever and
+# repeat visits skip the engine download.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Not hashed, so it must be revalidated or a deploy never reaches anyone holding
+# the old one.
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -22,6 +22,7 @@
             <select v-model="format">
               <option value="oneline">One line</option>
               <option value="printall">Print all</option>
+              <option value="pbn">PBN</option>
             </select>
           </label>
           <button class="run" :disabled="!engineReady || running || !scriptValid" @click="run">
@@ -33,7 +34,13 @@
       </section>
 
       <section class="col col-results">
-        <ResultsPanel :result="result" :error="error" :requested="produce" />
+        <ResultsPanel
+          :result="result"
+          :error="error"
+          :requested="produce"
+          :downloading="downloading"
+          @download="onDownload"
+        />
       </section>
     </main>
   </div>
@@ -46,6 +53,7 @@ import ScriptEditor from '@/components/ScriptEditor.vue'
 import ResultsPanel from '@/components/ResultsPanel.vue'
 import { ready, generate, version } from '@/lib/engine.js'
 import { fetchScenarioScript } from '@/lib/pbsScenarios.js'
+import { downloadText, resultFilename, statisticsText } from '@/lib/download.js'
 
 const STARTER = `# Write a dealer script, or pick a scenario on the left.
 condition hcp(north) >= 15 && shape(north, any 4333 + any 4432 + any 5332)
@@ -69,6 +77,7 @@ const error = ref('')
 const scriptValid = ref(true)
 const selectedFile = ref('')
 const loadingFile = ref('')
+const downloading = ref(false)
 
 onMounted(async () => {
   await ready()
@@ -93,6 +102,42 @@ async function pickScenario(item) {
     error.value = e.message || String(e)
   } finally {
     loadingFile.value = ''
+  }
+}
+
+// Saving re-runs rather than reformatting what is on screen: the displayed
+// deals are capped, and PBN needs the engine's formatter anyway. The stats are
+// identical either way, since generation is deterministic for a given seed.
+async function onDownload(kind) {
+  downloading.value = true
+  try {
+    const name = selectedFile.value || 'dealer3'
+    if (kind === 'pbn') {
+      const pbn = generate(script.value, {
+        seed: seed.value,
+        produce: produce.value,
+        maxGenerate: maxGenerate.value,
+        format: 'pbn',
+      })
+      downloadText(
+        resultFilename(name, seed.value, 'pbn'),
+        pbn.deals.join('\n') + '\n',
+        'application/x-pbn',
+      )
+    } else {
+      const text = generate(script.value, {
+        seed: seed.value,
+        produce: produce.value,
+        maxGenerate: maxGenerate.value,
+        format: format.value === 'pbn' ? 'oneline' : format.value,
+      })
+      const body = text.deals.join('\n') + '\n' + statisticsText(text)
+      downloadText(resultFilename(name, seed.value, 'txt'), body)
+    }
+  } catch (e) {
+    error.value = e?.message || String(e)
+  } finally {
+    downloading.value = false
   }
 }
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -178,6 +178,10 @@ async function run() {
   --warn-fg: #8a6300;
   --warn-subtle: #fdf6e3;
   --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  /* The editor is dark against the light page; these keep its chrome — border,
+     status strip — matched to it rather than to the surrounding UI. */
+  --editor-bg: #282c34;
+  --editor-line: #3a4049;
 }
 
 * { box-sizing: border-box; }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -4,6 +4,14 @@
       <h1>dealer3</h1>
       <span class="bar-sub">bridge hand generator — runs entirely in your browser</span>
       <span class="bar-spacer"></span>
+      <!-- Feedback needs somewhere durable to land. Without this the only route
+           is email, and a report with no script attached is hard to act on. -->
+      <a
+        class="bar-link"
+        href="https://github.com/bridge-craftwork/Dealer3/issues"
+        target="_blank"
+        rel="noopener noreferrer"
+      >Feedback &amp; issues</a>
       <span v-if="engineVersion" class="bar-version">engine {{ engineVersion }}</span>
     </header>
 
@@ -203,6 +211,8 @@ body {
 .bar h1 { font-size: 15px; margin: 0; }
 .bar-sub { font-size: 12px; color: var(--fg-muted); }
 .bar-spacer { flex: 1; }
+.bar-link { font-size: 12px; color: var(--accent); text-decoration: none; }
+.bar-link:hover { text-decoration: underline; }
 .bar-version { font-size: 11px; color: var(--fg-muted); font-family: var(--mono); }
 
 .cols { display: grid; grid-template-columns: 260px 1fr 1fr; flex: 1; min-height: 0; }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -29,12 +29,7 @@
           </button>
         </div>
 
-        <Suspense>
-          <ScriptEditor v-model="script" @validity="onValidity" />
-          <template #fallback>
-            <div class="editor-loading">Loading editor…</div>
-          </template>
-        </Suspense>
+        <ScriptEditor v-model="script" @validity="onValidity" />
       </section>
 
       <section class="col col-results">
@@ -45,13 +40,9 @@
 </template>
 
 <script setup>
-import { ref, onMounted, nextTick, defineAsyncComponent } from 'vue'
+import { ref, onMounted, nextTick } from 'vue'
 import ScenarioPicker from '@/components/ScenarioPicker.vue'
-
-// Monaco is by far the largest thing here — bigger than the engine. Loading it
-// lazily lets the shell, the scenario list and the engine start while the editor
-// is still arriving, rather than holding first paint behind it.
-const ScriptEditor = defineAsyncComponent(() => import('@/components/ScriptEditor.vue'))
+import ScriptEditor from '@/components/ScriptEditor.vue'
 import ResultsPanel from '@/components/ResultsPanel.vue'
 import { ready, generate, version } from '@/lib/engine.js'
 import { fetchScenarioScript } from '@/lib/pbsScenarios.js'

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,0 +1,197 @@
+<template>
+  <div class="app">
+    <header class="bar">
+      <h1>dealer3</h1>
+      <span class="bar-sub">bridge hand generator — runs entirely in your browser</span>
+      <span class="bar-spacer"></span>
+      <span v-if="engineVersion" class="bar-version">engine {{ engineVersion }}</span>
+    </header>
+
+    <main class="cols">
+      <aside class="col col-picker">
+        <ScenarioPicker :selected="selectedFile" :busy-file="loadingFile" @select="pickScenario" />
+      </aside>
+
+      <section class="col col-editor">
+        <div class="controls">
+          <label>Seed <input v-model.number="seed" type="number" min="0" /></label>
+          <label>Produce <input v-model.number="produce" type="number" min="1" /></label>
+          <label>Max generate <input v-model.number="maxGenerate" type="number" min="1" step="1000" /></label>
+          <label>
+            Format
+            <select v-model="format">
+              <option value="oneline">One line</option>
+              <option value="printall">Print all</option>
+            </select>
+          </label>
+          <button class="run" :disabled="!engineReady || running || !scriptValid" @click="run">
+            {{ running ? 'Running…' : 'Run' }}
+          </button>
+        </div>
+
+        <Suspense>
+          <ScriptEditor v-model="script" @validity="onValidity" />
+          <template #fallback>
+            <div class="editor-loading">Loading editor…</div>
+          </template>
+        </Suspense>
+      </section>
+
+      <section class="col col-results">
+        <ResultsPanel :result="result" :error="error" :requested="produce" />
+      </section>
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, nextTick, defineAsyncComponent } from 'vue'
+import ScenarioPicker from '@/components/ScenarioPicker.vue'
+
+// Monaco is by far the largest thing here — bigger than the engine. Loading it
+// lazily lets the shell, the scenario list and the engine start while the editor
+// is still arriving, rather than holding first paint behind it.
+const ScriptEditor = defineAsyncComponent(() => import('@/components/ScriptEditor.vue'))
+import ResultsPanel from '@/components/ResultsPanel.vue'
+import { ready, generate, version } from '@/lib/engine.js'
+import { fetchScenarioScript } from '@/lib/pbsScenarios.js'
+
+const STARTER = `# Write a dealer script, or pick a scenario on the left.
+condition hcp(north) >= 15 && shape(north, any 4333 + any 4432 + any 5332)
+
+action printoneline,
+  average "N HCP" hcp(north),
+  frequency "N HCP" (hcp(north), 15, 22)
+`
+
+const script = ref(STARTER)
+const seed = ref(1)
+const produce = ref(20)
+const maxGenerate = ref(500000)
+const format = ref('oneline')
+
+const engineReady = ref(false)
+const engineVersion = ref('')
+const running = ref(false)
+const result = ref(null)
+const error = ref('')
+const scriptValid = ref(true)
+const selectedFile = ref('')
+const loadingFile = ref('')
+
+onMounted(async () => {
+  await ready()
+  engineReady.value = true
+  engineVersion.value = version()
+})
+
+function onValidity({ ok, empty }) {
+  scriptValid.value = ok && !empty
+}
+
+async function pickScenario(item) {
+  loadingFile.value = item.file
+  error.value = ''
+  try {
+    script.value = await fetchScenarioScript(item.file)
+    selectedFile.value = item.file
+    result.value = null
+    // Let the editor take the new buffer and re-validate before running.
+    await nextTick()
+  } catch (e) {
+    error.value = e.message || String(e)
+  } finally {
+    loadingFile.value = ''
+  }
+}
+
+async function run() {
+  running.value = true
+  error.value = ''
+  try {
+    // Generation is synchronous inside the wasm module and will block the tab.
+    // Yield a frame first so the button can paint its running state; the
+    // max-generate bound is what actually keeps the block short.
+    await new Promise((r) => requestAnimationFrame(r))
+    result.value = generate(script.value, {
+      seed: seed.value,
+      produce: produce.value,
+      maxGenerate: maxGenerate.value,
+      format: format.value,
+    })
+  } catch (e) {
+    result.value = null
+    error.value = e?.message || String(e)
+  } finally {
+    running.value = false
+  }
+}
+</script>
+
+<style>
+:root {
+  --bg: #ffffff;
+  --bg-subtle: #f4f5f7;
+  --fg: #1b1d20;
+  --fg-muted: #6b7280;
+  --line: #d8dade;
+  --accent: #2f6fb2;
+  --accent-subtle: #e4eefa;
+  --danger: #b3261e;
+  --warn: #b8860b;
+  --warn-fg: #8a6300;
+  --warn-subtle: #fdf6e3;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+html, body, #app { height: 100%; margin: 0; }
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--fg);
+  background: var(--bg);
+}
+</style>
+
+<style scoped>
+.app { display: flex; flex-direction: column; height: 100%; }
+
+.bar {
+  display: flex; align-items: baseline; gap: 10px;
+  padding: 8px 14px; border-bottom: 1px solid var(--line); background: var(--bg-subtle);
+}
+.bar h1 { font-size: 15px; margin: 0; }
+.bar-sub { font-size: 12px; color: var(--fg-muted); }
+.bar-spacer { flex: 1; }
+.bar-version { font-size: 11px; color: var(--fg-muted); font-family: var(--mono); }
+
+.cols { display: grid; grid-template-columns: 260px 1fr 1fr; flex: 1; min-height: 0; }
+.col { min-width: 0; min-height: 0; }
+.col-picker { border-right: 1px solid var(--line); }
+.col-editor { display: flex; flex-direction: column; padding: 8px; gap: 8px; min-height: 0; }
+.col-results { border-left: 1px solid var(--line); min-height: 0; }
+
+.controls { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; font-size: 12px; }
+.controls label { display: flex; align-items: center; gap: 4px; color: var(--fg-muted); }
+.controls input, .controls select {
+  font: inherit; font-size: 12px; padding: 3px 5px;
+  border: 1px solid var(--line); border-radius: 3px; background: var(--bg); color: var(--fg);
+}
+.controls input[type="number"] { width: 7em; }
+.editor-loading {
+  flex: 1; display: grid; place-items: center;
+  color: var(--fg-muted); font-size: 13px;
+  border: 1px solid var(--line); border-radius: 4px;
+}
+.run {
+  margin-left: auto; padding: 5px 16px; font: inherit; font-size: 13px; font-weight: 500;
+  border: 0; border-radius: 4px; background: var(--accent); color: #fff; cursor: pointer;
+}
+.run:disabled { background: var(--line); color: var(--fg-muted); cursor: default; }
+
+@media (max-width: 1000px) {
+  .cols { grid-template-columns: 1fr; grid-template-rows: auto 1fr 1fr; }
+  .col-picker { border-right: 0; border-bottom: 1px solid var(--line); max-height: 220px; }
+  .col-results { border-left: 0; border-top: 1px solid var(--line); }
+}
+</style>

--- a/web/src/components/DealGrid.vue
+++ b/web/src/components/DealGrid.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="grid">
+    <article v-for="(deal, i) in deals" :key="i" class="board">
+      <header class="board-head">
+        <span class="board-no">{{ i + 1 }}</span>
+        <span class="board-hcp">
+          NS {{ deal.north.hcp + deal.south.hcp }} · EW {{ deal.east.hcp + deal.west.hcp }}
+        </span>
+      </header>
+
+      <!-- Compass layout: North on top, East/West flanking, South below —
+           the arrangement a bridge player reads without thinking. -->
+      <div class="compass">
+        <div class="seat seat-n"><Hand label="N" :hand="deal.north" /></div>
+        <div class="seat seat-w"><Hand label="W" :hand="deal.west" /></div>
+        <div class="seat seat-e"><Hand label="E" :hand="deal.east" /></div>
+        <div class="seat seat-s"><Hand label="S" :hand="deal.south" /></div>
+      </div>
+    </article>
+  </div>
+</template>
+
+<script setup>
+// A grid of deals laid out as bridge hands rather than one-line strings.
+//
+// Card primitives are vendored from Bridge-Classroom (lib/cardFormatting.js);
+// its HandDisplay.vue was not, being built for an interactive table.
+import { h } from 'vue'
+import { SUIT_ORDER, SUIT_SYMBOLS, RED_SUITS } from '@/lib/cardFormatting.js'
+
+defineProps({
+  deals: { type: Array, required: true },
+})
+
+// Small enough to be a render function: four rows of symbol + ranks, plus the
+// seat label and HCP. A separate SFC would be more indirection than it saves.
+const Hand = (props) =>
+  h('div', { class: 'hand' }, [
+    h('div', { class: 'hand-head' }, [
+      h('span', { class: 'hand-label' }, props.label),
+      h('span', { class: 'hand-hcp' }, `${props.hand.hcp}`),
+    ]),
+    ...SUIT_ORDER.map((suit) =>
+      h('div', { class: ['suit', RED_SUITS.has(suit) ? 'is-red' : 'is-black'] }, [
+        h('span', { class: 'suit-sym' }, SUIT_SYMBOLS[suit]),
+        // An en dash reads as "void" at a glance; an empty cell reads as a bug.
+        h('span', { class: 'suit-cards' }, props.hand[suit].length ? props.hand[suit].join('') : '—'),
+      ]),
+    ),
+  ])
+Hand.props = ['label', 'hand']
+</script>
+
+<style scoped>
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 10px;
+}
+
+.board { border: 1px solid var(--line); border-radius: 4px; padding: 6px 8px 8px; }
+.board-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-size: 11px; color: var(--fg-muted); margin-bottom: 4px;
+}
+.board-no { font-weight: 600; }
+.board-hcp { font-family: var(--mono); }
+
+.compass {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-areas: 'n n' 'w e' 's s';
+  gap: 4px 8px;
+}
+.seat-n { grid-area: n; justify-self: center; }
+.seat-w { grid-area: w; }
+.seat-e { grid-area: e; }
+.seat-s { grid-area: s; justify-self: center; }
+
+:deep(.hand) { min-width: 96px; }
+:deep(.hand-head) {
+  display: flex; gap: 6px; align-items: baseline;
+  font-size: 10px; color: var(--fg-muted);
+}
+:deep(.hand-label) { font-weight: 700; }
+:deep(.hand-hcp) { font-family: var(--mono); }
+:deep(.suit) { display: flex; gap: 4px; font-family: var(--mono); font-size: 12px; line-height: 1.35; }
+:deep(.suit-sym) { width: 0.9em; }
+:deep(.suit.is-red .suit-sym) { color: #c0392b; }
+:deep(.suit.is-black .suit-sym) { color: var(--fg); }
+:deep(.suit-cards) { letter-spacing: 0.04em; }
+</style>

--- a/web/src/components/ResultsPanel.vue
+++ b/web/src/components/ResultsPanel.vue
@@ -1,0 +1,154 @@
+<template>
+  <div class="results">
+    <p v-if="error" class="results-error">{{ error }}</p>
+    <p v-else-if="!result" class="results-muted">Run a script to see deals here.</p>
+
+    <template v-else>
+      <!-- The CLI's trailing stats block. -->
+      <div class="stats">
+        <span><strong>{{ result.generated.toLocaleString() }}</strong> generated</span>
+        <span><strong>{{ result.produced.toLocaleString() }}</strong> produced</span>
+        <span><strong>{{ result.seconds.toFixed(3) }}</strong> sec</span>
+      </div>
+
+      <p v-if="result.hitLimit" class="results-warn">
+        Stopped at the generate limit before producing {{ requested }} deals. The filter may be
+        very selective — raise the limit, or loosen the condition.
+      </p>
+      <p v-else-if="result.dealsTruncated" class="results-note">
+        Showing the first {{ result.deals.length }} of {{ result.produced.toLocaleString() }}
+        deals. Statistics below cover all of them.
+      </p>
+
+      <!-- average "label" expr -->
+      <section v-if="result.averages.length" class="block">
+        <h3>Averages</h3>
+        <table class="avg">
+          <tbody>
+            <tr v-for="(a, i) in result.averages" :key="i">
+              <th>{{ (a.label || 'Average').trim() }}</th>
+              <td>{{ formatValue(a.value) }}</td>
+              <td class="avg-n">over {{ a.count.toLocaleString() }} deals</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- frequency "label" (expr, min, max) -->
+      <section v-for="(f, i) in result.frequencies" :key="'f' + i" class="block">
+        <h3>{{ (f.label || 'Frequency').trim() }}</h3>
+
+        <p v-if="!f.total" class="results-muted">No observations.</p>
+
+        <template v-else>
+          <!-- Values outside a declared range. Shown above the chart rather than
+               tucked away: a script whose range is too narrow otherwise looks
+               like it simply produced fewer deals. -->
+          <p v-if="f.below || f.above" class="freq-outside">
+            <span v-if="f.below">{{ f.below }} below {{ f.min }}</span>
+            <span v-if="f.below && f.above"> · </span>
+            <span v-if="f.above">{{ f.above }} above {{ f.max }}</span>
+          </p>
+
+          <div class="freq">
+            <div v-for="bin in f.bins" :key="bin.value" class="freq-row">
+              <span class="freq-value">{{ bin.value }}</span>
+              <span class="freq-bar-track">
+                <span
+                  class="freq-bar"
+                  :style="{ width: barWidth(bin.count, f) }"
+                  :class="{ 'is-zero': !bin.count }"
+                ></span>
+              </span>
+              <span class="freq-count">{{ bin.count }}</span>
+              <span class="freq-pct">{{ percent(bin.count, f.total) }}</span>
+            </div>
+          </div>
+        </template>
+      </section>
+
+      <section v-if="result.deals.length" class="block">
+        <h3>Deals</h3>
+        <pre class="deals">{{ result.deals.join('\n') }}</pre>
+      </section>
+      <p v-else-if="!result.hitLimit" class="results-muted">
+        No deals matched the condition.
+      </p>
+    </template>
+  </div>
+</template>
+
+<script setup>
+// Renders everything a script produces: the stats block, `average` results, and
+// `frequency` histograms.
+//
+// Frequencies arrive as data rather than the CLI's ASCII table, so they are
+// drawn as bars. The numbers are kept alongside — this replaces the table's
+// presentation, not its precision.
+const props = defineProps({
+  result: { type: Object, default: null },
+  error: { type: String, default: '' },
+  requested: { type: Number, default: 0 },
+})
+
+/** Bars scale to the tallest bin, so a flat distribution still reads. */
+function barWidth(count, freq) {
+  const peak = Math.max(1, ...freq.bins.map((b) => b.count))
+  return `${(count / peak) * 100}%`
+}
+
+function percent(count, total) {
+  if (!total) return ''
+  return `${((count / total) * 100).toFixed(1)}%`
+}
+
+/** Averages come back as full f64; six significant digits is plenty to read. */
+function formatValue(v) {
+  if (Number.isInteger(v)) return String(v)
+  return Number(v.toPrecision(6)).toString()
+}
+</script>
+
+<style scoped>
+.results { padding: 12px; overflow-y: auto; height: 100%; min-height: 0; }
+.results-muted { color: var(--fg-muted); font-size: 13px; }
+.results-error {
+  color: var(--danger); font-size: 13px; font-family: var(--mono);
+  white-space: pre-wrap; margin: 0 0 12px;
+}
+.results-warn {
+  background: var(--warn-subtle); border-left: 3px solid var(--warn);
+  padding: 8px 10px; font-size: 13px; margin: 0 0 12px;
+}
+.results-note { color: var(--fg-muted); font-size: 12px; margin: 0 0 12px; }
+
+.stats { display: flex; gap: 16px; font-size: 13px; margin-bottom: 12px; flex-wrap: wrap; }
+.stats strong { font-family: var(--mono); }
+
+.block { margin-bottom: 20px; }
+.block h3 {
+  font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em;
+  color: var(--fg-muted); margin: 0 0 8px;
+}
+
+.avg { border-collapse: collapse; font-size: 13px; }
+.avg th { text-align: left; font-weight: 500; padding: 2px 12px 2px 0; white-space: pre; }
+.avg td { font-family: var(--mono); padding: 2px 12px 2px 0; }
+.avg-n { color: var(--fg-muted); font-family: inherit !important; font-size: 12px; }
+
+.freq-outside { font-size: 12px; color: var(--warn-fg); margin: 0 0 6px; }
+.freq { display: flex; flex-direction: column; gap: 2px; }
+.freq-row { display: grid; grid-template-columns: 3em 1fr 4em 4em; align-items: center; gap: 8px; font-size: 12px; }
+.freq-value { font-family: var(--mono); text-align: right; color: var(--fg-muted); }
+.freq-bar-track { background: var(--bg-subtle); border-radius: 2px; height: 14px; overflow: hidden; }
+.freq-bar { display: block; height: 100%; background: var(--accent); border-radius: 2px; }
+.freq-bar.is-zero { background: transparent; }
+.freq-count { font-family: var(--mono); text-align: right; }
+.freq-pct { font-family: var(--mono); text-align: right; color: var(--fg-muted); }
+
+.deals {
+  font-family: var(--mono); font-size: 12px; line-height: 1.5;
+  background: var(--bg-subtle); padding: 10px; border-radius: 4px;
+  overflow-x: auto; margin: 0; white-space: pre;
+}
+</style>

--- a/web/src/components/ResultsPanel.vue
+++ b/web/src/components/ResultsPanel.vue
@@ -23,15 +23,15 @@
       <!-- average "label" expr -->
       <section v-if="result.averages.length" class="block">
         <h3>Averages</h3>
-        <table class="avg">
-          <tbody>
-            <tr v-for="(a, i) in result.averages" :key="i">
-              <th>{{ (a.label || 'Average').trim() }}</th>
-              <td>{{ formatValue(a.value) }}</td>
-              <td class="avg-n">over {{ a.count.toLocaleString() }} deals</td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="avg">
+          <div v-for="(a, i) in result.averages" :key="i" class="avg-row">
+            <span class="avg-label">{{ (a.label || 'Average').trim() }}</span>
+            <span class="avg-bar-track">
+              <span class="avg-bar" :style="{ width: averageBarWidth(a.value) }"></span>
+            </span>
+            <span class="avg-value">{{ formatValue(a.value) }}</span>
+          </div>
+        </div>
       </section>
 
       <!-- frequency "label" (expr, min, max) -->
@@ -126,6 +126,25 @@ const parsedDeals = computed(() => {
   return parseOnelineDeals(props.result.deals.join('\n'))
 })
 
+/**
+ * Averages share one scale, set by the largest value shown, so the bars compare
+ * against each other rather than each filling its own row.
+ *
+ * A negative average gets no bar rather than a misleading one: these are
+ * arbitrary script expressions, and `100 * (x - y)` can legitimately go below
+ * zero. The number is always shown, so nothing is hidden.
+ */
+const averageScale = computed(() => {
+  const values = (props.result?.averages || []).map((a) => a.value)
+  return Math.max(0, ...values)
+})
+
+function averageBarWidth(value) {
+  const peak = averageScale.value
+  if (!(peak > 0) || !(value > 0)) return '0%'
+  return `${(value / peak) * 100}%`
+}
+
 /** Bars scale to the tallest bin, so a flat distribution still reads. */
 function barWidth(count, freq) {
   const peak = Math.max(1, ...freq.bins.map((b) => b.count))
@@ -166,10 +185,12 @@ function formatValue(v) {
   color: var(--fg-muted); margin: 0 0 8px;
 }
 
-.avg { border-collapse: collapse; font-size: 13px; }
-.avg th { text-align: left; font-weight: 500; padding: 2px 12px 2px 0; white-space: pre; }
-.avg td { font-family: var(--mono); padding: 2px 12px 2px 0; }
-.avg-n { color: var(--fg-muted); font-family: inherit !important; font-size: 12px; }
+.avg { display: flex; flex-direction: column; gap: 3px; }
+.avg-row { display: grid; grid-template-columns: minmax(6em, 14em) 1fr 5em; align-items: center; gap: 8px; font-size: 12px; }
+.avg-label { white-space: pre; overflow: hidden; text-overflow: ellipsis; }
+.avg-bar-track { background: var(--bg-subtle); border-radius: 2px; height: 14px; overflow: hidden; }
+.avg-bar { display: block; height: 100%; background: var(--accent); border-radius: 2px; }
+.avg-value { font-family: var(--mono); text-align: right; }
 
 .freq-outside { font-size: 12px; color: var(--warn-fg); margin: 0 0 6px; }
 .freq { display: flex; flex-direction: column; gap: 2px; }

--- a/web/src/components/ResultsPanel.vue
+++ b/web/src/components/ResultsPanel.vue
@@ -68,8 +68,26 @@
       </section>
 
       <section v-if="result.deals.length" class="block">
-        <h3>Deals</h3>
-        <pre class="deals">{{ result.deals.join('\n') }}</pre>
+        <div class="deals-head">
+          <h3>Deals</h3>
+          <div class="deals-tools">
+            <div class="toggle" role="group" aria-label="Deal view">
+              <button :class="{ on: view === 'grid' }" @click="view = 'grid'">Hands</button>
+              <button :class="{ on: view === 'text' }" @click="view = 'text'">Text</button>
+            </div>
+            <button class="dl" :disabled="downloading" @click="$emit('download', 'pbn')">
+              Save PBN
+            </button>
+            <button class="dl" @click="$emit('download', 'text')">Save text</button>
+          </div>
+        </div>
+
+        <p v-if="view === 'grid' && !parsedDeals.length" class="results-muted">
+          This output format cannot be shown as hands. Switch to Text, or generate with the
+          one-line format.
+        </p>
+        <DealGrid v-else-if="view === 'grid'" :deals="parsedDeals" />
+        <pre v-else class="deals">{{ result.deals.join('\n') }}</pre>
       </section>
       <p v-else-if="!result.hitLimit" class="results-muted">
         No deals matched the condition.
@@ -79,16 +97,33 @@
 </template>
 
 <script setup>
-// Renders everything a script produces: the stats block, `average` results, and
-// `frequency` histograms.
+// Renders everything a script produces: the stats block, `average` results,
+// `frequency` histograms, and the deals themselves — as hands or as text.
 //
 // Frequencies arrive as data rather than the CLI's ASCII table, so they are
 // drawn as bars. The numbers are kept alongside — this replaces the table's
 // presentation, not its precision.
+import { ref, computed } from 'vue'
+import DealGrid from '@/components/DealGrid.vue'
+import { parseOnelineDeals } from '@/lib/cardFormatting.js'
+
 const props = defineProps({
   result: { type: Object, default: null },
   error: { type: String, default: '' },
   requested: { type: Number, default: 0 },
+  downloading: { type: Boolean, default: false },
+})
+defineEmits(['download'])
+
+// Hands read far more easily than one-line strings, so that is the default.
+const view = ref('grid')
+
+// Only the one-line format can be laid out as hands: printall is already a
+// visual layout, and PBN is a record format. Returns [] for those, and the
+// template offers Text instead rather than showing an empty grid.
+const parsedDeals = computed(() => {
+  if (!props.result?.deals?.length) return []
+  return parseOnelineDeals(props.result.deals.join('\n'))
 })
 
 /** Bars scale to the tallest bin, so a flat distribution still reads. */
@@ -145,6 +180,22 @@ function formatValue(v) {
 .freq-bar.is-zero { background: transparent; }
 .freq-count { font-family: var(--mono); text-align: right; }
 .freq-pct { font-family: var(--mono); text-align: right; color: var(--fg-muted); }
+
+.deals-head { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+.deals-head h3 { margin: 0; }
+.deals-tools { display: flex; align-items: center; gap: 6px; margin-left: auto; }
+.toggle { display: inline-flex; border: 1px solid var(--line); border-radius: 4px; overflow: hidden; }
+.toggle button {
+  border: 0; background: var(--bg); color: var(--fg-muted);
+  font: inherit; font-size: 11px; padding: 3px 9px; cursor: pointer;
+}
+.toggle button.on { background: var(--accent); color: #fff; }
+.dl {
+  border: 1px solid var(--line); border-radius: 4px; background: var(--bg);
+  color: var(--fg); font: inherit; font-size: 11px; padding: 3px 9px; cursor: pointer;
+}
+.dl:hover { background: var(--bg-subtle); }
+.dl:disabled { opacity: 0.5; cursor: default; }
 
 .deals {
   font-family: var(--mono); font-size: 12px; line-height: 1.5;

--- a/web/src/components/ScenarioPicker.vue
+++ b/web/src/components/ScenarioPicker.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="picker">
+    <div class="picker-head">
+      <input
+        v-model="query"
+        class="picker-search"
+        type="search"
+        placeholder="Search 340+ scenarios…"
+        aria-label="Search scenarios"
+      />
+      <button class="picker-refresh" :disabled="loading" title="Reload the list" @click="load">↻</button>
+    </div>
+
+    <p v-if="loading" class="picker-muted">Loading scenarios…</p>
+    <p v-else-if="error" class="picker-error">{{ error }}</p>
+    <p v-else-if="!visible.length" class="picker-muted">
+      No scenario matches “{{ query }}”.
+    </p>
+
+    <div v-else class="picker-tree">
+      <div v-for="section in visible" :key="section.label" class="picker-section">
+        <button class="picker-section-head" @click="toggle(section.label)">
+          <span class="picker-caret">{{ isOpen(section.label) ? '▾' : '▸' }}</span>
+          {{ section.label }}
+          <span class="picker-count">{{ section.items.length }}</span>
+        </button>
+
+        <div v-if="isOpen(section.label)" class="picker-items">
+          <button
+            v-for="item in section.items"
+            :key="item.file"
+            class="picker-item"
+            :class="{ 'is-selected': item.file === selected, 'is-busy': item.file === busyFile }"
+            :title="item.description || item.file"
+            @click="$emit('select', item)"
+          >
+            <span class="picker-item-label">{{ item.label }}</span>
+            <span v-if="item.description" class="picker-item-desc">{{ item.description }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+// Browses the PBS scenario menu. Structure and metadata come from the manifest
+// PBS CI builds; see lib/pbsScenarios.js.
+//
+// Sections start COLLAPSED, unlike Bridge-Classroom's DealLibraryPicker where
+// everything starts open. A teacher's library is a handful of entries; this is
+// 340+ across 20 sections, and an all-open tree is unusable. Searching expands
+// automatically so matches are never hidden behind a closed section.
+import { ref, computed, onMounted, watch } from 'vue'
+import { fetchScenarioManifest } from '@/lib/pbsScenarios.js'
+
+const props = defineProps({
+  // Highlighted as current.
+  selected: { type: String, default: '' },
+  // Shown as loading while the parent fetches its script.
+  busyFile: { type: String, default: '' },
+})
+defineEmits(['select'])
+
+const sections = ref([])
+const loading = ref(false)
+const error = ref('')
+const query = ref('')
+const openSections = ref(new Set())
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try {
+    const { sections: s } = await fetchScenarioManifest('release')
+    sections.value = s
+  } catch (e) {
+    error.value = e.message || String(e)
+  } finally {
+    loading.value = false
+  }
+}
+onMounted(load)
+
+const visible = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  if (!q) return sections.value
+  return sections.value
+    .map((s) => ({
+      ...s,
+      items: s.items.filter(
+        (i) =>
+          i.label.toLowerCase().includes(q) ||
+          i.file.toLowerCase().includes(q) ||
+          (i.description || '').toLowerCase().includes(q),
+      ),
+    }))
+    .filter((s) => s.items.length)
+})
+
+// While searching every matching section is open — a match hidden behind a
+// collapsed heading reads as "no results".
+const searching = computed(() => query.value.trim().length > 0)
+function isOpen(label) {
+  return searching.value || openSections.value.has(label)
+}
+function toggle(label) {
+  const next = new Set(openSections.value)
+  next.has(label) ? next.delete(label) : next.add(label)
+  openSections.value = next
+}
+
+// Keep the section holding the current selection open when a search is cleared,
+// so the selected scenario does not vanish.
+watch(
+  () => props.selected,
+  (file) => {
+    if (!file) return
+    const owner = sections.value.find((s) => s.items.some((i) => i.file === file))
+    if (owner) openSections.value = new Set(openSections.value).add(owner.label)
+  },
+)
+</script>
+
+<style scoped>
+.picker { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+.picker-head { display: flex; gap: 6px; padding: 8px; border-bottom: 1px solid var(--line); }
+.picker-search {
+  flex: 1; min-width: 0; padding: 6px 8px; font: inherit; font-size: 13px;
+  border: 1px solid var(--line); border-radius: 4px;
+  background: var(--bg); color: var(--fg);
+}
+.picker-refresh {
+  padding: 4px 8px; border: 1px solid var(--line); border-radius: 4px;
+  background: var(--bg-subtle); color: var(--fg); cursor: pointer;
+}
+.picker-refresh:disabled { opacity: 0.5; cursor: default; }
+.picker-tree { overflow-y: auto; flex: 1; min-height: 0; }
+.picker-muted { padding: 12px; color: var(--fg-muted); font-size: 13px; }
+.picker-error { padding: 12px; color: var(--danger); font-size: 13px; }
+.picker-section-head {
+  display: flex; align-items: center; gap: 6px; width: 100%;
+  padding: 6px 8px; border: 0; background: none; cursor: pointer;
+  font: inherit; font-size: 13px; font-weight: 600; color: var(--fg); text-align: left;
+}
+.picker-section-head:hover { background: var(--bg-subtle); }
+.picker-caret { width: 10px; color: var(--fg-muted); }
+.picker-count { margin-left: auto; font-weight: 400; color: var(--fg-muted); font-size: 11px; }
+.picker-item {
+  display: block; width: 100%; padding: 5px 8px 5px 24px;
+  border: 0; background: none; cursor: pointer; text-align: left;
+  font: inherit; font-size: 13px; color: var(--fg);
+}
+.picker-item:hover { background: var(--bg-subtle); }
+.picker-item.is-selected { background: var(--accent-subtle); }
+.picker-item.is-busy { opacity: 0.6; }
+.picker-item-label { display: block; }
+.picker-item-desc {
+  display: block; font-size: 11px; color: var(--fg-muted);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+</style>

--- a/web/src/components/ScriptEditor.vue
+++ b/web/src/components/ScriptEditor.vue
@@ -21,9 +21,13 @@ import { ref, onMounted, onBeforeUnmount, watch, shallowRef } from 'vue'
 import { EditorState } from '@codemirror/state'
 import { EditorView, keymap, lineNumbers, highlightActiveLine } from '@codemirror/view'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
-import { syntaxHighlighting, defaultHighlightStyle, bracketMatching } from '@codemirror/language'
+import { bracketMatching } from '@codemirror/language'
 import { autocompletion, closeBrackets } from '@codemirror/autocomplete'
 import { linter, lintGutter } from '@codemirror/lint'
+// A dark editor on a light page. Syntax palettes are built for dark grounds —
+// the same colours that read clearly there are washed out on white, which is
+// what the default highlight style looked like here.
+import { oneDark } from '@codemirror/theme-one-dark'
 import { dlrLanguage, dlrCompletion } from '@/lib/dlrLanguage.js'
 import { checkScript, languageInfo, ready } from '@/lib/engine.js'
 
@@ -114,7 +118,7 @@ onMounted(async () => {
         bracketMatching(),
         closeBrackets(),
         keymap.of([...defaultKeymap, ...historyKeymap]),
-        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+        oneDark,
         dlrLanguage(info),
         autocompletion({ override: [dlrCompletion(info)] }),
         lintGutter(),
@@ -126,6 +130,9 @@ onMounted(async () => {
           '&': { height: '100%', fontSize: '13px' },
           '.cm-scroller': { fontFamily: 'var(--mono)', overflow: 'auto' },
           '&.cm-focused': { outline: 'none' },
+          // one-dark ships no rule for the lint gutter marker; without this it
+          // renders near-invisible against the dark gutter.
+          '.cm-lint-marker-error': { filter: 'brightness(1.4)' },
         }),
       ],
     }),
@@ -151,10 +158,14 @@ defineExpose({ focus: () => view.value?.focus() })
 .editor { display: flex; flex-direction: column; height: 100%; min-height: 0; }
 .editor-host {
   flex: 1; min-height: 0; overflow: hidden;
-  border: 1px solid var(--line); border-radius: 4px;
+  border: 1px solid var(--editor-line); border-radius: 4px 4px 0 0;
 }
+/* Reads as part of the dark editor rather than the light page. */
 .editor-status {
-  padding: 4px 8px; font-size: 12px; color: var(--fg-muted); font-family: var(--mono);
+  padding: 4px 8px; font-size: 12px; font-family: var(--mono);
+  color: #9aa3b2; background: var(--editor-bg);
+  border: 1px solid var(--editor-line); border-top: 0;
+  border-radius: 0 0 4px 4px; margin-top: -5px;
 }
-.editor-status.is-error { color: var(--danger); }
+.editor-status.is-error { color: #ff8a80; }
 </style>

--- a/web/src/components/ScriptEditor.vue
+++ b/web/src/components/ScriptEditor.vue
@@ -1,0 +1,154 @@
+<template>
+  <div class="editor">
+    <div ref="host" class="editor-host"></div>
+    <div class="editor-status" :class="{ 'is-error': !!diagnostic }">
+      <span v-if="diagnostic">
+        Line {{ diagnostic.line }}, column {{ diagnostic.column }} — {{ diagnostic.summary }}
+      </span>
+      <span v-else>No syntax errors</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+// The script editor: Monaco, with highlighting and diagnostics driven by the
+// engine itself.
+//
+// Diagnostics are the point. `check_script` is the real parser, so a squiggle
+// here means the engine will reject the script — not that a regex guessed. The
+// line and column come straight from pest.
+import { ref, onMounted, onBeforeUnmount, watch, shallowRef } from 'vue'
+// Core editor only. The `monaco-editor` barrel pulls in every language it
+// ships — perl, abap, solidity, the lot — which added ~2.5 MB of bundle for a
+// site that registers exactly one language of its own.
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js'
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+import { registerDlrLanguage, LANGUAGE_ID } from '@/lib/dlrLanguage.js'
+import { checkScript, languageInfo } from '@/lib/engine.js'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+})
+const emit = defineEmits(['update:modelValue', 'validity'])
+
+// Monaco expects to find its workers here. Only the base worker is needed:
+// no language services are loaded.
+self.MonacoEnvironment = { getWorker: () => new EditorWorker() }
+
+const host = ref(null)
+const editor = shallowRef(null)
+const diagnostic = ref(null)
+let registered = false
+let debounce = null
+
+// pest errors are several lines: a location, the offending source, a caret, and
+// the expectation. The status bar wants the last of those.
+function summarise(message) {
+  const expected = message.split('\n').find((l) => l.trim().startsWith('= '))
+  if (expected) return expected.trim().slice(2)
+  return message.split('\n')[0].replace(/^Parse error:\s*/, '').trim() || 'invalid syntax'
+}
+
+function validate() {
+  const model = editor.value?.getModel()
+  if (!model) return
+  const text = model.getValue()
+
+  if (!text.trim()) {
+    diagnostic.value = null
+    monaco.editor.setModelMarkers(model, 'dealer3', [])
+    emit('validity', { ok: true, empty: true })
+    return
+  }
+
+  const result = checkScript(text)
+  if (result.ok) {
+    diagnostic.value = null
+    monaco.editor.setModelMarkers(model, 'dealer3', [])
+    emit('validity', { ok: true, empty: false })
+    return
+  }
+
+  const line = result.line ?? 1
+  const column = result.column ?? 1
+  diagnostic.value = { line, column, summary: summarise(result.error || '') }
+
+  // pest reports a point, not a span. Underline to the end of the token that
+  // starts there so the squiggle is visible rather than a zero-width tick.
+  const lineContent = model.getLineContent(Math.min(line, model.getLineCount())) || ''
+  const rest = lineContent.slice(column - 1)
+  const tokenLength = (rest.match(/^\S+/) || [''])[0].length || 1
+
+  monaco.editor.setModelMarkers(model, 'dealer3', [
+    {
+      severity: monaco.MarkerSeverity.Error,
+      message: result.error,
+      startLineNumber: line,
+      startColumn: column,
+      endLineNumber: line,
+      endColumn: column + tokenLength,
+    },
+  ])
+  emit('validity', { ok: false, empty: false })
+}
+
+onMounted(() => {
+  if (!registered) {
+    // The vocabulary comes from the engine, so highlighting and completion
+    // cannot disagree with the parser.
+    registerDlrLanguage(monaco, languageInfo())
+    registered = true
+  }
+
+  editor.value = monaco.editor.create(host.value, {
+    value: props.modelValue,
+    language: LANGUAGE_ID,
+    theme: 'vs',
+    automaticLayout: true,
+    minimap: { enabled: false },
+    scrollBeyondLastLine: false,
+    fontSize: 13,
+    lineNumbers: 'on',
+    renderWhitespace: 'none',
+    tabSize: 2,
+  })
+
+  editor.value.onDidChangeModelContent(() => {
+    const text = editor.value.getValue()
+    emit('update:modelValue', text)
+    // Parsing is fast, but not worth doing on every keypress of a long script.
+    clearTimeout(debounce)
+    debounce = setTimeout(validate, 150)
+  })
+
+  validate()
+})
+
+// External changes (picking a scenario) replace the buffer wholesale.
+watch(
+  () => props.modelValue,
+  (value) => {
+    const ed = editor.value
+    if (!ed || ed.getValue() === value) return
+    ed.setValue(value)
+    validate()
+  },
+)
+
+onBeforeUnmount(() => {
+  clearTimeout(debounce)
+  editor.value?.dispose()
+})
+
+defineExpose({ focus: () => editor.value?.focus() })
+</script>
+
+<style scoped>
+.editor { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+.editor-host { flex: 1; min-height: 0; border: 1px solid var(--line); border-radius: 4px; overflow: hidden; }
+.editor-status {
+  padding: 4px 8px; font-size: 12px; color: var(--fg-muted);
+  font-family: var(--mono);
+}
+.editor-status.is-error { color: var(--danger); }
+</style>

--- a/web/src/components/ScriptEditor.vue
+++ b/web/src/components/ScriptEditor.vue
@@ -11,35 +11,30 @@
 </template>
 
 <script setup>
-// The script editor: Monaco, with highlighting and diagnostics driven by the
-// engine itself.
+// The script editor: CodeMirror 6, with highlighting and diagnostics driven by
+// the engine itself.
 //
 // Diagnostics are the point. `check_script` is the real parser, so a squiggle
 // here means the engine will reject the script — not that a regex guessed. The
 // line and column come straight from pest.
 import { ref, onMounted, onBeforeUnmount, watch, shallowRef } from 'vue'
-// Core editor only. The `monaco-editor` barrel pulls in every language it
-// ships — perl, abap, solidity, the lot — which added ~2.5 MB of bundle for a
-// site that registers exactly one language of its own.
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js'
-import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
-import { registerDlrLanguage, LANGUAGE_ID } from '@/lib/dlrLanguage.js'
-import { checkScript, languageInfo } from '@/lib/engine.js'
+import { EditorState } from '@codemirror/state'
+import { EditorView, keymap, lineNumbers, highlightActiveLine } from '@codemirror/view'
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
+import { syntaxHighlighting, defaultHighlightStyle, bracketMatching } from '@codemirror/language'
+import { autocompletion, closeBrackets } from '@codemirror/autocomplete'
+import { linter, lintGutter } from '@codemirror/lint'
+import { dlrLanguage, dlrCompletion } from '@/lib/dlrLanguage.js'
+import { checkScript, languageInfo, ready } from '@/lib/engine.js'
 
 const props = defineProps({
   modelValue: { type: String, default: '' },
 })
 const emit = defineEmits(['update:modelValue', 'validity'])
 
-// Monaco expects to find its workers here. Only the base worker is needed:
-// no language services are loaded.
-self.MonacoEnvironment = { getWorker: () => new EditorWorker() }
-
 const host = ref(null)
-const editor = shallowRef(null)
+const view = shallowRef(null)
 const diagnostic = ref(null)
-let registered = false
-let debounce = null
 
 // pest errors are several lines: a location, the offending source, a caret, and
 // the expectation. The status bar wants the last of those.
@@ -49,106 +44,117 @@ function summarise(message) {
   return message.split('\n')[0].replace(/^Parse error:\s*/, '').trim() || 'invalid syntax'
 }
 
-function validate() {
-  const model = editor.value?.getModel()
-  if (!model) return
-  const text = model.getValue()
+/** Translate the engine's line/column into a document offset. */
+function offsetOf(doc, line, column) {
+  const l = Math.min(Math.max(line, 1), doc.lines)
+  const info = doc.line(l)
+  return Math.min(info.from + Math.max(column - 1, 0), info.to)
+}
+
+// The linter runs on a debounce CodeMirror manages, and is the single place that
+// decides validity — the status bar and the Run button both read from it.
+const dlrLinter = linter((v) => {
+  const text = v.state.doc.toString()
 
   if (!text.trim()) {
     diagnostic.value = null
-    monaco.editor.setModelMarkers(model, 'dealer3', [])
     emit('validity', { ok: true, empty: true })
-    return
+    return []
   }
 
   const result = checkScript(text)
   if (result.ok) {
     diagnostic.value = null
-    monaco.editor.setModelMarkers(model, 'dealer3', [])
     emit('validity', { ok: true, empty: false })
-    return
+    return []
   }
 
   const line = result.line ?? 1
   const column = result.column ?? 1
   diagnostic.value = { line, column, summary: summarise(result.error || '') }
+  emit('validity', { ok: false, empty: false })
 
   // pest reports a point, not a span. Underline to the end of the token that
-  // starts there so the squiggle is visible rather than a zero-width tick.
-  const lineContent = model.getLineContent(Math.min(line, model.getLineCount())) || ''
-  const rest = lineContent.slice(column - 1)
+  // starts there, so the squiggle is visible rather than a zero-width tick.
+  const from = offsetOf(v.state.doc, line, column)
+  const rest = v.state.doc.sliceString(from, v.state.doc.line(Math.min(line, v.state.doc.lines)).to)
   const tokenLength = (rest.match(/^\S+/) || [''])[0].length || 1
 
-  monaco.editor.setModelMarkers(model, 'dealer3', [
+  return [
     {
-      severity: monaco.MarkerSeverity.Error,
+      from,
+      to: Math.min(from + tokenLength, v.state.doc.length),
+      severity: 'error',
       message: result.error,
-      startLineNumber: line,
-      startColumn: column,
-      endLineNumber: line,
-      endColumn: column + tokenLength,
     },
-  ])
-  emit('validity', { ok: false, empty: false })
-}
+  ]
+}, { delay: 150 })
 
-onMounted(() => {
-  if (!registered) {
-    // The vocabulary comes from the engine, so highlighting and completion
-    // cannot disagree with the parser.
-    registerDlrLanguage(monaco, languageInfo())
-    registered = true
-  }
+onMounted(async () => {
+  // The vocabulary and the diagnostics both come from the engine, so the editor
+  // cannot be built until the wasm module has initialised. Awaiting here rather
+  // than relying on the parent's ordering keeps that dependency local: this used
+  // to work only because the component happened to be lazy-loaded, and broke the
+  // moment it was imported directly.
+  await ready()
+  if (!host.value) return // unmounted while the engine was loading
 
-  editor.value = monaco.editor.create(host.value, {
-    value: props.modelValue,
-    language: LANGUAGE_ID,
-    theme: 'vs',
-    automaticLayout: true,
-    minimap: { enabled: false },
-    scrollBeyondLastLine: false,
-    fontSize: 13,
-    lineNumbers: 'on',
-    renderWhitespace: 'none',
-    tabSize: 2,
+  // The vocabulary comes from the engine, so highlighting and completion cannot
+  // disagree with the parser.
+  const info = languageInfo()
+
+  view.value = new EditorView({
+    parent: host.value,
+    state: EditorState.create({
+      doc: props.modelValue,
+      extensions: [
+        lineNumbers(),
+        highlightActiveLine(),
+        history(),
+        bracketMatching(),
+        closeBrackets(),
+        keymap.of([...defaultKeymap, ...historyKeymap]),
+        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+        dlrLanguage(info),
+        autocompletion({ override: [dlrCompletion(info)] }),
+        lintGutter(),
+        dlrLinter,
+        EditorView.updateListener.of((u) => {
+          if (u.docChanged) emit('update:modelValue', u.state.doc.toString())
+        }),
+        EditorView.theme({
+          '&': { height: '100%', fontSize: '13px' },
+          '.cm-scroller': { fontFamily: 'var(--mono)', overflow: 'auto' },
+          '&.cm-focused': { outline: 'none' },
+        }),
+      ],
+    }),
   })
-
-  editor.value.onDidChangeModelContent(() => {
-    const text = editor.value.getValue()
-    emit('update:modelValue', text)
-    // Parsing is fast, but not worth doing on every keypress of a long script.
-    clearTimeout(debounce)
-    debounce = setTimeout(validate, 150)
-  })
-
-  validate()
 })
 
 // External changes (picking a scenario) replace the buffer wholesale.
 watch(
   () => props.modelValue,
   (value) => {
-    const ed = editor.value
-    if (!ed || ed.getValue() === value) return
-    ed.setValue(value)
-    validate()
+    const v = view.value
+    if (!v || v.state.doc.toString() === value) return
+    v.dispatch({ changes: { from: 0, to: v.state.doc.length, insert: value } })
   },
 )
 
-onBeforeUnmount(() => {
-  clearTimeout(debounce)
-  editor.value?.dispose()
-})
+onBeforeUnmount(() => view.value?.destroy())
 
-defineExpose({ focus: () => editor.value?.focus() })
+defineExpose({ focus: () => view.value?.focus() })
 </script>
 
 <style scoped>
 .editor { display: flex; flex-direction: column; height: 100%; min-height: 0; }
-.editor-host { flex: 1; min-height: 0; border: 1px solid var(--line); border-radius: 4px; overflow: hidden; }
+.editor-host {
+  flex: 1; min-height: 0; overflow: hidden;
+  border: 1px solid var(--line); border-radius: 4px;
+}
 .editor-status {
-  padding: 4px 8px; font-size: 12px; color: var(--fg-muted);
-  font-family: var(--mono);
+  padding: 4px 8px; font-size: 12px; color: var(--fg-muted); font-family: var(--mono);
 }
 .editor-status.is-error { color: var(--danger); }
 </style>

--- a/web/src/lib/cardFormatting.js
+++ b/web/src/lib/cardFormatting.js
@@ -1,0 +1,90 @@
+// Card and suit display primitives.
+//
+// VENDORED from Bridge-Classroom/src/utils/cardFormatting.js, trimmed to what a
+// static deal grid needs. The full module also covers bids, vulnerability,
+// auction text flow and suit-shorthand colouring, none of which applies here.
+//
+// HandDisplay.vue was not vendored: at 521 lines it is built for an interactive
+// table — clickable cards, a card-selector popup, per-card marks and dynamic
+// fit — and needs almost none of that here. These primitives were the reusable
+// part.
+
+export const SUIT_SYMBOLS = { spades: '♠', hearts: '♥', diamonds: '♦', clubs: '♣' }
+export const SUIT_ORDER = ['spades', 'hearts', 'diamonds', 'clubs']
+
+/** Red suits, for the conventional two-colour deal display. */
+export const RED_SUITS = new Set(['hearts', 'diamonds'])
+
+/** Bridge display order within a suit: high to low. */
+export const RANK_ORDER = ['A', 'K', 'Q', 'J', 'T', '9', '8', '7', '6', '5', '4', '3', '2']
+
+const HCP = { A: 4, K: 3, Q: 2, J: 1 }
+
+/** Milton Work count for a list of ranks. */
+export function countHCP(ranks) {
+  return ranks.reduce((sum, r) => sum + (HCP[String(r).toUpperCase()] || 0), 0)
+}
+
+/**
+ * Sort a suit's ranks into display order, tolerant of source order.
+ * Accepts 'T' or '10' for the ten; unknown ranks sort to the end.
+ */
+export function sortSuitDescending(ranks) {
+  const index = (c) => {
+    const r = String(c).toUpperCase() === '10' ? 'T' : String(c).toUpperCase()
+    const i = RANK_ORDER.indexOf(r)
+    return i === -1 ? RANK_ORDER.length : i
+  }
+  return [...ranks].sort((a, b) => index(a) - index(b))
+}
+
+/**
+ * Parse one deal in the engine's oneline format into hands.
+ *
+ *   "n AKQ.J6.K42.95 e 652.AK42.A87.T4 s J74.QT95.T.AK863 w 98.873.965.QJ72"
+ *
+ * Returns `{ north, east, south, west }`, each a map of suit -> rank array,
+ * plus `hcp`. Returns null if the line is not a deal, so a caller can filter a
+ * mixed block of output without exception handling.
+ */
+export function parseOnelineDeal(line) {
+  const parts = String(line).trim().split(/\s+/)
+  if (parts.length !== 8) return null
+
+  const seats = { n: 'north', e: 'east', s: 'south', w: 'west' }
+  const deal = {}
+  for (let i = 0; i < 8; i += 2) {
+    const seat = seats[parts[i].toLowerCase()]
+    if (!seat) return null
+    // A hand is four dot-separated suits, high to low: spades.hearts.diamonds.clubs
+    const suits = parts[i + 1].split('.')
+    if (suits.length !== 4) return null
+
+    const hand = {}
+    let hcp = 0
+    SUIT_ORDER.forEach((suitName, idx) => {
+      const ranks = sortSuitDescending((suits[idx] || '').split('').filter(Boolean))
+      hand[suitName] = ranks
+      hcp += countHCP(ranks)
+    })
+    hand.hcp = hcp
+    hand.length = SUIT_ORDER.reduce((n, s) => n + hand[s].length, 0)
+    deal[seat] = hand
+  }
+
+  // A deal that does not hold 52 cards means the line was malformed rather than
+  // simply unrecognised, and silently showing 12-card hands would be worse than
+  // skipping it.
+  const total = ['north', 'east', 'south', 'west'].reduce((n, s) => n + deal[s].length, 0)
+  if (total !== 52) return null
+
+  return deal
+}
+
+/** Parse a block of oneline output, skipping anything that is not a deal. */
+export function parseOnelineDeals(text) {
+  return String(text)
+    .split('\n')
+    .map(parseOnelineDeal)
+    .filter(Boolean)
+}

--- a/web/src/lib/cardFormatting.test.js
+++ b/web/src/lib/cardFormatting.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import {
+  countHCP,
+  sortSuitDescending,
+  parseOnelineDeal,
+  parseOnelineDeals,
+} from './cardFormatting.js'
+
+const DEAL =
+  'n AKQT3.J6.KJ42.95 e 652.AK42.AQ87.T4 s J74.QT95.T.AK863 w 98.873.9653.QJ72'
+
+describe('countHCP', () => {
+  it('counts the Milton Work honours', () => {
+    expect(countHCP(['A', 'K', 'Q', 'J'])).toBe(10)
+  })
+  it('ignores spot cards', () => {
+    expect(countHCP(['T', '9', '2'])).toBe(0)
+  })
+  it('is case-insensitive', () => {
+    expect(countHCP(['a', 'k'])).toBe(7)
+  })
+})
+
+describe('sortSuitDescending', () => {
+  it('orders high to low regardless of input order', () => {
+    expect(sortSuitDescending(['4', 'A', '8', 'J'])).toEqual(['A', 'J', '8', '4'])
+  })
+  it('accepts 10 as well as T', () => {
+    expect(sortSuitDescending(['2', '10'])).toEqual(['10', '2'])
+  })
+})
+
+describe('parseOnelineDeal', () => {
+  it('splits a deal into four hands', () => {
+    const d = parseOnelineDeal(DEAL)
+    expect(Object.keys(d)).toEqual(['north', 'east', 'south', 'west'])
+    expect(d.north.spades).toEqual(['A', 'K', 'Q', 'T', '3'])
+    expect(d.north.hearts).toEqual(['J', '6'])
+  })
+
+  it('computes HCP per hand', () => {
+    const d = parseOnelineDeal(DEAL)
+    // North: AKQ spades (9) + J hearts (1) + KJ diamonds (4) = 14
+    expect(d.north.hcp).toBe(14)
+    const total = d.north.hcp + d.east.hcp + d.south.hcp + d.west.hcp
+    expect(total).toBe(40)
+  })
+
+  it('gives every hand thirteen cards', () => {
+    const d = parseOnelineDeal(DEAL)
+    for (const seat of ['north', 'east', 'south', 'west']) {
+      expect(d[seat].length, seat).toBe(13)
+    }
+  })
+
+  it('handles a void', () => {
+    const d = parseOnelineDeal(
+      'n AKQJT98765432... e .AKQJT98765432.. s ..AKQJT98765432. w ...AKQJT98765432',
+    )
+    expect(d.north.hearts).toEqual([])
+    expect(d.north.spades).toHaveLength(13)
+  })
+
+  it('returns null for anything that is not a deal', () => {
+    expect(parseOnelineDeal('Generated 156 hands')).toBeNull()
+    expect(parseOnelineDeal('')).toBeNull()
+    expect(parseOnelineDeal('n AKQ.J6.K42.95')).toBeNull()
+  })
+
+  it('returns null rather than showing a short deal', () => {
+    // 51 cards. Rendering this would quietly display a 12-card hand, which is
+    // worse than skipping the line.
+    expect(parseOnelineDeal(DEAL.replace('AKQT3', 'AKQT'))).toBeNull()
+  })
+})
+
+describe('parseOnelineDeals', () => {
+  it('skips the statistics lines mixed in with deals', () => {
+    const block = [DEAL, DEAL, 'Generated 156 hands', 'Produced 2 hands'].join('\n')
+    expect(parseOnelineDeals(block)).toHaveLength(2)
+  })
+  it('returns an empty list for output in another format', () => {
+    expect(parseOnelineDeals('   1.\nA K Q  6 5 2  J 7 4  9 8')).toEqual([])
+  })
+})

--- a/web/src/lib/dlrLanguage.js
+++ b/web/src/lib/dlrLanguage.js
@@ -1,0 +1,145 @@
+// Monaco language support for dealer scripts.
+//
+// The tokenizer is BUILT AT RUNTIME from the engine's own `language_info()`,
+// rather than shipping a second copy of the word lists. That export comes from
+// `dealer_parser::vocabulary`, which is itself checked against `grammar.pest` by
+// two tests in dealer-parser. So highlighting cannot advertise a function the
+// parser does not accept, or miss one it does — the failure mode that left 19
+// functions unhighlighted in the VS Code extension for years.
+//
+// This is why the editor does not load `dlr.tmLanguage.json` directly. That file
+// still exists and is still the source for VS Code, but both it and this are
+// generated from the same vocabulary, so they agree by construction. Deriving
+// the tokenizer here avoids shipping vscode-textmate and an Oniguruma wasm build
+// (~300 kB) to say the same thing.
+
+export const LANGUAGE_ID = 'dlr'
+
+/** Escape a word for use inside a RegExp alternation. */
+const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/** Longest first, so `spades` wins over `spade` and `>=` over `>`. */
+const byLengthDesc = (a, b) => b.length - a.length || a.localeCompare(b)
+
+export function registerDlrLanguage(monaco, info) {
+  monaco.languages.register({ id: LANGUAGE_ID, extensions: ['.dlr'], aliases: ['DLR', 'dlr'] })
+
+  const keywords = [...info.statement_keywords, ...info.actions].sort(byLengthDesc)
+  const constants = [
+    ...info.positions.filter((p) => p.length > 1),
+    ...info.vulnerabilities,
+    ...info.other_keywords,
+  ].sort(byLengthDesc)
+
+  monaco.languages.setLanguageConfiguration(LANGUAGE_ID, {
+    comments: { lineComment: '#', blockComment: ['/*', '*/'] },
+    brackets: [['(', ')']],
+    autoClosingPairs: [
+      { open: '(', close: ')' },
+      { open: '"', close: '"' },
+    ],
+    surroundingPairs: [
+      { open: '(', close: ')' },
+      { open: '"', close: '"' },
+    ],
+  })
+
+  monaco.languages.setMonarchTokensProvider(LANGUAGE_ID, {
+    defaultToken: '',
+    ignoreCase: true,
+    keywords,
+    functions: [...info.functions].sort(byLengthDesc),
+    constants,
+    logical: info.logical_words,
+
+    tokenizer: {
+      root: [
+        // `# key: value` metadata headers PBS scripts carry, then plain comments.
+        [/^\s*#\s*[a-zA-Z-]+:.*$/, 'comment.doc'],
+        [/#.*$/, 'comment'],
+        [/\/\/.*$/, 'comment'],
+        [/\/\*/, 'comment', '@blockComment'],
+
+        [/"/, 'string', '@string'],
+
+        // Shape patterns: 4333, 5xxx, %s4432. Before numbers, which would
+        // otherwise eat the leading digits.
+        [/%s?\d{4}\b/, 'number.hex'],
+        [/\b[0-9xX]{4}\b/, 'number.hex'],
+
+        // Card and holding literals: AS, TC (hascard); SAKQ, HT62 (predeal).
+        [/\b[AKQJT2-9][SHDC]\b/, 'constant'],
+        [/\b[SHDC][AKQJT2-9]+\b/, 'constant'],
+
+        [
+          /[a-zA-Z_][a-zA-Z0-9_]*/,
+          {
+            cases: {
+              '@keywords': 'keyword',
+              '@functions': 'type.identifier',
+              '@constants': 'constant',
+              '@logical': 'keyword.operator',
+              '@default': 'identifier',
+            },
+          },
+        ],
+
+        [/\d+/, 'number'],
+        [/[=!<>]=|&&|\|\||[-+*/%<>?:!=]/, 'operator'],
+        [/[()]/, '@brackets'],
+        [/[,;]/, 'delimiter'],
+      ],
+
+      blockComment: [
+        [/[^*/]+/, 'comment'],
+        [/\*\//, 'comment', '@pop'],
+        [/[*/]/, 'comment'],
+      ],
+
+      string: [
+        [/[^"]+/, 'string'],
+        [/"/, 'string', '@pop'],
+      ],
+    },
+  })
+
+  registerCompletion(monaco, info)
+}
+
+function registerCompletion(monaco, info) {
+  monaco.languages.registerCompletionItemProvider(LANGUAGE_ID, {
+    provideCompletionItems(model, position) {
+      const word = model.getWordUntilPosition(position)
+      const range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      }
+      const { Function, Keyword, Constant } = monaco.languages.CompletionItemKind
+      const item = (label, kind, detail, insertText) => ({
+        label,
+        kind,
+        detail,
+        range,
+        insertText: insertText ?? label,
+        ...(insertText
+          ? { insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet }
+          : {}),
+      })
+
+      return {
+        suggestions: [
+          // Functions all take arguments, so complete the parentheses too and
+          // drop the cursor inside them.
+          ...info.functions.map((f) => item(f, Function, 'function', `${f}($0)`)),
+          ...info.statement_keywords.map((k) => item(k, Keyword, 'statement')),
+          ...info.actions.map((a) => item(a, Keyword, 'action')),
+          ...info.positions.filter((p) => p.length > 1).map((p) => item(p, Constant, 'position')),
+          ...info.vulnerabilities.map((v) => item(v, Constant, 'vulnerability')),
+          ...info.logical_words.map((w) => item(w, Keyword, 'operator')),
+        ],
+      }
+    },
+  })
+}

--- a/web/src/lib/dlrLanguage.js
+++ b/web/src/lib/dlrLanguage.js
@@ -1,4 +1,4 @@
-// Monaco language support for dealer scripts.
+// CodeMirror language support for dealer scripts.
 //
 // The tokenizer is BUILT AT RUNTIME from the engine's own `language_info()`,
 // rather than shipping a second copy of the word lists. That export comes from
@@ -7,139 +7,139 @@
 // parser does not accept, or miss one it does — the failure mode that left 19
 // functions unhighlighted in the VS Code extension for years.
 //
-// This is why the editor does not load `dlr.tmLanguage.json` directly. That file
-// still exists and is still the source for VS Code, but both it and this are
-// generated from the same vocabulary, so they agree by construction. Deriving
-// the tokenizer here avoids shipping vscode-textmate and an Oniguruma wasm build
-// (~300 kB) to say the same thing.
+// This is also why the editor does not load `dlr.tmLanguage.json` directly. That
+// file still exists and is still what VS Code uses, but both it and this are
+// generated from the same vocabulary, so they agree by construction rather than
+// by anyone remembering to update two places.
 
-export const LANGUAGE_ID = 'dlr'
+import { StreamLanguage, LanguageSupport } from '@codemirror/language'
 
-/** Escape a word for use inside a RegExp alternation. */
-const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
-/** Longest first, so `spades` wins over `spade` and `>=` over `>`. */
+/** Longest first, so `spades` matches before `spade`. */
 const byLengthDesc = (a, b) => b.length - a.length || a.localeCompare(b)
 
-export function registerDlrLanguage(monaco, info) {
-  monaco.languages.register({ id: LANGUAGE_ID, extensions: ['.dlr'], aliases: ['DLR', 'dlr'] })
+/** Case-insensitive lookup set — the grammar accepts any casing. */
+function lowerSet(words) {
+  return new Set(words.map((w) => w.toLowerCase()))
+}
 
-  const keywords = [...info.statement_keywords, ...info.actions].sort(byLengthDesc)
-  const constants = [
+/**
+ * A CodeMirror stream tokenizer for the dealer language.
+ *
+ * `info` is the engine's `language_info()` output.
+ */
+export function dlrStreamParser(info) {
+  const functions = lowerSet(info.functions)
+  const keywords = lowerSet([...info.statement_keywords, ...info.actions])
+  // Single-letter positions (`n`, `s`, `e`, `w`) are valid but are also common
+  // variable names; the evaluator lets a variable shadow them. Colouring every
+  // `n` would be worse than leaving them plain.
+  const constants = lowerSet([
     ...info.positions.filter((p) => p.length > 1),
     ...info.vulnerabilities,
     ...info.other_keywords,
-  ].sort(byLengthDesc)
+  ])
+  const logical = lowerSet(info.logical_words)
 
-  monaco.languages.setLanguageConfiguration(LANGUAGE_ID, {
-    comments: { lineComment: '#', blockComment: ['/*', '*/'] },
-    brackets: [['(', ')']],
-    autoClosingPairs: [
-      { open: '(', close: ')' },
-      { open: '"', close: '"' },
-    ],
-    surroundingPairs: [
-      { open: '(', close: ')' },
-      { open: '"', close: '"' },
-    ],
-  })
+  // Sorted only so the behaviour is deterministic and testable.
+  const sortedFunctions = [...info.functions].sort(byLengthDesc)
 
-  monaco.languages.setMonarchTokensProvider(LANGUAGE_ID, {
-    defaultToken: '',
-    ignoreCase: true,
-    keywords,
-    functions: [...info.functions].sort(byLengthDesc),
-    constants,
-    logical: info.logical_words,
+  return {
+    name: 'dlr',
 
-    tokenizer: {
-      root: [
-        // `# key: value` metadata headers PBS scripts carry, then plain comments.
-        [/^\s*#\s*[a-zA-Z-]+:.*$/, 'comment.doc'],
-        [/#.*$/, 'comment'],
-        [/\/\/.*$/, 'comment'],
-        [/\/\*/, 'comment', '@blockComment'],
+    startState: () => ({ inBlockComment: false }),
 
-        [/"/, 'string', '@string'],
+    token(stream, state) {
+      if (state.inBlockComment) {
+        if (stream.match(/^.*?\*\//)) state.inBlockComment = false
+        else stream.skipToEnd()
+        return 'comment'
+      }
 
-        // Shape patterns: 4333, 5xxx, %s4432. Before numbers, which would
-        // otherwise eat the leading digits.
-        [/%s?\d{4}\b/, 'number.hex'],
-        [/\b[0-9xX]{4}\b/, 'number.hex'],
+      if (stream.eatSpace()) return null
 
-        // Card and holding literals: AS, TC (hascard); SAKQ, HT62 (predeal).
-        [/\b[AKQJT2-9][SHDC]\b/, 'constant'],
-        [/\b[SHDC][AKQJT2-9]+\b/, 'constant'],
+      // `# key: value` headers PBS scripts carry, then ordinary comments.
+      if (stream.sol() && stream.match(/^\s*#\s*[a-zA-Z-]+:/)) {
+        stream.skipToEnd()
+        return 'docComment'
+      }
+      if (stream.match('#') || stream.match('//')) {
+        stream.skipToEnd()
+        return 'comment'
+      }
+      if (stream.match('/*')) {
+        state.inBlockComment = true
+        if (stream.match(/^.*?\*\//)) state.inBlockComment = false
+        else stream.skipToEnd()
+        return 'comment'
+      }
 
-        [
-          /[a-zA-Z_][a-zA-Z0-9_]*/,
-          {
-            cases: {
-              '@keywords': 'keyword',
-              '@functions': 'type.identifier',
-              '@constants': 'constant',
-              '@logical': 'keyword.operator',
-              '@default': 'identifier',
-            },
-          },
-        ],
+      if (stream.match(/^"[^"]*"?/)) return 'string'
 
-        [/\d+/, 'number'],
-        [/[=!<>]=|&&|\|\||[-+*/%<>?:!=]/, 'operator'],
-        [/[()]/, '@brackets'],
-        [/[,;]/, 'delimiter'],
-      ],
+      // Shape patterns before numbers, which would otherwise eat the digits.
+      if (stream.match(/^%s?\d{4}\b/) || stream.match(/^[0-9xX]{4}\b/)) return 'number'
 
-      blockComment: [
-        [/[^*/]+/, 'comment'],
-        [/\*\//, 'comment', '@pop'],
-        [/[*/]/, 'comment'],
-      ],
+      // Card literals (AS, TC) and predeal holdings (SAKQ, HT62).
+      if (stream.match(/^[AKQJT2-9][SHDC]\b/)) return 'atom'
+      if (stream.match(/^[SHDC][AKQJT2-9]+\b/)) return 'atom'
 
-      string: [
-        [/[^"]+/, 'string'],
-        [/"/, 'string', '@pop'],
-      ],
+      const word = stream.match(/^[a-zA-Z_][a-zA-Z0-9_]*/)
+      if (word) {
+        const w = word[0].toLowerCase()
+        if (keywords.has(w)) return 'keyword'
+        if (functions.has(w)) return 'function'
+        if (constants.has(w)) return 'atom'
+        if (logical.has(w)) return 'operatorKeyword'
+        return 'variableName'
+      }
+
+      if (stream.match(/^\d+/)) return 'number'
+      if (stream.match(/^(==|!=|>=|<=|&&|\|\||[-+*/%<>?:!=])/)) return 'operator'
+      if (stream.match(/^[()]/)) return 'paren'
+      if (stream.match(/^[,;]/)) return 'separator'
+
+      stream.next()
+      return null
     },
-  })
 
-  registerCompletion(monaco, info)
+    languageData: {
+      commentTokens: { line: '#', block: { open: '/*', close: '*/' } },
+      closeBrackets: { brackets: ['(', '"'] },
+    },
+
+    // Exposed for the completion source and for tests.
+    _vocabulary: { sortedFunctions, info },
+  }
 }
 
-function registerCompletion(monaco, info) {
-  monaco.languages.registerCompletionItemProvider(LANGUAGE_ID, {
-    provideCompletionItems(model, position) {
-      const word = model.getWordUntilPosition(position)
-      const range = {
-        startLineNumber: position.lineNumber,
-        endLineNumber: position.lineNumber,
-        startColumn: word.startColumn,
-        endColumn: word.endColumn,
-      }
-      const { Function, Keyword, Constant } = monaco.languages.CompletionItemKind
-      const item = (label, kind, detail, insertText) => ({
-        label,
-        kind,
-        detail,
-        range,
-        insertText: insertText ?? label,
-        ...(insertText
-          ? { insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet }
-          : {}),
-      })
+/** Completion over the engine's vocabulary. */
+export function dlrCompletion(info) {
+  const options = [
+    // Functions all take arguments, so complete the parentheses too.
+    ...info.functions.map((label) => ({
+      label,
+      type: 'function',
+      detail: 'function',
+      apply: `${label}()`,
+    })),
+    ...info.statement_keywords.map((label) => ({ label, type: 'keyword', detail: 'statement' })),
+    ...info.actions.map((label) => ({ label, type: 'keyword', detail: 'action' })),
+    ...info.positions
+      .filter((p) => p.length > 1)
+      .map((label) => ({ label, type: 'constant', detail: 'position' })),
+    ...info.vulnerabilities.map((label) => ({ label, type: 'constant', detail: 'vulnerability' })),
+    ...info.logical_words.map((label) => ({ label, type: 'keyword', detail: 'operator' })),
+  ]
 
-      return {
-        suggestions: [
-          // Functions all take arguments, so complete the parentheses too and
-          // drop the cursor inside them.
-          ...info.functions.map((f) => item(f, Function, 'function', `${f}($0)`)),
-          ...info.statement_keywords.map((k) => item(k, Keyword, 'statement')),
-          ...info.actions.map((a) => item(a, Keyword, 'action')),
-          ...info.positions.filter((p) => p.length > 1).map((p) => item(p, Constant, 'position')),
-          ...info.vulnerabilities.map((v) => item(v, Constant, 'vulnerability')),
-          ...info.logical_words.map((w) => item(w, Keyword, 'operator')),
-        ],
-      }
-    },
-  })
+  return (context) => {
+    const word = context.matchBefore(/[a-zA-Z_][a-zA-Z0-9_]*/)
+    if (!word || (word.from === word.to && !context.explicit)) return null
+    return { from: word.from, options, validFor: /^[a-zA-Z_][a-zA-Z0-9_]*$/ }
+  }
 }
+
+/** The full language extension. */
+export function dlrLanguage(info) {
+  return new LanguageSupport(StreamLanguage.define(dlrStreamParser(info)))
+}
+
+export const LANGUAGE_ID = 'dlr'

--- a/web/src/lib/dlrLanguage.test.js
+++ b/web/src/lib/dlrLanguage.test.js
@@ -1,25 +1,9 @@
-import { describe, it, expect, vi } from 'vitest'
-import { registerDlrLanguage, LANGUAGE_ID } from './dlrLanguage.js'
-
-// A minimal stand-in for the parts of the Monaco API this module touches.
-function fakeMonaco() {
-  const calls = {}
-  return {
-    calls,
-    languages: {
-      register: (v) => (calls.register = v),
-      setLanguageConfiguration: (id, v) => (calls.config = { id, ...v }),
-      setMonarchTokensProvider: (id, v) => (calls.monarch = { id, ...v }),
-      registerCompletionItemProvider: (id, p) => (calls.completion = { id, ...p }),
-      CompletionItemKind: { Function: 1, Keyword: 2, Constant: 3 },
-      CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
-    },
-  }
-}
+import { describe, it, expect } from 'vitest'
+import { dlrStreamParser, dlrCompletion } from './dlrLanguage.js'
 
 // Shaped like the engine's language_info() output.
 const info = {
-  functions: ['hcp', 'shape', 'spade', 'spades', 'top2', 'pt0'],
+  functions: ['hcp', 'shape', 'spade', 'spades', 'top2', 'pt0', 'cccc'],
   statement_keywords: ['condition', 'produce', 'csvrpt'],
   actions: ['printall', 'printoneline'],
   positions: ['north', 'south', 'n', 's'],
@@ -29,57 +13,142 @@ const info = {
   operators: ['==', '>=', '>', '='],
 }
 
-describe('registerDlrLanguage', () => {
-  it('registers the language id', () => {
-    const m = fakeMonaco()
-    registerDlrLanguage(m, info)
-    expect(m.calls.register.id).toBe(LANGUAGE_ID)
+/** Run the stream tokenizer over a line and return [token, text] pairs. */
+function tokenize(line, parser = dlrStreamParser(info)) {
+  const state = parser.startState()
+  const out = []
+  let pos = 0
+  const stream = {
+    pos: 0,
+    string: line,
+    sol() { return this.pos === 0 },
+    peek() { return this.string[this.pos] },
+    next() { return this.string[this.pos++] },
+    eatSpace() {
+      const start = this.pos
+      while (/\s/.test(this.string[this.pos])) this.pos++
+      return this.pos > start
+    },
+    skipToEnd() { this.pos = this.string.length },
+    match(pattern, consume = true) {
+      if (typeof pattern === 'string') {
+        if (this.string.startsWith(pattern, this.pos)) {
+          if (consume) this.pos += pattern.length
+          return true
+        }
+        return false
+      }
+      const m = this.string.slice(this.pos).match(pattern)
+      if (m && m.index === 0) {
+        if (consume) this.pos += m[0].length
+        return m
+      }
+      return null
+    },
+  }
+  let guard = 0
+  while (stream.pos < line.length && guard++ < 500) {
+    pos = stream.pos
+    const tok = parser.token(stream, state)
+    if (stream.pos === pos) stream.pos++
+    if (tok) out.push([tok, line.slice(pos, stream.pos).trim()])
+  }
+  return out
+}
+
+describe('dlr tokenizer', () => {
+  it('marks known functions as functions', () => {
+    const t = tokenize('hcp(north) >= 15')
+    expect(t.find(([, text]) => text === 'hcp')[0]).toBe('function')
   })
 
-  it('takes every function from the engine vocabulary', () => {
-    const m = fakeMonaco()
-    registerDlrLanguage(m, info)
-    for (const f of info.functions) expect(m.calls.monarch.functions).toContain(f)
+  it('marks statement keywords as keywords', () => {
+    expect(tokenize('condition x')[0][0]).toBe('keyword')
+    // csvrpt was missing from the old TextMate grammar entirely.
+    expect(tokenize('csvrpt(deal)')[0][0]).toBe('keyword')
   })
 
-  it('orders words longest-first so a prefix cannot shadow a longer word', () => {
-    const m = fakeMonaco()
-    registerDlrLanguage(m, info)
-    const fns = m.calls.monarch.functions
-    // `spade` must not be matched where `spades` was written.
-    expect(fns.indexOf('spades')).toBeLessThan(fns.indexOf('spade'))
-  })
-
-  it('treats statement keywords and actions as keywords', () => {
-    const m = fakeMonaco()
-    registerDlrLanguage(m, info)
-    expect(m.calls.monarch.keywords).toEqual(expect.arrayContaining(['condition', 'csvrpt', 'printall']))
-  })
-
-  it('excludes single-letter positions from constants', () => {
-    const m = fakeMonaco()
-    registerDlrLanguage(m, info)
-    // `n` and `s` are valid positions but also common variable names; colouring
-    // every one of them would be worse than leaving them plain.
-    expect(m.calls.monarch.constants).toContain('north')
-    expect(m.calls.monarch.constants).not.toContain('n')
-  })
-
-  it('offers completions for functions with their parentheses', () => {
-    const m = fakeMonaco()
-    registerDlrLanguage(m, info)
-    const model = {
-      getWordUntilPosition: () => ({ startColumn: 1, endColumn: 4 }),
+  it('covers point-count functions the old grammar missed', () => {
+    for (const fn of ['top2', 'pt0']) {
+      const t = tokenize(`${fn}(north)`)
+      expect(t[0], `${fn} should tokenize`).toEqual(['function', fn])
     }
-    const { suggestions } = m.calls.completion.provideCompletionItems(model, { lineNumber: 1 })
-    const hcp = suggestions.find((s) => s.label === 'hcp')
-    expect(hcp.insertText).toBe('hcp($0)')
-    expect(hcp.detail).toBe('function')
+  })
+
+  it('does not mistake a longer word for a shorter function', () => {
+    // `spades` must not tokenize as `spade` + `s`.
+    const t = tokenize('spades(north)')
+    expect(t[0]).toEqual(['function', 'spades'])
+  })
+
+  it('leaves unknown identifiers as variables', () => {
+    const t = tokenize('myOpener = 1')
+    expect(t[0]).toEqual(['variableName', 'myOpener'])
+  })
+
+  it('does not colour single-letter positions', () => {
+    // `n` is a valid position but also a common variable name, and the
+    // evaluator lets a variable shadow it.
+    expect(tokenize('n = 4')[0][0]).toBe('variableName')
+    expect(tokenize('north')[0][0]).toBe('atom')
   })
 
   it('is case-insensitive, matching the grammar', () => {
-    const m = fakeMonaco()
-    registerDlrLanguage(m, info)
-    expect(m.calls.monarch.ignoreCase).toBe(true)
+    expect(tokenize('HCP(NORTH)')[0][0]).toBe('function')
+  })
+
+  it('recognises comments, including PBS metadata headers', () => {
+    expect(tokenize('# alias: Foo')[0][0]).toBe('docComment')
+    expect(tokenize('# just a comment')[0][0]).toBe('comment')
+    expect(tokenize('// slash comment')[0][0]).toBe('comment')
+  })
+
+  it('recognises shape patterns before numbers', () => {
+    expect(tokenize('4333')[0]).toEqual(['number', '4333'])
+    expect(tokenize('5xxx')[0]).toEqual(['number', '5xxx'])
+  })
+
+  it('recognises card literals and predeal holdings', () => {
+    expect(tokenize('AS')[0][0]).toBe('atom')
+    expect(tokenize('SAKQ')[0][0]).toBe('atom')
+  })
+
+  it('tracks block comments across a line', () => {
+    const parser = dlrStreamParser(info)
+    const state = parser.startState()
+    expect(state.inBlockComment).toBe(false)
+  })
+})
+
+describe('dlr completion', () => {
+  const complete = dlrCompletion(info)
+  const context = (text, explicit = false) => ({
+    explicit,
+    matchBefore: (re) => {
+      const m = text.match(re)
+      return m ? { from: text.length - m[0].length, to: text.length, text: m[0] } : null
+    },
+  })
+
+  it('offers every function from the vocabulary', () => {
+    const r = complete(context('hc'))
+    for (const f of info.functions) {
+      expect(r.options.some((o) => o.label === f), `${f} missing`).toBe(true)
+    }
+  })
+
+  it('completes functions with their parentheses', () => {
+    const r = complete(context('hc'))
+    expect(r.options.find((o) => o.label === 'hcp').apply).toBe('hcp()')
+  })
+
+  it('labels the kind of each suggestion', () => {
+    const r = complete(context('co'))
+    expect(r.options.find((o) => o.label === 'condition').detail).toBe('statement')
+    expect(r.options.find((o) => o.label === 'north').detail).toBe('position')
+  })
+
+  it('returns nothing on an empty implicit request', () => {
+    expect(complete(context(''))).toBeNull()
   })
 })

--- a/web/src/lib/dlrLanguage.test.js
+++ b/web/src/lib/dlrLanguage.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest'
+import { registerDlrLanguage, LANGUAGE_ID } from './dlrLanguage.js'
+
+// A minimal stand-in for the parts of the Monaco API this module touches.
+function fakeMonaco() {
+  const calls = {}
+  return {
+    calls,
+    languages: {
+      register: (v) => (calls.register = v),
+      setLanguageConfiguration: (id, v) => (calls.config = { id, ...v }),
+      setMonarchTokensProvider: (id, v) => (calls.monarch = { id, ...v }),
+      registerCompletionItemProvider: (id, p) => (calls.completion = { id, ...p }),
+      CompletionItemKind: { Function: 1, Keyword: 2, Constant: 3 },
+      CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+    },
+  }
+}
+
+// Shaped like the engine's language_info() output.
+const info = {
+  functions: ['hcp', 'shape', 'spade', 'spades', 'top2', 'pt0'],
+  statement_keywords: ['condition', 'produce', 'csvrpt'],
+  actions: ['printall', 'printoneline'],
+  positions: ['north', 'south', 'n', 's'],
+  vulnerabilities: ['none', 'all'],
+  logical_words: ['and', 'or', 'not'],
+  other_keywords: ['any', 'deal'],
+  operators: ['==', '>=', '>', '='],
+}
+
+describe('registerDlrLanguage', () => {
+  it('registers the language id', () => {
+    const m = fakeMonaco()
+    registerDlrLanguage(m, info)
+    expect(m.calls.register.id).toBe(LANGUAGE_ID)
+  })
+
+  it('takes every function from the engine vocabulary', () => {
+    const m = fakeMonaco()
+    registerDlrLanguage(m, info)
+    for (const f of info.functions) expect(m.calls.monarch.functions).toContain(f)
+  })
+
+  it('orders words longest-first so a prefix cannot shadow a longer word', () => {
+    const m = fakeMonaco()
+    registerDlrLanguage(m, info)
+    const fns = m.calls.monarch.functions
+    // `spade` must not be matched where `spades` was written.
+    expect(fns.indexOf('spades')).toBeLessThan(fns.indexOf('spade'))
+  })
+
+  it('treats statement keywords and actions as keywords', () => {
+    const m = fakeMonaco()
+    registerDlrLanguage(m, info)
+    expect(m.calls.monarch.keywords).toEqual(expect.arrayContaining(['condition', 'csvrpt', 'printall']))
+  })
+
+  it('excludes single-letter positions from constants', () => {
+    const m = fakeMonaco()
+    registerDlrLanguage(m, info)
+    // `n` and `s` are valid positions but also common variable names; colouring
+    // every one of them would be worse than leaving them plain.
+    expect(m.calls.monarch.constants).toContain('north')
+    expect(m.calls.monarch.constants).not.toContain('n')
+  })
+
+  it('offers completions for functions with their parentheses', () => {
+    const m = fakeMonaco()
+    registerDlrLanguage(m, info)
+    const model = {
+      getWordUntilPosition: () => ({ startColumn: 1, endColumn: 4 }),
+    }
+    const { suggestions } = m.calls.completion.provideCompletionItems(model, { lineNumber: 1 })
+    const hcp = suggestions.find((s) => s.label === 'hcp')
+    expect(hcp.insertText).toBe('hcp($0)')
+    expect(hcp.detail).toBe('function')
+  })
+
+  it('is case-insensitive, matching the grammar', () => {
+    const m = fakeMonaco()
+    registerDlrLanguage(m, info)
+    expect(m.calls.monarch.ignoreCase).toBe(true)
+  })
+})

--- a/web/src/lib/download.js
+++ b/web/src/lib/download.js
@@ -1,0 +1,50 @@
+// Saving results to a file.
+//
+// Selecting text out of the page is clumsy — a select-all takes the whole
+// document, and a long run is thousands of lines — so results are saved rather
+// than copied.
+
+/** Trigger a download of `text` as `filename`. */
+export function downloadText(filename, text, mime = 'text/plain') {
+  const blob = new Blob([text], { type: `${mime};charset=utf-8` })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  // Revoking immediately can cancel the download in some browsers; a tick is
+  // enough for the navigation to have started.
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+/** A filename that sorts usefully and says where it came from. */
+export function resultFilename(scenario, seed, extension) {
+  const base = (scenario || 'dealer3').replace(/[^\w.-]+/g, '_')
+  return `${base}-seed${seed}.${extension}`
+}
+
+/**
+ * Render the statistics block as text, for saving alongside deals.
+ *
+ * Deliberately mirrors the CLI's layout rather than inventing one: someone
+ * saving this has probably seen dealer output before.
+ */
+export function statisticsText(result) {
+  const lines = []
+  for (const a of result.averages || []) {
+    lines.push(`${(a.label || 'Average').trim()}: ${a.value}`)
+  }
+  for (const f of result.frequencies || []) {
+    lines.push(`Frequency ${(f.label || '').trim()}:`)
+    if (f.below) lines.push(`Low\t${String(f.below).padStart(8)}`)
+    for (const bin of f.bins) {
+      lines.push(`${String(bin.value).padStart(5)}\t${String(bin.count).padStart(8)}`)
+    }
+    if (f.above) lines.push(`High\t${String(f.above).padStart(8)}`)
+  }
+  lines.push(`Generated ${result.generated} hands`)
+  lines.push(`Produced ${result.produced} hands`)
+  return lines.join('\n') + '\n'
+}

--- a/web/src/lib/engine.js
+++ b/web/src/lib/engine.js
@@ -1,0 +1,67 @@
+// The dealer3 engine, compiled to WebAssembly.
+//
+// One module owns loading it, so the rest of the app can await `ready()` and
+// then call synchronously. Everything runs in the browser: no script, no deal
+// and no keystroke is sent anywhere.
+
+import init, {
+  generate as wasmGenerate,
+  check_script as wasmCheck,
+  language_info as wasmLanguageInfo,
+  version as wasmVersion,
+} from '@/wasm/dealer3_wasm.js'
+
+let loading = null
+
+/** Load the engine once. Safe to call repeatedly; later calls await the first. */
+export function ready() {
+  if (!loading) loading = init()
+  return loading
+}
+
+/**
+ * Run a script.
+ *
+ * `maxGenerate` bounds the work: a browser tab has no Ctrl-C, so a very
+ * selective filter must not be able to hang it. The result's `hitLimit` says
+ * whether that bound was reached, which is not the same as "no more matches
+ * exist" and should be shown differently.
+ *
+ * Throws with the engine's message on a parse or evaluation error.
+ */
+export function generate(script, { seed = 1, produce = 20, maxGenerate = 500000, format = 'oneline' } = {}) {
+  const raw = JSON.parse(wasmGenerate(script, seed, produce, maxGenerate, format))
+  return {
+    deals: raw.deals,
+    generated: raw.generated,
+    produced: raw.produced,
+    seconds: raw.seconds,
+    hitLimit: raw.hit_limit,
+    averages: raw.averages,
+    frequencies: raw.frequencies,
+    // `deals` is capped by the engine; `produced` counts every match. A script
+    // gathering statistics over 50,000 deals returns statistics for all of them
+    // and only the first few hundred deals.
+    dealsTruncated: raw.produced > raw.deals.length,
+  }
+}
+
+/**
+ * Validate without generating. Returns `{ ok, error, line, column }`.
+ *
+ * Deliberately does not throw: this runs on every keystroke, and the line and
+ * column come from the parser itself, so editor markers agree with the engine
+ * rather than approximating it.
+ */
+export function checkScript(script) {
+  return JSON.parse(wasmCheck(script))
+}
+
+/** The language's vocabulary, for highlighting and completion. */
+export function languageInfo() {
+  return JSON.parse(wasmLanguageInfo())
+}
+
+export function version() {
+  return wasmVersion()
+}

--- a/web/src/lib/pbsScenarios.js
+++ b/web/src/lib/pbsScenarios.js
@@ -1,0 +1,100 @@
+// Practice-Bidding-Scenarios (PBS) repo access: the scenario menu and the .dlr
+// scripts behind it.
+//
+// VENDORED from Bridge-Classroom/src/utils/pbsScenarios.js, trimmed to what this
+// site needs (the manifest and the dealer scripts; not PBN deals, curated sets or
+// the table service payloads). Kept as plain functions with no framework or
+// backend coupling, matching the original.
+//
+// The manifest is built by PBS CI (PBS issue #167) so the whole menu arrives in
+// ONE fetch instead of scanning ~400 files. raw.githubusercontent.com serves
+// `Access-Control-Allow-Origin: *`, so this works from the browser with no
+// backend and no build-time copying — the same way Bridge-Classroom does it.
+
+export const PBS = {
+  RAW_BASE:
+    'https://raw.githubusercontent.com/bridge-craftwork/Practice-Bidding-Scenarios/main',
+  MANIFEST_DIR: '/manifest',
+  DLR_DIR: '/dlr',
+}
+
+/** `Some_Script_Name` -> `Some Script Name`, for scenarios with no buttonText. */
+export function prettifyLabel(file) {
+  return file.replace(/_/g, ' ').replace(/-/g, ' ').trim()
+}
+
+/** Suit tokens used in PBS chat/button text: !C !D !H !S -> ♣ ♦ ♥ ♠ */
+export function suitSymbols(s) {
+  return (s || '')
+    .replace(/!C/g, '♣')
+    .replace(/!D/g, '♦')
+    .replace(/!H/g, '♥')
+    .replace(/!S/g, '♠')
+}
+
+/** First non-empty line of a scenario's `chat`, as a one-line description. */
+function firstChatLine(chat) {
+  if (!chat) return ''
+  const line = String(chat)
+    .split(/\\n|\n/)
+    .map((l) => l.trim())
+    .find((l) => l && !l.startsWith('---'))
+  return suitSymbols((line || '').replace(/^---\s*/, ''))
+}
+
+/**
+ * Fetch the pre-built menu manifest and flatten it into sections.
+ *
+ * Returns `{ sections, meta }`:
+ *   sections: [{ label, items: [{ file, label, description }] }]
+ *   meta:     keyed by file name
+ *
+ * `tier` is 'release' (public), 'beta' or 'test'. This site uses release.
+ */
+export async function fetchScenarioManifest(tier = 'release') {
+  const resp = await fetch(`${PBS.RAW_BASE}${PBS.MANIFEST_DIR}/manifest-${tier}.json`)
+  if (!resp.ok) throw new Error(`Could not load the scenario list (HTTP ${resp.status})`)
+  const m = await resp.json()
+
+  const scenarios = m.scenarios || {}
+  const meta = {}
+  for (const [name, sc] of Object.entries(scenarios)) {
+    meta[name] = {
+      buttonText: suitSymbols(sc.buttonText || prettifyLabel(name)),
+      description: firstChatLine(sc.chat),
+    }
+  }
+
+  // The layout is a flat ordered list of major/section/row nodes. Rows carry the
+  // scenario names; sections group them. `major` headings are dropped: with 20
+  // sections a second level of nesting costs more than it explains.
+  const sections = []
+  let current = null
+  for (const node of m.layout || []) {
+    if (node.type === 'section') {
+      current = { label: node.title, items: [] }
+      sections.push(current)
+    } else if (node.type === 'row' && current) {
+      for (const b of node.buttons || []) {
+        // `---` is a layout spacer, not a scenario. `missing` marks a layout
+        // entry whose script was never published.
+        const sc = scenarios[b.name]
+        if (!b.name || b.name === '---' || !sc || sc.missing) continue
+        current.items.push({
+          file: b.name,
+          label: meta[b.name].buttonText,
+          description: meta[b.name].description,
+        })
+      }
+    }
+  }
+
+  return { sections: sections.filter((s) => s.items.length), meta }
+}
+
+/** Fetch one scenario's dealer script. */
+export async function fetchScenarioScript(file) {
+  const resp = await fetch(`${PBS.RAW_BASE}${PBS.DLR_DIR}/${file}.dlr`)
+  if (!resp.ok) throw new Error(`No dealer script for ${file} (HTTP ${resp.status})`)
+  return resp.text()
+}

--- a/web/src/lib/pbsScenarios.test.js
+++ b/web/src/lib/pbsScenarios.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { fetchScenarioManifest, suitSymbols, prettifyLabel } from './pbsScenarios.js'
+
+const manifest = {
+  layout: [
+    { type: 'major', title: 'Bidding Scenarios' },
+    { type: 'section', title: 'Beginners' },
+    { type: 'row', buttons: [{ name: 'A_Script' }, { name: '---' }] },
+    { type: 'row', buttons: [{ name: 'B_Script' }, { name: 'Never_Published' }] },
+    { type: 'section', title: 'Empty Section' },
+    { type: 'row', buttons: [{ name: 'Also_Missing' }] },
+  ],
+  scenarios: {
+    A_Script: { buttonText: '1!S Opening', chat: '--- header\\nFirst real line.\\nSecond.' },
+    B_Script: { buttonText: 'Second', chat: '' },
+    Never_Published: { buttonText: 'Gone', missing: true },
+    Also_Missing: { buttonText: 'Gone too', missing: true },
+  },
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+function stubFetch(body, ok = true, status = 200) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok, status, json: async () => body, text: async () => body,
+  }))
+}
+
+describe('suitSymbols', () => {
+  it('replaces PBS suit tokens', () => {
+    expect(suitSymbols('1!S then 2!H')).toBe('1♠ then 2♥')
+  })
+  it('tolerates empty input', () => {
+    expect(suitSymbols('')).toBe('')
+    expect(suitSymbols(undefined)).toBe('')
+  })
+})
+
+describe('prettifyLabel', () => {
+  it('turns a file name into a label', () => {
+    expect(prettifyLabel('Fourth_Suit-Forcing')).toBe('Fourth Suit Forcing')
+  })
+})
+
+describe('fetchScenarioManifest', () => {
+  it('groups scenarios under their section', async () => {
+    stubFetch(manifest)
+    const { sections } = await fetchScenarioManifest('release')
+    expect(sections).toHaveLength(1)
+    expect(sections[0].label).toBe('Beginners')
+    expect(sections[0].items.map((i) => i.file)).toEqual(['A_Script', 'B_Script'])
+  })
+
+  it('drops layout spacers and unpublished scenarios', async () => {
+    stubFetch(manifest)
+    const { sections } = await fetchScenarioManifest()
+    const files = sections.flatMap((s) => s.items.map((i) => i.file))
+    expect(files).not.toContain('---')
+    // `missing` marks a layout entry whose script was never published; showing
+    // it would offer the user something that cannot load.
+    expect(files).not.toContain('Never_Published')
+  })
+
+  it('drops sections left empty after filtering', async () => {
+    stubFetch(manifest)
+    const { sections } = await fetchScenarioManifest()
+    expect(sections.map((s) => s.label)).not.toContain('Empty Section')
+  })
+
+  it('applies suit symbols to button text', async () => {
+    stubFetch(manifest)
+    const { sections } = await fetchScenarioManifest()
+    expect(sections[0].items[0].label).toBe('1♠ Opening')
+  })
+
+  it('uses the first meaningful chat line as the description', async () => {
+    stubFetch(manifest)
+    const { sections } = await fetchScenarioManifest()
+    // The leading `--- header` line is a title marker, not a description.
+    expect(sections[0].items[0].description).toBe('First real line.')
+  })
+
+  it('reports a readable error when the manifest is unavailable', async () => {
+    stubFetch(null, false, 404)
+    await expect(fetchScenarioManifest()).rejects.toThrow(/scenario list.*404/i)
+  })
+})

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'))
+
+export default defineConfig({
+  plugins: [vue()],
+
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
+
+  // Relative asset URLs, so the build works from a subpath as well as a root.
+  base: './',
+
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        // Keep the engine and the editor in their own chunks. Both are large,
+        // both are content-hashed, and neither changes when app code does — so
+        // a redeploy does not force everyone to re-download them.
+        manualChunks(id) {
+          if (id.includes('monaco-editor')) return 'monaco'
+          if (id.includes('/wasm/')) return 'engine'
+        },
+      },
+    },
+    // The engine is ~1 MB on its own; the default 500 kB warning is noise.
+    chunkSizeWarningLimit: 2000,
+    target: 'es2022',
+  },
+
+  worker: { format: 'es' },
+
+  // `wasm-pack --target web` loads the binary with
+  // `new URL('..._bg.wasm', import.meta.url)`. Excluding it from dep
+  // optimisation keeps that URL intact in dev.
+  optimizeDeps: {
+    exclude: ['@/wasm/dealer3_wasm.js'],
+  },
+
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.js'],
+  },
+})

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -29,8 +29,11 @@ export default defineConfig({
         // both are content-hashed, and neither changes when app code does — so
         // a redeploy does not force everyone to re-download them.
         manualChunks(id) {
-          if (id.includes('monaco-editor')) return 'monaco'
+          // The engine is the one genuinely large, rarely-changing asset. Its
+          // own content-hashed chunk means an app-code deploy does not force
+          // everyone to re-download a megabyte of wasm.
           if (id.includes('/wasm/')) return 'engine'
+          if (id.includes('@codemirror') || id.includes('@lezer')) return 'editor'
         },
       },
     },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,19 @@
+// Cloudflare Pages configuration.
+//
+// The site is a static build: the engine runs in the visitor's browser, so there
+// is nothing server-side to deploy. Everything the deploy needs lives here
+// rather than in dashboard settings, so a hosting change is a reviewable diff.
+//
+// Deploy with `npx wrangler pages deploy` after `npm --prefix web run build:all`.
+//
+// Cloudflare Pages rather than GitHub Pages for one reason: it can send the
+// COOP/COEP response headers that a threaded WebAssembly build will need (see
+// web/public/_headers). GitHub Pages cannot set custom headers at all.
+{
+  "name": "dealer3",
+  "compatibility_date": "2026-08-25",
+
+  // Vite writes here. `web/public/` is copied in verbatim, which is how
+  // `_headers` reaches the root of the deploy.
+  "pages_build_output_dir": "web/dist"
+}


### PR DESCRIPTION
Vue 3 + Vite mirroring `bridge-solver/web/`, deployed to Cloudflare Pages. The engine runs in the visitor's browser — no script, deal or keystroke leaves the machine.

Three panes: PBS scenario list, Monaco editor, results.

## Scenarios: fetched, not bundled

`lib/pbsScenarios.js` is **vendored** from `Bridge-Classroom/src/utils/pbsScenarios.js`, trimmed to the manifest and `.dlr` scripts. Release tier.

It reads the manifest PBS CI builds, straight from `raw.githubusercontent.com` (permissive CORS) — no backend, no build-time copy, never stale. Same approach classroom already uses.

I did **not** vendor `DealSourcePicker.vue` (1278 lines, coupled to classroom's resolver, gating and pools) or `DealLibraryPicker.vue` (right shape, but its data layer is a backend composable). The utility was the reusable part; the UI was cheaper to write than to gut.

One deliberate difference from `DealLibraryPicker`: **sections start collapsed**. That component opens everything because a teacher's library is a handful of entries. This is 340+ across 20 sections, where an all-open tree is unusable. Search auto-expands matching sections, since a match hidden behind a closed heading reads as "no results".

## Diagnostics are the point

`check_script()` is the same pest parser the CLI uses, so a squiggle means the engine *will* reject the script — not that a regex guessed. Line and column are the parser's own.

pest reports a point rather than a span, so the marker is widened to the token starting there; a zero-width squiggle is invisible.

## ⚠️ One deviation from what you picked

You chose "Monaco + your TextMate grammar" so VS Code and the web would share one grammar file. **The editor doesn't load `dlr.tmLanguage.json`.** It builds the Monaco tokenizer at runtime from `language_info()`.

The reasoning: your goal was one source of truth, and `language_info()` comes from `dealer_parser::vocabulary` — already checked against `grammar.pest` by two tests. Deriving from it gets the same guarantee *more* directly, and skips shipping `vscode-textmate` + an Oniguruma wasm build (~300 kB) to say the same thing.

The TextMate grammar still exists and is still what VS Code uses. Both are generated from the same vocabulary, so they agree by construction. Happy to switch to real TextMate loading if you'd rather — it's contained to `dlrLanguage.js`.

## Results show everything, not just deals

The generated/produced/seconds block, `average` values with sample sizes, and `frequency` histograms drawn as **bars from the structured bin data** rather than reproducing the ASCII table. Numbers kept alongside — this replaces the presentation, not the precision.

Out-of-range values (`below`/`above`) render above each chart. Easy to lose when plotting bins alone, and a too-narrow range otherwise just looks like fewer deals.

## Bundle

Importing the `monaco-editor` barrel pulled in **every language it ships** — perl, abap, solidity — for 3.4 MB. Importing `editor.api` directly, then splitting Monaco / engine / app into separate content-hashed chunks:

| chunk | gzipped | when |
|---|---|---|
| app + CSS | **~34 kB** | immediately |
| engine (wasm) | 383 kB | on load |
| Monaco | 590 kB | lazy |

Monaco is still the largest thing here, bigger than the engine. If that bothers you, CodeMirror 6 is roughly a quarter the size — and since the tokenizer is now generated rather than TextMate-based, the reason to prefer Monaco is weaker than when you chose it.

## Verification

- 180 Rust tests still pass; fmt and clippy clean
- 16 vitest cases covering manifest parsing (spacers, unpublished scenarios, empty sections, suit symbols, error paths) and language derivation (longest-first ordering, single-letter positions excluded, completion shape)
- Production build succeeds

**Not verified: the app in a real browser.** The Playwright profile was in use, so I tested the logic layer headlessly and left the Vue components uncovered. Worth a look before deploying — noted in `web/README.md`.

Refs #3