### PR TITLE
Say how good a levelling is, and where the run will stop

### DIFF
--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -165,6 +165,36 @@ impl LevelingReport {
     pub fn cost(&self) -> f64 {
         1.0 / (self.base_rate * self.acceptance)
     }
+
+    /// The rarest category, which is what the whole levelling's precision rests
+    /// on: every other one was seen more often and is better known.
+    pub fn rarest(&self) -> Option<&dealer_level::LevelPlan> {
+        self.plans
+            .iter()
+            .min_by(|a, b| a.natural.total_cmp(&b.natural))
+    }
+
+    /// How well the rarest category's rate is known, as a relative standard
+    /// error — 0.022 for the 2,000 sightings characterizing aims at.
+    ///
+    /// The number worth reading, and the reason a sighting count is reported at
+    /// all. A keep is `mix / natural`, so this error passes straight into the
+    /// delivered mix and does not average out over a longer run: dealing more
+    /// afterwards converges on the wrong number rather than scattering around
+    /// the right one.
+    ///
+    /// Infinite when the rarest was never seen, which is a levelling that could
+    /// not be computed rather than one that is merely thin.
+    pub fn precision(&self) -> f64 {
+        let Some(rarest) = self.rarest() else {
+            return f64::INFINITY;
+        };
+        if rarest.seen == 0 || self.measured.produced == 0 {
+            return f64::INFINITY;
+        }
+        (rarest.natural * (1.0 - rarest.natural) / self.measured.produced as f64).sqrt()
+            / rarest.natural
+    }
 }
 
 /// What a front end supplies to a run: when to stop, and where produced deals

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -637,16 +637,8 @@ fn leveling_summary(levelling: &dealer_run::LevelingReport) -> String {
             width = width
         ));
     }
-    let rarest = leveled
-        .plans
-        .iter()
-        .min_by(|a, b| a.natural.total_cmp(&b.natural))
-        .expect("at least one hand type");
-    let relative = if rarest.seen > 0 {
-        (rarest.natural * (1.0 - rarest.natural) / measured.produced as f64).sqrt() / rarest.natural
-    } else {
-        f64::INFINITY
-    };
+    let rarest = levelling.rarest().expect("at least one hand type");
+    let relative = levelling.precision();
     out.push_str(&format!(
         "\n  exactness {:.3}{}\n  acceptance {:.4} of qualifying deals\n  about {:.0} deals \
          dealt per deal kept\n  keeps pinned down by `{}`, the rarest, seen {} times: +-{:.1}%",

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -160,10 +160,16 @@ struct LevelingResult {
     cost: f64,
     /// How many deals the keeps were measured over.
     measured: usize,
-    /// The rarest type's count in the measuring pass, and what that is worth as
-    /// a relative error — the precision of the whole levelling rests on it.
+    /// The rarest type's count, and what that is worth as a relative error.
+    /// The precision of the whole levelling rests on it, and this is the number
+    /// to read: a keep is `mix / natural`, so an error here is baked into the
+    /// delivered mix rather than averaging out.
     rarest: String,
     rarest_seen: usize,
+    /// Relative standard error on that rate — 0.022 at the 2,000 sightings
+    /// characterizing aims at. Absent when the type was never seen, which is a
+    /// levelling that could not be computed rather than one that is merely thin.
+    rarest_error: Option<f64>,
     /// Wall-clock seconds spent measuring, which is the pass the reader did not
     /// ask for and cannot otherwise account for.
     measure_seconds: f64,
@@ -238,6 +244,8 @@ struct Page<'a> {
     progress: &'a Progress,
     /// When the characterizing pass must stop, whatever it has managed.
     deadline: f64,
+    /// Deals it may take, which is the other thing that can stop it short.
+    max_generate: usize,
     /// Deals to hand back, capped: a large `produce` used to gather statistics
     /// does not have to ship every deal to JS.
     held: Vec<(Option<usize>, Deal)>,
@@ -253,6 +261,31 @@ struct Page<'a> {
     characterizing_seconds: f64,
 }
 
+impl Page<'_> {
+    /// How far this pass is likely to get, in sightings of the scarcest
+    /// category — which is what its bar is counting.
+    ///
+    /// Two limits can stop characterizing short of the goal, and both are the
+    /// page's: the clock, and the deals it is allowed. Whichever arrives first
+    /// sets the ceiling, and the rate so far projects it — `seen` sightings in
+    /// this much of the budget will be about `seen / spent` in all of it.
+    ///
+    /// Rough on purpose, and it firms up within the first moment. A bar drawn
+    /// against 2,000 that ends at 61 looks broken; the same bar with the mark
+    /// at 63 says the run is doing what it can and will not reach the goal,
+    /// which is the thing worth knowing.
+    fn reachable(&self, seen: usize, generated: usize, goal: usize) -> usize {
+        if seen == 0 || generated == 0 {
+            return goal;
+        }
+        let by_deals = seen as f64 * self.max_generate as f64 / generated as f64;
+        let spent = (now_ms() - self.characterizing_started).max(1.0);
+        let budget = (self.deadline - self.characterizing_started).max(1.0);
+        let by_clock = seen as f64 * budget / spent;
+        (by_deals.min(by_clock).round() as usize).clamp(seen.max(1), goal)
+    }
+}
+
 impl RunHost for Page<'_> {
     fn should_stop(
         &mut self,
@@ -261,8 +294,13 @@ impl RunHost for Page<'_> {
         generated: usize,
         target: usize,
     ) -> bool {
+        let expected = if phase == Phase::Characterizing {
+            self.reachable(produced, generated, target)
+        } else {
+            target
+        };
         self.progress
-            .report(phase, produced, generated, target, false);
+            .report(phase, produced, generated, target, expected, false);
         if phase == Phase::Characterizing && now_ms() >= self.deadline {
             self.ran_out = true;
             return true;
@@ -274,8 +312,11 @@ impl RunHost for Page<'_> {
         if phase == Phase::Characterizing {
             self.characterizing_seconds = (now_ms() - self.characterizing_started) / 1000.0;
         }
+        // A finished pass reached exactly what it reached, so that is the mark
+        // too — a bar arriving at its own expectation rather than stopping
+        // somewhere short of a figure it was never going to meet.
         self.progress
-            .report(phase, produced, generated, target, true);
+            .report(phase, produced, generated, target, produced.max(1), true);
     }
 
     fn produced(&mut self, deal: &Produced) -> Result<(), String> {
@@ -366,6 +407,7 @@ pub fn generate(
     let mut page = Page {
         progress: &progress,
         deadline: started + MEASURE_BUDGET_MS,
+        max_generate,
         held: Vec::new(),
         printed: String::new(),
         ran_out: false,
@@ -475,10 +517,7 @@ pub fn generate(
     };
 
     let leveling = report.leveling.as_ref().map(|levelling| {
-        let rarest = levelling
-            .plans
-            .iter()
-            .min_by(|a, b| a.natural.total_cmp(&b.natural));
+        let rarest = levelling.rarest();
         LevelingResult {
             script: levelling.script.clone(),
             shares: hand_types.clone(),
@@ -488,6 +527,7 @@ pub fn generate(
             measured: levelling.measured.produced,
             rarest: rarest.map(|p| p.name.clone()).unwrap_or_default(),
             rarest_seen: rarest.map(|p| p.seen).unwrap_or(0),
+            rarest_error: Some(levelling.precision()).filter(|e| e.is_finite()),
             measure_seconds: page.characterizing_seconds,
             warnings: levelling.warnings.clone(),
             characterized: levelling.characterized,
@@ -580,7 +620,18 @@ impl Progress {
 
     /// Report, unless one went out too recently. `force` overrides that, for
     /// the end of a phase — otherwise a bar can stop short of its own total.
-    fn report(&self, phase: Phase, produced: usize, generated: usize, target: usize, force: bool) {
+    #[allow(clippy::too_many_arguments)]
+    fn report(
+        &self,
+        phase: Phase,
+        produced: usize,
+        generated: usize,
+        target: usize,
+        // How far this pass is expected to get, which is `target` unless a
+        // limit will stop it short.
+        expected: usize,
+        force: bool,
+    ) {
         let Some(to) = &self.to else { return };
         let now = now_ms();
         if !force && now - self.last_ms.get() < PROGRESS_EVERY_MS {
@@ -589,11 +640,12 @@ impl Progress {
         self.last_ms.set(now);
 
         let message = format!(
-            r#"{{"phase":"{}","produced":{},"generated":{},"target":{}}}"#,
+            r#"{{"phase":"{}","produced":{},"generated":{},"target":{},"expected":{}}}"#,
             phase.name(),
             produced,
             generated,
-            target
+            target,
+            expected
         );
         // A caller that throws is not worth stopping the run for: the deals are
         // the point and the bar is decoration.

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -131,8 +131,17 @@
                 :class="{ indeterminate: bar.fraction === null }"
                 :style="bar.fraction === null ? null : { width: (100 * bar.fraction).toFixed(1) + '%' }"
               ></span>
+              <!-- Where this pass is expected to end, when that is short of the
+                   goal. Without it a bar that stops at 3% looks broken, when in
+                   fact it is doing all it can. -->
+              <span
+                v-if="bar.expected !== null"
+                class="progress-mark"
+                :style="{ left: (100 * bar.expected).toFixed(1) + '%' }"
+                :title="bar.expectedHint"
+              ></span>
             </span>
-            <span class="progress-count">{{ bar.count }}</span>
+            <span class="progress-count" :title="bar.expectedHint || undefined">{{ bar.count }}</span>
           </div>
         </div>
 
@@ -262,10 +271,19 @@ const progressBars = computed(() =>
     .map((key) => {
       const p = phases.value[key]
       const target = p.target > 0 ? p.target : 0
+      // Only worth drawing when it says something the bar does not: a pass on
+      // course for its goal has its mark at the far end, which is just the end.
+      const short = target && p.expected > 0 && p.expected < target * 0.98
       return {
         key,
         label: PHASE_LABELS[key],
         fraction: target ? Math.min(1, p.produced / target) : null,
+        expected: short ? Math.min(1, p.expected / target) : null,
+        expectedHint: short
+          ? `On course for about ${p.expected.toLocaleString()} of ${target.toLocaleString()} — ` +
+            'the deal limit or the time budget will stop it first. ' +
+            'The levelling still works; its rarest rate is just less well known.'
+          : '',
         count: target
           ? `${p.produced.toLocaleString()} / ${target.toLocaleString()}`
           : p.produced.toLocaleString(),
@@ -657,7 +675,11 @@ body {
   font-size: 11px; color: var(--fg-muted); font-family: var(--mono);
 }
 .progress-track {
-  height: 5px; border-radius: 3px; background: var(--line); overflow: hidden;
+  height: 5px; border-radius: 3px; background: var(--line);
+  /* `relative` for the expected mark, which is positioned within it, and not
+     `overflow: hidden` because that mark stands slightly proud of a 5px bar to
+     be visible at all. The fill rounds its own corners. */
+  position: relative;
 }
 .progress-fill {
   display: block; height: 100%; border-radius: 3px;
@@ -675,6 +697,13 @@ body {
   100% { transform: translateX(300%); }
 }
 .progress-count { font-variant-numeric: tabular-nums; }
+/* Where the pass is expected to end. A hairline rather than a block: it marks a
+   position, and the bar filling up to it is the thing to watch. */
+.progress-mark {
+  position: absolute; top: -2px; bottom: -2px; width: 2px;
+  background: var(--warn, #b45309); border-radius: 1px;
+  transition: left 0.3s ease-out;
+}
 
 @media (prefers-reduced-motion: reduce) {
   .progress-fill.indeterminate { animation: none; width: 100%; opacity: 0.4; }

--- a/web/src/components/ResultsPanel.vue
+++ b/web/src/components/ResultsPanel.vue
@@ -49,7 +49,8 @@
           Levelled over {{ leveling.measured.toLocaleString() }} measured deals ·
           {{ Math.round(leveling.cost).toLocaleString() }} dealt per deal kept ·
           keeps pinned down by <strong>{{ leveling.rarest }}</strong>, seen
-          {{ leveling.rarest_seen.toLocaleString() }} times
+          {{ leveling.rarest_seen.toLocaleString() }} times<template v-if="precision">,
+          <strong :class="precisionClass">±{{ precision }}</strong> on that rate</template>
         </p>
         <!-- A thin measurement is the one error levelling cannot recover from:
              the keep is `mix / natural`, so an error in a rate measured on too
@@ -265,6 +266,35 @@ const producedSeconds = computed(() =>
   Math.max(0, (props.result?.seconds || 0) - (measuredThisRun.value?.measure_seconds || 0)),
 )
 
+/// How well the rarest category's rate is known, which is the number that says
+/// whether a levelling is worth trusting.
+///
+/// The command line has always printed this; the page printed the sighting
+/// count alone, which asks a reader to know that 61 sightings is ±13% and 2,000
+/// is ±2.2%. A keep is `mix / natural`, so this error is baked into the
+/// delivered mix and does not average out with a longer run.
+const precision = computed(() => {
+  const e = props.leveling?.rarest_error
+  if (typeof e !== 'number' || !isFinite(e)) return null
+  // A decimal where the number is small enough for one to mean something, as
+  // the command line prints it: `2.2%` reads as a measurement, `2%` as a
+  // rounding. Past ten percent the decimal is noise.
+  const percent = e * 100
+  return percent < 10 ? `${percent.toFixed(1)}%` : `${percent.toFixed(0)}%`
+})
+
+/// Coloured once it is worth noticing, and not before.
+///
+/// One threshold rather than a scale: at a tenth or worse the mix this delivers
+/// can be a couple of points off its target and stay there, which is worth an
+/// eye; above that the number speaks for itself. An earlier version dimmed the
+/// middle band, which had it backwards — a measurement that is merely adequate
+/// should not be quieter than a good one.
+const precisionClass = computed(() => {
+  const e = props.leveling?.rarest_error
+  return typeof e === 'number' && isFinite(e) && e >= 0.1 ? 'ht-thin' : ''
+})
+
 const timingHint = computed(
   () =>
     'Levelling deals the scenario twice: once to characterize it — how often each hand type ' +
@@ -436,6 +466,10 @@ const formatValue = formatAverage
   font-size: 0.86em;
 }
 
+/* A rate known to a tenth or worse: the mix this delivers can be a couple of
+   points off its target, permanently. Not an error, so it is coloured rather
+   than boxed. */
+.ht-thin { color: var(--warn, #b45309); }
 .ht-warn {
   margin: 0.35rem 0 0.6rem;
   padding: 0.45rem 0.6rem;

--- a/web/src/lib/engine.js
+++ b/web/src/lib/engine.js
@@ -185,7 +185,9 @@ export async function generate(
     // `delivered` what the keeps produced; otherwise the two agree.
     handTypes: raw.hand_types,
     // Present only when the run was levelled: the scenario that actually ran,
-    // and what it cost. Numbers only — the page draws the bars.
+    // and what it cost. Numbers only — the page draws the bars. `rarest_error`
+    // is the relative standard error on the rate every keep divides by, which
+    // is the one figure that says whether a levelling is worth trusting.
     leveling: raw.leveling,
     // `deals` is capped by the engine; `produced` counts every match. A script
     // gathering statistics over 50,000 deals returns statistics for all of them


### PR DESCRIPTION
Closes #18.

Two things a levelled run knew and did not say.

### How good the measurement was

The panel reported the rarest category's sighting count and stopped there, which asks a reader to know that 61 sightings is ±13% and 2,000 is ±2.2%. It now says so:

```
keeps pinned down by 22_24, seen 117 times, ±9.2% on that rate
```

That is the number the whole levelling rests on. A keep is `mix / natural`, so an error in the divisor is baked into the delivered mix and does not average out — dealing more afterwards converges on the wrong number rather than scattering around the right one. The command line has printed this since levelling existed; the browser never did.

Coloured past a tenth and not before. `LevelingReport::precision` and `::rarest` move the formula into the engine so the two front ends cannot disagree about what a levelling is worth.

### Where the characterizing pass will actually stop

The bar counts sightings of the scarcest category toward 2,000, and for a demanding scenario it cannot get there — the deal limit or the six-second budget arrives first. Ending at 3% of a bar looks broken when it is in fact the run doing all it can.

So the bar keeps its 2,000 scale, which is what makes runs comparable with each other, and gains a mark at the projected stopping point. The projection is the rate so far against whichever limit binds first: `seen` sightings in this much of the budget will be about `seen / spent` in all of it.

Measured on a scenario keeping one deal in 430, at the default million-deal limit:

| bar | mark says | |
|---|---|---|
| 17 / 2,000 | ~25 | |
| 19 / 2,000 | ~25 | |
| 24 / 2,000 | ~27 | |
| — | — | run ended at **28** |

A pass on course for the goal shows no mark at all, so a short run and a full one are told apart before either finishes.

Rescaling the bar to what it will reach was the other option and is worse: it fills, and in filling hides the shortfall, which is the thing worth seeing.

### Verification

- 433 workspace tests, web 110, `verify.mjs` 8/8.
- 78 browser before/after runs identical; every levelled run still holds exactly the deals a fresh run of its own script gives.
- The command line's summary is unchanged — 28 general and 9 `--write-leveled` comparison runs identical, and it still prints `+-2.2%` from the same formula the browser now uses.
- Driven in a browser: mark tracking and converging on a short run, absent on a run that reaches the goal, and `±2.2%` matching the command line.

Not addressed here, and still open in #20: the time budget doing double duty with `Max generate`, the browser characterizing on one thread, and characterizing carrying on when the producing pass would otherwise deal more itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)