### PR TITLE
A threaded wasm build that works, and is not switched on

### DIFF
--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -239,31 +239,43 @@ pub trait RunHost {
     fn produced(&mut self, deal: &Produced) -> Result<(), String>;
 }
 
-/// The engine's thread pool, and how it maps work over a batch.
+/// The engine's threads, and how it maps work over a batch.
 ///
-/// A pool of its own rather than rayon's global one: a global can only be
-/// configured once per process, so a second run in the same process would
-/// silently keep the first one's thread count.
+/// A pool of its own where one can be had: rayon's global pool can only be
+/// configured once per process, so a second run would silently keep the first
+/// one's thread count.
+///
+/// On the web it cannot. Building a pool spawns threads, and on wasm that needs
+/// a spawn hook which `wasm-bindgen-rayon` installs for the global pool alone —
+/// a private pool simply fails to build. So a build that cannot have its own
+/// falls back to the global one rather than to running serially, which is what
+/// it did at first, silently, while looking like it had threads.
 struct Workers {
     #[cfg(feature = "parallel")]
     pool: Option<rayon::ThreadPool>,
+    /// Whether to use rayon's global pool, because a private one was wanted and
+    /// could not be built.
+    #[cfg(feature = "parallel")]
+    global: bool,
 }
 
 impl Workers {
     fn new(_threads: usize) -> Self {
-        #[cfg(feature = "parallel")]
         // One thread is this one, so there is nothing to hand off to.
-        let pool = if _threads == 1 {
-            None
-        } else {
+        #[cfg(feature = "parallel")]
+        let wanted = _threads > 1;
+        #[cfg(feature = "parallel")]
+        let pool = wanted.then(|| {
             rayon::ThreadPoolBuilder::new()
                 .num_threads(_threads)
                 .build()
                 .ok()
-        };
+        });
         Workers {
             #[cfg(feature = "parallel")]
-            pool,
+            pool: pool.flatten(),
+            #[cfg(feature = "parallel")]
+            global: wanted,
         }
     }
 
@@ -288,9 +300,14 @@ impl Workers {
             (deal, passed)
         };
         #[cfg(feature = "parallel")]
-        if let Some(pool) = &self.pool {
+        {
             use rayon::prelude::*;
-            return pool.install(|| (0..count).into_par_iter().map(one).collect());
+            if let Some(pool) = &self.pool {
+                return pool.install(|| (0..count).into_par_iter().map(one).collect());
+            }
+            if self.global {
+                return (0..count).into_par_iter().map(one).collect();
+            }
         }
         (0..count).map(one).collect()
     }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -27,6 +27,20 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 console_error_panic_hook = "0.1"
 
+# Threads on the web. Optional because a threaded build is a different build:
+# it needs nightly, `-Z build-std`, atomics, and a page served with COOP/COEP so
+# `SharedArrayBuffer` exists. `./build.sh threaded` does all that; the ordinary
+# build stays on stable and single-threaded, and both produce the same deals.
+# Default features, not `no-bundler`: Vite *is* a bundler, and understands the
+# `new Worker(new URL(...), { type: "module" })` the default emits. With
+# `no-bundler` the pool's workers never started and nothing said so — the run
+# simply produced nothing, with no error on the page or in the console.
+wasm-bindgen-rayon = { version = "1.3", optional = true }
+
+[features]
+default = []
+parallel = ["dep:wasm-bindgen-rayon", "dealer-run/parallel"]
+
 [profile.release]
 # Size matters more than a few percent of speed for a page download.
 opt-level = "z"

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -3,10 +3,19 @@
 # build.sh - Build the dealer3 WebAssembly package.
 #
 # Usage:
-#   ./build.sh [web|nodejs|both]     (default: web)
+#   ./build.sh [web|nodejs|both|threaded]     (default: web)
 #
-#   web     ES module for the browser / Cloudflare Pages  -> pkg/
-#   nodejs  CommonJS for Node, used by the verification tests -> pkg-node/
+#   web       ES module for the browser / Cloudflare Pages  -> pkg/
+#   nodejs    CommonJS for Node, used by the verification tests -> pkg-node/
+#   threaded  the same ES module built for wasm threads       -> pkg/
+#
+# `threaded` needs a pinned nightly and rust-src, and the page must be served
+# with COOP/COEP. It works and it is correct — the same deals, whatever the
+# thread count — but it is **not** what the site ships, because today it is
+# slower: 4M deals in six seconds on one thread against 290K on twelve, getting
+# worse with every thread added. That shape is lock contention, and the lock is
+# almost certainly the allocator: a `Deal` is four `Vec<Card>` allocations and
+# wasm's dlmalloc serialises them all. Allocation-free dealing comes first.
 #
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
@@ -17,6 +26,112 @@ command -v wasm-pack >/dev/null || {
 }
 
 target="${1:-web}"
+
+# A threaded build is a different build, not a flag on the same one: wasm
+# threads need atomics and shared memory, which means rebuilding the standard
+# library, which means nightly. Everything else stays on stable.
+#
+# The page it lands on must also be served with COOP and COEP, or
+# `SharedArrayBuffer` does not exist and the workers cannot share memory. Those
+# headers are in `web/public/_headers`.
+# The nightly a threaded build is known to work with.
+#
+# Pinned rather than tracking `nightly`, and not because nightly is unstable in
+# the usual sense. wasm-bindgen 0.2.127 looks for a `__wasm_init_tls` symbol
+# that newer LLVM no longer emits — it emits `__wasm_apply_tls_relocs` instead —
+# so a current nightly builds fine and then fails at the bindgen step with
+# "failed to find `__wasm_init_tls`". Until wasm-bindgen catches up, the version
+# that still emits it is the version to use.
+#
+# `wasm-bindgen-rayon` pins `nightly-2024-08-02`, which is too old for this
+# codebase: `usize::is_multiple_of` arrived in 1.87.
+THREADED_TOOLCHAIN=nightly-2025-06-01
+
+# A threaded build is a different build, not a flag on the same one: wasm
+# threads need atomics and shared memory, which means rebuilding the standard
+# library, which means nightly. Everything else stays on stable.
+#
+# The page it lands on must also be served with COOP and COEP, or
+# `SharedArrayBuffer` does not exist and the workers cannot share memory. Those
+# headers are in `web/public/_headers`, and `vite.config.js` sends them in dev.
+build_threaded() {
+    echo "==> building web (threaded, $THREADED_TOOLCHAIN) -> $1"
+    command -v rustup >/dev/null || {
+        echo "Error: threaded builds need rustup, for a pinned nightly toolchain." >&2
+        exit 1
+    }
+    rustup run "$THREADED_TOOLCHAIN" rustc --version >/dev/null 2>&1 || {
+        echo "Error: threaded builds need $THREADED_TOOLCHAIN:" >&2
+        echo "    rustup toolchain install $THREADED_TOOLCHAIN --profile minimal \\" >&2
+        echo "        --component rust-src --target wasm32-unknown-unknown" >&2
+        exit 1
+    }
+    # `-Z build-std` before the subcommand, and through `cargo` directly rather
+    # than `wasm-pack`, which passes trailing arguments where `-Z` is not
+    # accepted. The bindgen and optimise steps are then run by hand.
+    RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
+        rustup run "$THREADED_TOOLCHAIN" cargo -Z build-std=panic_abort,std \
+            build --target wasm32-unknown-unknown --release --features parallel
+
+    local built="target/wasm32-unknown-unknown/release/dealer3_wasm.wasm"
+    # `__wasm_init_tls` is what wasm-bindgen needs and what pins the toolchain.
+    # Checked here so a toolchain bump fails with the reason rather than with
+    # bindgen's message about a symbol nobody has heard of.
+    # `grep -c`, not `grep -q`: under `pipefail` an early-exiting `grep -q`
+    # leaves `strings` killed by SIGPIPE, and the pipeline then reports failure
+    # on the very binaries that pass.
+    [ "$(strings "$built" | grep -c '__wasm_init_tls')" -gt 0 ] || {
+        echo "Error: $built has no __wasm_init_tls, so wasm-bindgen will refuse it." >&2
+        echo "       The toolchain's LLVM no longer emits it; see THREADED_TOOLCHAIN above." >&2
+        exit 1
+    }
+
+    rm -rf "$1"
+    # wasm-pack keeps a matching wasm-bindgen of its own; using that one rather
+    # than asking for a separate install keeps the two versions in step, which
+    # is a thing they must be.
+    local bindgen
+    # `|| true` because `ls` reports failure for whichever of the two cache
+    # locations this machine does not have, and `set -e` would take that as the
+    # assignment failing.
+    bindgen=$(ls -t "$HOME"/Library/Caches/.wasm-pack/wasm-bindgen-*/wasm-bindgen \
+                     "$HOME"/.cache/.wasm-pack/wasm-bindgen-*/wasm-bindgen 2>/dev/null \
+              | head -1 || true)
+    [ -n "$bindgen" ] || bindgen=$(command -v wasm-bindgen) || {
+        echo "Error: no wasm-bindgen. Run './build.sh web' once to have wasm-pack fetch one." >&2
+        exit 1
+    }
+    "$bindgen" "$built" --out-dir "$1" --target web --no-typescript
+    # wasm-bindgen, unlike wasm-pack, writes no package.json — and the pool's
+    # worker helper needs one. It reaches the glue with `await import('../../..')`
+    # from inside `snippets/<hash>/src/`, which lands on this directory and only
+    # resolves if something here names the entry point. Without it Vite fails
+    # with "Failed to resolve import ../../.." and replaces the whole app with
+    # an error overlay — which from a headless browser looks like a page that
+    # simply never finished loading.
+    cat > "$1/package.json" <<JSON
+{
+  "name": "dealer3-wasm",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dealer3_wasm.js",
+  "module": "dealer3_wasm.js",
+  "sideEffects": ["./snippets/*"]
+}
+JSON
+
+    # Threads carry features wasm-opt will otherwise refuse. Skipped rather than
+    # failed if it is not installed: the binary is merely larger.
+    if command -v wasm-opt >/dev/null; then
+        wasm-opt -O --enable-threads --enable-bulk-memory --enable-mutable-globals \
+            "$1"/dealer3_wasm_bg.wasm -o "$1"/dealer3_wasm_bg.wasm
+    fi
+    local wasm
+    wasm=$(ls "$1"/*_bg.wasm)
+    printf "    %.0f KB raw, %.0f KB gzipped\n" \
+        "$(( $(wc -c < "$wasm") / 1024 ))" \
+        "$(( $(gzip -c "$wasm" | wc -c) / 1024 ))"
+}
 build() {
     echo "==> building $1 -> $2"
     wasm-pack build --target "$1" --release --out-dir "$2"
@@ -28,8 +143,9 @@ build() {
 }
 
 case "$target" in
-    web)    build web pkg ;;
-    nodejs) build nodejs pkg-node ;;
-    both)   build web pkg; build nodejs pkg-node ;;
-    *)      echo "Unknown target '$target'. Use web, nodejs or both." >&2; exit 1 ;;
+    web)      build web pkg ;;
+    nodejs)   build nodejs pkg-node ;;
+    both)     build web pkg; build nodejs pkg-node ;;
+    threaded) build_threaded "${2:-pkg}" ;;
+    *)        echo "Unknown target '$target'. Use web, nodejs, both or threaded." >&2; exit 1 ;;
 esac

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -234,6 +234,51 @@ fn now_ms() -> f64 {
 /// `max_generate` bounds the work: a browser tab has no Ctrl-C, so a selective
 /// filter must not be able to hang it. Callers should surface `hit_limit`
 /// rather than silently showing a short result.
+/// Start a pool of `threads` web workers for the engine to deal on.
+///
+/// Only present in a threaded build (`./build.sh threaded`), and it must be
+/// awaited before `generate` if a run is to use more than this thread. Needs
+/// the page served with COOP and COEP — `SharedArrayBuffer` does not exist
+/// without them — and the caller built for it.
+///
+/// Not calling it is not an error: the engine falls back to one thread and
+/// deals exactly the same deals, which is the property that makes any of this
+/// safe.
+///
+/// **The site does not ship a threaded build**, because more threads currently
+/// make it slower rather than faster — see `build.sh`. This is the groundwork
+/// and the proof that the engine's side is right, not a switch to flip.
+#[cfg(feature = "parallel")]
+#[wasm_bindgen]
+pub fn start_threads(threads: usize) -> js_sys::Promise {
+    THREADS.with(|t| t.set(threads.max(1)));
+    wasm_bindgen_rayon::init_thread_pool(threads.max(1))
+}
+
+thread_local! {
+    /// How many workers the caller started, which is what a run may use.
+    static THREADS: std::cell::Cell<usize> = const { std::cell::Cell::new(1) };
+}
+
+/// Threads this build and this page can actually deal on.
+fn threads_available() -> usize {
+    #[cfg(feature = "parallel")]
+    {
+        THREADS.with(|t| t.get())
+    }
+    #[cfg(not(feature = "parallel"))]
+    {
+        1
+    }
+}
+
+/// Whether this build can use more than one thread at all, so a page can tell
+/// the difference between "not built for it" and "the browser refused".
+#[wasm_bindgen]
+pub fn supports_threads() -> bool {
+    cfg!(feature = "parallel")
+}
+
 /// A page's side of a run: it holds deals, collects what the script printed,
 /// paints a bar and answers a clock.
 ///
@@ -424,11 +469,11 @@ pub fn generate(
                 predeal,
                 swap: dealer_core::SwapMode::None,
             },
-            // A page has one thread until it is served with COOP/COEP and built
-            // for wasm threads, at which point turning on `dealer-run`'s
-            // `parallel` feature is the whole of what it takes. The headers are
-            // already set; the build is not.
-            threads: 1,
+            // Whatever the caller started a pool with, and one if it did not
+            // — see `start_threads`. A thread count cannot change what comes
+            // out, only how long it takes, so a page that cannot spawn any
+            // gets the same deals more slowly.
+            threads: threads_available(),
             batch: 0,
             params: Default::default(),
             leveling: auto_level.then_some(LevelingOptions {

--- a/web/package.json
+++ b/web/package.json
@@ -6,9 +6,11 @@
   "description": "Write and run bridge dealer scripts in the browser",
   "scripts": {
     "wasm": "wasm-pack build ../wasm --release --target web --out-dir ../web/src/wasm --no-typescript",
+    "wasm:threaded": "cd ../wasm && ./build.sh threaded ../web/src/wasm",
     "dev": "npm run wasm && vite",
     "build": "vite build",
     "build:all": "npm run wasm && vite build",
+    "build:threaded": "npm run wasm:threaded && vite build",
     "preview": "vite preview",
     "test": "vitest run"
   },

--- a/web/src/lib/engine.worker.js
+++ b/web/src/lib/engine.worker.js
@@ -16,23 +16,61 @@
 // synchronously while the editor is being set up and are far too fast to be
 // worth an await, so they stay on the main thread's own instance.
 
-import init, { generate as wasmGenerate } from '@/wasm/dealer3_wasm.js'
+import init, * as engine from '@/wasm/dealer3_wasm.js'
 
 let ready = null
+
+/// Bring up the engine, and its thread pool if this build has one.
+///
+/// A threaded build spawns workers of its own that share the wasm's memory, so
+/// it needs `SharedArrayBuffer` — which exists only on a page served with COOP
+/// and COEP. Both are set in `public/_headers`; a dev server or a host that
+/// drops them leaves `crossOriginIsolated` false, and then the pool cannot
+/// start.
+///
+/// Failing to start one is not an error. The engine falls back to this thread
+/// and deals exactly the same deals, only slower — which is what makes it safe
+/// to try and carry on.
+async function bringUp() {
+  await init()
+  if (typeof engine.start_threads !== 'function') return { threads: 1, why: 'built without threads' }
+  if (!self.crossOriginIsolated) {
+    return { threads: 1, why: 'the page is not cross-origin isolated' }
+  }
+  const wanted = Math.max(1, Math.min(navigator.hardwareConcurrency || 1, 12))
+  try {
+    await engine.start_threads(wanted)
+    return { threads: wanted, why: null }
+  } catch (e) {
+    return { threads: 1, why: e?.message || String(e) }
+  }
+}
 
 self.onmessage = async (event) => {
   const { id, script, options } = event.data || {}
   try {
-    // Loaded once per worker, and a worker outlives any single run.
-    if (!ready) ready = init()
-    await ready
+    // Loaded once per worker, and a worker outlives any single run — so the
+    // thread pool is started once too, not per run.
+    if (!ready) ready = bringUp()
+    const pool = await ready
+    // Once per worker, not per run: a page that quietly fell back to one thread
+    // looks exactly like a slow scenario, which is how the first threaded build
+    // shipped serial without anyone noticing.
+    if (!pool.reported) {
+      pool.reported = true
+      console.info(
+        pool.threads > 1
+          ? `dealer3: dealing on ${pool.threads} threads`
+          : `dealer3: dealing on one thread (${pool.why})`,
+      )
+    }
 
     const onProgress = (message) => {
       // Passed through as the engine wrote it; the page decides what to show.
       self.postMessage({ id, type: 'progress', message })
     }
 
-    const raw = wasmGenerate(
+    const raw = engine.generate(
       script,
       options.seed,
       options.produce,
@@ -41,7 +79,7 @@ self.onmessage = async (event) => {
       options.autoLevel,
       onProgress,
     )
-    self.postMessage({ id, type: 'done', raw })
+    self.postMessage({ id, type: 'done', raw, threads: pool.threads })
   } catch (e) {
     // `Error` does not survive structured cloning with its message intact in
     // every browser, so send the text.

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -7,6 +7,13 @@ const entry = (name) => fileURLToPath(new URL(name, import.meta.url))
 
 const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'))
 
+/// What `SharedArrayBuffer` needs, and so what wasm threads need. Kept in step
+/// with `public/_headers`, which is what production serves.
+const ISOLATION = {
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Embedder-Policy': 'require-corp',
+}
+
 export default defineConfig({
   plugins: [vue()],
 
@@ -55,6 +62,14 @@ export default defineConfig({
   },
 
   worker: { format: 'es' },
+
+  // A threaded engine needs `SharedArrayBuffer`, which a browser only exposes
+  // to a cross-origin isolated page. In production Cloudflare sends these from
+  // `public/_headers`; dev and preview need them here or the pool silently
+  // fails to start and every run falls back to one thread — the same deals,
+  // several times slower, with nothing on screen to say why.
+  server: { headers: ISOLATION },
+  preview: { headers: ISOLATION },
 
   // `wasm-pack --target web` loads the binary with
   // `new URL('..._bg.wasm', import.meta.url)`. Excluding it from dep


### PR DESCRIPTION
`./build.sh threaded` produces a wasm built for threads, and the worker starts a pool. It is correct — identical measurement and identical deals at one thread and at twelve, in a browser — and it is **slower**, so the site does not ship it.

Characterizing a selective scenario for six seconds:

| threads | deals |  |
|---|---|---|
| 1 | 3,991,552 | — |
| 2 | 3,060,736 | 0.77× |
| 4 | 1,061,888 | 0.27× |
| 12 | 290,400 | 0.07× |

Monotonically worse with every thread added, which is contention rather than parallel work. The lock is the allocator: a `Deal` is four `Vec<Card>` allocations, an `EvalContext` another, and wasm's dlmalloc serialises all of them. Filed as #24, which is the blocker — and which should speed the single-threaded path too, since the shuffle is mostly those allocations.

So this is groundwork and a proof that the engine's side is right, not a switch to flip. **`npm run wasm` is unchanged and the shipping build has no threading exports at all.**

## Four things that had to be right, each failing silently

- `-Z build-std` through `CARGO_UNSTABLE_BUILD_STD` is ignored, so `std` came from rustup precompiled without atomics — and the build looked fine.
- `+atomics` alone does not give a *shared* memory. Without `--shared-memory --import-memory --max-memory`, `postMessage` refuses to hand the memory to a worker (`#<Memory> could not be cloned`) and the pool falls back to one thread while reporting that it started.
- wasm-bindgen 0.2.127 looks for `__wasm_init_tls`, which current LLVM no longer emits — it emits `__wasm_apply_tls_relocs`. Hence a pinned `nightly-2025-06-01`; `wasm-bindgen-rayon` pins `nightly-2024-08-02`, which predates `usize::is_multiple_of`.
- wasm-bindgen writes no `package.json`, and the pool's worker helper reaches the glue with `await import('../../..')`. Without one, Vite replaces the whole app with an error overlay — which from a headless browser is indistinguishable from a page that never loaded.

`build.sh` now checks for `__wasm_init_tls` itself, so a toolchain bump fails with the reason rather than with a symbol nobody has heard of.

## Also

- `vite.config.js` sends COOP/COEP in dev and preview, matching `public/_headers`. Without them the pool cannot start and every run silently falls back.
- The worker logs which it got, once. A page dealing on one thread when it meant twelve looks exactly like a slow scenario.
- `dealer-run` falls back to rayon's global pool when a private one cannot be built — the case on wasm, where `wasm-bindgen-rayon` installs its spawn hook for the global pool alone. Without this the engine ran serial while looking threaded.

## Verification

433 workspace tests, web 110, `verify.mjs` 8/8, 78 browser before/after runs identical with the shipping single-threaded build restored. Native threading unaffected: `-R 12` on Jacoby 2NT still 0.418s against 1.750s single-threaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)