### PR TITLE
The prefix is a magic word, so its case is not part of it

### DIFF
--- a/dealer-level/src/lib.rs
+++ b/dealer-level/src/lib.rs
@@ -122,7 +122,6 @@ pub fn render_leveled(
     base_rate: f64,
     measured: usize,
     seed: u32,
-    prefix: &str,
     groups: &[(String, f64)],
 ) -> Result<String, String> {
     if source.contains(LEVEL_STAMP) {
@@ -255,11 +254,11 @@ pub fn render_leveled(
                 canonical_roll(scale.saturating_mul(100).max(scale))
             ));
         } else if keep >= scale {
-            block.push(format!("level_{0} = {1}_{0}", plan.name, prefix));
+            block.push(format!("level_{} = {}", plan.name, plan.variable));
         } else {
             block.push(format!(
-                "level_{0} = {1}_{0} and roll < {2}",
-                plan.name, prefix, keep
+                "level_{} = {} and roll < {}",
+                plan.name, plan.variable, keep
             ));
         }
     }
@@ -294,11 +293,10 @@ pub fn write_leveled(
     base_rate: f64,
     measured: usize,
     seed: u32,
-    prefix: &str,
     groups: &[(String, f64)],
 ) -> Result<String, String> {
     let generated = render_leveled(
-        source, plans, lambda, acceptance, base_rate, measured, seed, prefix, groups,
+        source, plans, lambda, acceptance, base_rate, measured, seed, groups,
     )?;
     std::fs::write(path, &generated)
         .map_err(|e| format!("could not write {}: {}", path.display(), e))?;
@@ -497,6 +495,16 @@ pub fn parse_level_target(spec: &str, labels: &[String]) -> Result<Vec<f64>, Str
 pub struct LevelPlan {
     /// The hand type's name, with the `HandType` prefix stripped.
     pub name: String,
+    /// The variable as the script declares it, which is what the generated
+    /// block has to reference.
+    ///
+    /// Not `HandType_` + `name`, because that is only true of a scenario
+    /// written the way the generator would have written it. The prefix is a
+    /// magic word matched without regard to case and the separator may be `-`,
+    /// so a script declaring `handtype_south_15` was handed a block referring
+    /// to a `HandType_south_15` that does not exist — which evaluates false
+    /// forever, and produced nothing while every number above it looked right.
+    pub variable: String,
     /// Its share of the deals the scenario produces, as measured.
     pub natural: f64,
     /// The share asked for.
@@ -526,6 +534,7 @@ pub struct LevelPlan {
 /// the affordable fraction is closed-form and there is nothing to search for.
 pub fn level_plan(
     names: &[String],
+    variables: &[String],
     natural: &[f64],
     target: &[f64],
     seen: &[usize],
@@ -563,6 +572,7 @@ pub fn level_plan(
     let plans = (0..names.len())
         .map(|i| LevelPlan {
             name: names[i].clone(),
+            variable: variables[i].clone(),
             natural: natural[i],
             target: target[i],
             mix: mix[i],
@@ -712,6 +722,23 @@ pub const HAND_TYPE_PREFIX: &str = "HandType";
 /// hand type called `12_share`, overlapping the real one.
 pub const SHARE_SUFFIX: &str = "_Share";
 
+/// Whether a name carries one of the convention's prefixes.
+///
+/// Without regard to case, as the `_Share` suffix has always been matched, and
+/// for the same reason: a name that differs only in case is not a name anybody
+/// meant to be different. `handtype_south_15` was silently an ordinary variable
+/// once, and a scenario written that way declared no hand types at all — no
+/// levelling, no PBN tags, no rounds, and nothing said so, because a script
+/// with no hand types is perfectly legal.
+///
+/// The variable itself stays case-sensitive, as it is in dealer.exe, which
+/// resolves names with `strcmp`. This decides only whether a name is one the
+/// levelling machinery reads; referring to it still means spelling it the way
+/// it was declared.
+fn has_prefix(name: &str, prefix: &str) -> bool {
+    name.len() >= prefix.len() && name[..prefix.len()].eq_ignore_ascii_case(prefix)
+}
+
 /// Whether this name declares a share rather than a hand type.
 fn is_share(name: &str) -> bool {
     name.len() > SHARE_SUFFIX.len()
@@ -744,8 +771,7 @@ pub fn level_types(program: &Program) -> Vec<&str> {
 
 /// A level type's name without its prefix, and without the separator after it.
 pub fn level_type_label(name: &str) -> &str {
-    name.trim_start_matches(LEVEL_TYPE_PREFIX)
-        .trim_start_matches(['_', '-'])
+    strip_prefix(name, LEVEL_TYPE_PREFIX)
 }
 
 /// Variables with a given prefix, in declaration order, skipping shares.
@@ -756,7 +782,7 @@ fn named_with<'a>(program: &'a Program, prefix: &str) -> Vec<&'a str> {
     let mut found = Vec::new();
     for statement in &program.statements {
         if let Statement::Assignment { name, .. } = statement {
-            if name.starts_with(prefix) && !is_share(name) && !found.contains(&name.as_str()) {
+            if has_prefix(name, prefix) && !is_share(name) && !found.contains(&name.as_str()) {
                 found.push(name.as_str());
             }
         }
@@ -822,9 +848,9 @@ pub fn leveling_types(program: &Program) -> Result<LevelingTypes, String> {
             if !is_share(name) {
                 continue;
             }
-            if name.starts_with(LEVEL_TYPE_PREFIX) {
+            if has_prefix(name, LEVEL_TYPE_PREFIX) {
                 weights_level = true;
-            } else if name.starts_with(HAND_TYPE_PREFIX) {
+            } else if has_prefix(name, HAND_TYPE_PREFIX) {
                 weights_hand = true;
             }
         }
@@ -854,6 +880,24 @@ pub fn leveling_types(program: &Program) -> Result<LevelingTypes, String> {
         .iter()
         .map(|n| strip_prefix(n, prefix).to_string())
         .collect();
+    // Two declarations that come to the same label. Newly possible once the
+    // prefix stopped caring about case — `HandType_a` and `handtype_a` are two
+    // variables and one category — and worth refusing rather than resolving,
+    // because everything downstream identifies a category by its label: the PBN
+    // tag, the bar chart, the share lookup, `--interleave`. Two rows called `a`
+    // is not a thing to hand anybody.
+    for (i, label) in labels.iter().enumerate() {
+        if let Some(j) = labels[..i]
+            .iter()
+            .position(|l| l.eq_ignore_ascii_case(label))
+        {
+            return Err(format!(
+                "`{}` and `{}` are the same category, `{}`.\n       Names differing only in \
+                 case are not two hand types — rename one.",
+                names[j], names[i], label
+            ));
+        }
+    }
     let shares = shares_for(program, prefix, &labels)?;
     Ok(LevelingTypes {
         names,
@@ -864,9 +908,17 @@ pub fn leveling_types(program: &Program) -> Result<LevelingTypes, String> {
 }
 
 /// A name without its prefix, and without the separator after it.
+///
+/// Matched the way [`has_prefix`] matches, so the two cannot disagree about
+/// what a name is: `handtype_south_15` and `HandType_south_15` both label
+/// `south_15`.
 fn strip_prefix<'a>(name: &'a str, prefix: &str) -> &'a str {
-    name.trim_start_matches(prefix)
-        .trim_start_matches(['_', '-'])
+    let rest = if has_prefix(name, prefix) {
+        &name[prefix.len()..]
+    } else {
+        name
+    };
+    rest.trim_start_matches(['_', '-'])
 }
 
 /// The target share each hand type asks for, in declaration order.
@@ -970,19 +1022,25 @@ fn shares_for(program: &Program, prefix: &str, labels: &[String]) -> Result<Vec<
         let Statement::Assignment { name, expr } = statement else {
             continue;
         };
-        if !name.starts_with(prefix) || !is_share(name) {
+        if !has_prefix(name, prefix) || !is_share(name) {
             continue;
         }
         let label = strip_prefix(name, prefix);
         let label = &label[..label.len() - SHARE_SUFFIX.len()];
 
-        let index = labels.iter().position(|l| l == label).ok_or_else(|| {
-            format!(
-                "`{}` sets the share of a `{}` the scenario never \
+        // Without regard to case, like the prefix and the suffix around it, and
+        // unambiguous because two types whose labels differ only in case are
+        // refused as one category before this is reached.
+        let index = labels
+            .iter()
+            .position(|l| l.eq_ignore_ascii_case(label))
+            .ok_or_else(|| {
+                format!(
+                    "`{}` sets the share of a `{}` the scenario never \
                      declares.\n       Add `{}_{} = ...`, or correct the name.",
-                name, label, prefix, label
-            )
-        })?;
+                    name, label, prefix, label
+                )
+            })?;
 
         // A share has to be known before a card is dealt, so it is a number and
         // not an expression. Anything else is a mistake worth naming rather
@@ -1017,7 +1075,7 @@ fn shares_for(program: &Program, prefix: &str, labels: &[String]) -> Result<Vec<
 /// prose — so the expression is asked instead.
 pub fn mentions_hand_type(expr: &Expr) -> bool {
     match expr {
-        Expr::Variable(name) => name.starts_with(HAND_TYPE_PREFIX),
+        Expr::Variable(name) => has_prefix(name, HAND_TYPE_PREFIX),
         Expr::BinaryOp { left, right, .. } => mentions_hand_type(left) || mentions_hand_type(right),
         Expr::UnaryOp { expr, .. } => mentions_hand_type(expr),
         Expr::Ternary {
@@ -1037,8 +1095,7 @@ pub fn mentions_hand_type(expr: &Expr) -> bool {
 /// What goes in the `[HandType "..."]` tag: the name without its prefix, and
 /// without the separator someone will have written after it.
 pub fn hand_type_label(name: &str) -> &str {
-    name.trim_start_matches(HAND_TYPE_PREFIX)
-        .trim_start_matches(['_', '-'])
+    strip_prefix(name, HAND_TYPE_PREFIX)
 }
 
 /// What one measuring pass over a scenario found.
@@ -1054,6 +1111,9 @@ pub struct Measurement {
     /// Hand type names, with the `HandType` prefix stripped, in declaration
     /// order.
     pub names: Vec<String>,
+    /// The same, as the script declares them, parallel to `names`. What the
+    /// generated block references — see [`LevelPlan::variable`].
+    pub variables: Vec<String>,
     /// How many produced deals matched each, parallel to `names`.
     pub counts: Vec<usize>,
     /// Which prefix `names` came from — `HandType` normally, `LevelType` when
@@ -1236,6 +1296,7 @@ pub fn level_from(
     let budget_acceptance = budget.map(|b| ((1.0 / b) / base_rate).min(1.0));
     let (plans, lambda, acceptance) = level_plan(
         &measured.names,
+        &measured.variables,
         &natural,
         &target,
         &measured.counts,
@@ -1265,7 +1326,6 @@ pub fn level_from(
         base_rate,
         measured.produced,
         seed,
-        measured.prefix,
         &groups,
     )?;
     Ok(Leveled {

--- a/dealer-level/tests/hand_type_shares.rs
+++ b/dealer-level/tests/hand_type_shares.rs
@@ -284,3 +284,76 @@ fn a_share_of_zero_is_refused() {
     assert!(err.contains("HandType_b_Share"), "{err}");
     assert!(err.contains("1 or more"), "{err}");
 }
+
+// ---------------------------------------------------------------------------
+// The prefix is a magic word, so its case is not part of it.
+
+#[test]
+fn a_prefix_is_recognised_in_any_case() {
+    // What this exists to prevent: `handtype_south_15` declared no hand type
+    // at all, so the scenario had none — no levelling, no PBN tags, no rounds
+    // — and nothing said so, because a script with no hand types is legal.
+    let source = "
+handtype_a = hcp(south) <= 10
+HANDTYPE_b = hcp(south) >= 11 and hcp(south) <= 20
+HandType_c = hcp(south) >= 21
+condition 1
+";
+    assert_eq!(labels(source), vec!["a", "b", "c"]);
+}
+
+#[test]
+fn a_share_finds_its_type_whatever_case_either_is_written_in() {
+    let source = "
+handtype_a = hcp(south) <= 10
+HandType_b = hcp(south) >= 11
+HANDTYPE_A_share = 3
+condition 1
+";
+    assert_eq!(
+        hand_type_shares(&program(source)).unwrap(),
+        vec![3.0, 1.0],
+        "the share did not reach the type it names"
+    );
+}
+
+/// Two variables, one category. Refused rather than resolved: everything
+/// downstream identifies a category by its label — the PBN tag, the bar chart,
+/// the share lookup, `--interleave` — and two rows called `a` is not a thing to
+/// hand anybody.
+#[test]
+fn two_types_differing_only_in_case_are_refused() {
+    let source = "
+HandType_a = hcp(south) <= 10
+handtype_A = hcp(south) >= 21
+condition 1
+";
+    let err = leveling_types(&program(source)).unwrap_err();
+    assert!(err.contains("the same category"), "{err}");
+    assert!(err.contains("HandType_a"), "{err}");
+    assert!(err.contains("handtype_A"), "{err}");
+}
+
+/// The variable is still case-sensitive to refer to, as it is in dealer.exe,
+/// which resolves names with `strcmp`. Only the convention stopped caring.
+#[test]
+fn the_name_itself_is_still_case_sensitive() {
+    let matching = program(
+        "
+handtype_a = hcp(south) <= 10
+condition handtype_a
+",
+    );
+    assert!(dealer_parser::undefined_variables(&matching).is_empty());
+
+    let wrong = program(
+        "
+handtype_a = hcp(south) <= 10
+condition HandType_a
+",
+    );
+    assert_eq!(
+        dealer_parser::undefined_variables(&wrong),
+        vec!["HandType_a"]
+    );
+}

--- a/dealer-parser/syntaxes/dlr.tmLanguage.json
+++ b/dealer-parser/syntaxes/dlr.tmLanguage.json
@@ -204,11 +204,11 @@
       "patterns": [
         {
           "name": "support.type.leveling.share.dlr",
-          "match": "\\b(?:HandType|LevelType)[A-Za-z0-9_]*(?i:_Share)\\b"
+          "match": "\\b(?i:HandType|LevelType)[A-Za-z0-9_]*(?i:_Share)\\b"
         },
         {
           "name": "support.type.leveling.dlr",
-          "match": "\\b(?:HandType|LevelType)[A-Za-z0-9_]*\\b"
+          "match": "\\b(?i:HandType|LevelType)[A-Za-z0-9_]*\\b"
         },
         {
           "name": "support.type.leveling.dlr",

--- a/dealer-run/src/lib.rs
+++ b/dealer-run/src/lib.rs
@@ -549,6 +549,17 @@ impl<'a> RunAccumulator<'a> {
             produced: self.produced,
             generated,
             names: self.leveling_labels.clone(),
+            // As declared, which is what the generated block has to reference:
+            // the levelling decomposition when the script names one, the hand
+            // types otherwise.
+            variables: if self.level_type_names.is_empty() {
+                self.hand_type_names.iter().map(|n| n.to_string()).collect()
+            } else {
+                self.level_type_names
+                    .iter()
+                    .map(|n| n.to_string())
+                    .collect()
+            },
             counts: self.leveling_counts.clone(),
             prefix: self.leveling_prefix,
             groups: if self.joint.is_empty() {

--- a/dealer/tests/write_leveled.rs
+++ b/dealer/tests/write_leveled.rs
@@ -578,3 +578,64 @@ fn a_scenario_with_no_condition_at_all_is_refused() {
     assert_eq!(run.status, 1);
     assert!(run.stderr.contains("no condition"), "{}", run.stderr);
 }
+
+/// The prefix is a magic word matched without regard to case, so the block has
+/// to reference the variable the script *declares* rather than one built from
+/// the canonical spelling.
+///
+/// It used to build the name, which was true only of a scenario written the way
+/// the generator would have written it. A script declaring `handtype_south_15`
+/// got a block gating on a `HandType_south_15` that did not exist: the
+/// condition was false on every deal, the run produced nothing out of ten
+/// million, and every number in the summary above it looked right.
+#[test]
+fn the_block_references_the_variable_the_script_declares() {
+    const LOWER: &str = "\
+handtype_south_15 = hcp(south) == 15
+handtype_south_16 = hcp(south) == 16
+handtype_south_17 = hcp(south) == 17
+
+### BEGIN GENERATED LEVELING ###
+noLeveling = 1
+levelTheDeal = noLeveling
+### END GENERATED LEVELING ###
+
+condition hcp(south) >= 15 and hcp(south) <= 17 and levelTheDeal
+";
+    let run = level(LOWER, &[], "lowercase-prefix");
+    assert_eq!(run.status, 0, "{}", run.stderr);
+    let written = run.written.expect("a levelled scenario");
+    assert!(
+        written.contains("= handtype_south_15"),
+        "the block names a variable the script does not declare:\n{written}"
+    );
+    assert!(
+        !written.contains("HandType_south_15"),
+        "the block built the name instead of using it:\n{written}"
+    );
+
+    // And the proof that it matters: the levelled copy produces deals.
+    let path = temp("lowercase-runs", &written);
+    let output = Command::new(env!("CARGO_BIN_EXE_dealer"))
+        .args([
+            &path.display().to_string(),
+            "-q",
+            "-v",
+            "-p",
+            "20",
+            "-s",
+            "1",
+            "-g",
+            "200000",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("dealer should run");
+    let _ = std::fs::remove_file(&path);
+    let report = String::from_utf8_lossy(&output.stderr).into_owned()
+        + &String::from_utf8_lossy(&output.stdout);
+    assert!(
+        report.contains("Produced 20 hands"),
+        "the levelled copy produced nothing:\n{report}"
+    );
+}

--- a/docs/leveling-guide.md
+++ b/docs/leveling-guide.md
@@ -189,6 +189,20 @@ variable — so the types found are always reported back, in the statistics, in
 `--stats-json`, and in the browser's Hand types panel. **Check the count is the
 one you expected.**
 
+**Case does not matter in the prefix or the suffix.** `handtype_south_15`,
+`HANDTYPE_south_15` and `HandType_south_15` all declare the type `south_15`, and
+`_share` weights it as well as `_Share` does. The prefix is a magic word, and a
+name that differs only in case is not a name anybody meant to be different —
+`handtype_` used to declare no type at all, which meant no levelling, no PBN
+tags and no rounds, with nothing to say so because a script with no hand types
+is perfectly legal.
+
+**The variable itself is still case-sensitive**, as it is in dealer.exe, which
+resolves names with `strcmp`. Declare `handtype_a` and you refer to it as
+`handtype_a`; `HandType_a` is a different name, and an undefined one. Two types
+whose labels differ only in case are refused — they are one category, and
+everything downstream identifies a category by its label.
+
 Two rules the types have to obey: **no overlaps** (two types matching one deal
 is refused) and **no gaps** (for levelling they must cover every deal the
 scenario produces, or the keeps will not add up). Outside levelling an untyped

--- a/scripts/generate-tmlanguage.py
+++ b/scripts/generate-tmlanguage.py
@@ -148,15 +148,17 @@ def main():
     # the point of them, since a script using them still parses on BBO — so
     # nothing but this tells an author which names the engine acts on.
     #
-    # Prefixes are matched with regard to case and the share suffix without,
-    # because that is what dealer-level does: `handtype_12` is silently not a
-    # hand type, and colouring it as one would promise what the run will not keep.
+    # Prefix and suffix are both matched without regard to case, because that is
+    # what dealer-level does: `handtype_12` is a hand type, and colouring it as
+    # an ordinary variable would be the grammar disagreeing with the run. The
+    # variable is still case-sensitive to *refer* to, as it is in dealer.exe,
+    # which is a fact about the name rather than about the convention.
     prefixes = "|".join(lit(p) for p in (hand_prefix, level_prefix))
     g["repository"]["leveling"] = {"patterns": [
         {"name": "support.type.leveling.share.dlr",
-         "match": r"\b(?:%s)[A-Za-z0-9_]*(?i:%s)\b" % (prefixes, lit(share_suffix))},
+         "match": r"\b(?i:%s)[A-Za-z0-9_]*(?i:%s)\b" % (prefixes, lit(share_suffix))},
         {"name": "support.type.leveling.dlr",
-         "match": r"\b(?:%s)[A-Za-z0-9_]*\b" % prefixes},
+         "match": r"\b(?i:%s)[A-Za-z0-9_]*\b" % prefixes},
         {"name": "support.type.leveling.dlr",
          "match": r"\b(?:%s)\b" % "|".join(
              lit(w) for w in list(verdicts) + [no_leveling])},

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1050,9 +1050,11 @@ mod docs {
 /// its own constants out, for the same reason it hands out its vocabulary:
 /// a second copy in JavaScript would be a second copy to go stale.
 ///
-/// `hand_type_prefix` and `level_type_prefix` are matched with regard to case,
-/// as `dealer_level` matches them; `share_suffix` is not, as `dealer_level`
-/// does not. A highlighter that follows suit shows an author the difference.
+/// Prefixes and the share suffix are all matched without regard to case, as
+/// `dealer_level` matches them: the prefix is a magic word, and a name that
+/// differs only in case is not a name anybody meant to be different. The
+/// variable itself stays case-sensitive to refer to, as it is in dealer.exe,
+/// but that is a fact about the name rather than about the convention.
 #[derive(Serialize)]
 struct LevelingNames {
     hand_type_prefix: &'static str,

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -96,8 +96,6 @@
               @click="editorTab = 'leveled'"
             >Leveled</button>
           </div>
-          <span v-else></span>
-
           <!-- Ticks itself when a script names hand types, since that is the
                only thing levelling needs and the reason to want it. Untouched
                after that: turning it back off is a choice, and re-ticking it on
@@ -671,14 +669,19 @@ body {
    space-between so the middle is actually centred: with three flex items of
    unequal width it drifts, and it drifts differently depending on whether the
    tabs are there at all. */
+/* Flex rather than three fixed columns. It was `1fr auto 1fr` — tabs, one
+   centred checkbox, Run at the end — and a second checkbox made four items for
+   three columns, so Run wrapped onto a line of its own and took a line of
+   script with it. Wrapping is now the row's own decision, so everything shares
+   a line while there is room for it. */
 .run-row {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  display: flex;
+  flex-wrap: wrap;
   align-items: end;
-  gap: 10px;
+  gap: 6px 14px;
 }
-.run-row > .check { justify-self: center; }
-.run-row > .run { justify-self: end; }
+/* Run to the far right, whichever line it ends up on. */
+.run-row > .run { margin-left: auto; }
 
 .tabs { display: flex; gap: 2px; margin-bottom: -1px; }
 .tabs button {

--- a/web/src/lib/dlrLanguage.js
+++ b/web/src/lib/dlrLanguage.js
@@ -86,14 +86,20 @@ export function dlrStreamParser(info) {
   /**
    * Which levelling token, if any, a name earns.
    *
-   * Prefixes are matched with regard to case and the share suffix without,
-   * because that is what `dealer_level` does: `handtype_12` is not a hand type
-   * and will silently not be one, so it must not be coloured as though it were,
-   * while `HandType_12_share` is a share and is.
+   * Prefix and suffix are both matched without regard to case, because that is
+   * what `dealer_level` does: `handtype_12` is a hand type, and colouring it as
+   * an ordinary variable would be the highlighter disagreeing with the run.
+   *
+   * The variable is still case-sensitive to *refer* to, as it is in dealer.exe.
+   * That is a fact about the name, not about the convention, and nothing here
+   * could show it anyway.
    */
+  const hasPrefix = (name, prefix) =>
+    name.slice(0, prefix.length).toLowerCase() === prefix.toLowerCase()
+
   const levelingToken = (name) => {
     if (!level) return null
-    if (name.startsWith(level.hand_type_prefix) || name.startsWith(level.level_type_prefix)) {
+    if (hasPrefix(name, level.hand_type_prefix) || hasPrefix(name, level.level_type_prefix)) {
       // A share carries its type's prefix — a bare `foo_Share` weights nothing.
       const tail = name.slice(-level.share_suffix.length)
       const share =

--- a/web/src/lib/dlrLanguage.test.js
+++ b/web/src/lib/dlrLanguage.test.js
@@ -197,11 +197,21 @@ describe('the levelling conventions', () => {
     expect(tokenize('profit_Share = 3')[0][0]).toBe('variableName')
   })
 
-  it('respects the case the engine matches prefixes in', () => {
-    // `starts_with` is case-sensitive, so `handtype_12` is silently not a hand
-    // type. Colouring it as one would be the highlighter telling a lie the
-    // engine will not back up.
-    expect(tokenize('handtype_12 = 1')[0][0]).toBe('variableName')
+  it('marks a decomposition whatever case it is written in', () => {
+    // The prefix is a magic word, and a name differing only in case is not a
+    // name anybody meant to be different — `dealer_level` reads them all, so
+    // the highlighter has to as well or it would disagree with the run.
+    for (const name of ['handtype_12', 'HANDTYPE_12', 'HandType_12', 'leveltype_12']) {
+      expect(tokenize(`${name} = 1`)[0][0], name).toBe('levelingName')
+    }
+    expect(tokenize('handtype_12_SHARE = 2')[0][0]).toBe('levelingShare')
+  })
+
+  it('does not mistake a name that merely starts the same way', () => {
+    // `handtypes` is not `HandType_`-anything, and neither is a variable that
+    // happens to begin with those letters and carry on.
+    expect(tokenize('handy = 1')[0][0]).toBe('variableName')
+    expect(tokenize('level = 1')[0][0]).toBe('variableName')
   })
 
   it('marks the verdict and its placeholder', () => {


### PR DESCRIPTION
## What went wrong

`handtype_south_15` declared no hand type. The prefix was matched with `starts_with`, so a scenario written in lower case had **no categories at all** — no levelling, no PBN tags, no rounds — and nothing said so, because a script with no hand types is perfectly legal. The only symptom was Auto-level refusing to do anything.

## The rule now

`has_prefix` matches without regard to case, as the `_Share` suffix always has and for the same reason: a name that differs only in case is not a name anybody meant to be different. `handtype_`, `HANDTYPE_` and `HandType_` all declare a hand type.

**The variable itself is still case-sensitive**, as it is in dealer.exe — `scan.l:112` copies the identifier verbatim and `defs.y:464` resolves it with `strcmp`. Declare `handtype_a` and refer to `HandType_a` and you get an undefined variable, which is that check catching a real typo rather than a convention.

## Two things it refuses

**Two types whose labels match without regard to case.** Newly reachable, since `HandType_a` and `handtype_a` now both parse as types. Everything downstream identifies a category by its label — the PBN tag, the bar chart, the share lookup, `--interleave` — and two rows called `a` is not a thing to hand anybody. Share labels are matched the same way, which is unambiguous *because* of that refusal.

**A share of a type that does not exist**, as before.

## The bug this uncovered

Worth reading the diff for, and the reason this PR is bigger than a case fold.

The generated block built its variable names as `HandType_` + label — true only of a scenario written the way the generator would have written it. Given `handtype_south_15` it emitted:

```
level_south_15 = HandType_south_15 and roll < 577
```

gating on a variable that does not exist. False on every deal. **Ten million dealt, zero produced** — and every number in the summary above it correct, including the keeps, the acceptance and the precision.

The block now references the name the script declares, carried through `Measurement` and `LevelPlan` rather than rebuilt. That also fixes a separator written `-` instead of `_`, latent for the same reason, and `render_leveled` no longer needs the prefix parameter at all.

`dealer/tests/write_leveled.rs` gains a test that asserts both halves: the block names the declared variable, and the levelled copy actually produces its deals.

## Also

Both highlighters follow the engine — that is the whole point of generating them from its constants — so `handtype_12` now colours as a hand type in the browser and in VS Code. The PBS extension's copy of the grammar is regenerated in a companion commit over there.

A second commit here fixes the Run button, which a second checkbox had pushed onto a line of its own: the row was `1fr auto 1fr` and had four items for three columns. Flex with wrapping instead, so a line of that row stops costing a line of the editor.

## Verified

- 466 Rust tests (was 461), 128 web tests, 8 wasm cases, clippy clean
- The reported script, all lower case: before, `Generated 10000000 / Produced 0`; after, `Generated 79456 / Produced 30` with the block gating on `handtype_south_15`
- Grammar checked under real vscode-textmate: `handtype_x`, `HANDTYPE_x`, `HandType_x`, `leveltype_x` and `handtype_x_SHARE` all take the levelling scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)