### PR TITLE
Defaults for script parameters, and a way to enter them

### DIFF
--- a/dealer-parser/src/lib.rs
+++ b/dealer-parser/src/lib.rs
@@ -12,5 +12,5 @@ pub use parser::{
     condition_span, parse, parse_program, ParseError, MAX_COUNT_VALUES, NUM_COUNT_ROWS,
 };
 pub use preprocess::{preprocess, preprocess_all};
-pub use script_params::ScriptParams;
+pub use script_params::{script_parameters, ParamDecl, ScriptParam, ScriptParams};
 pub use undefined::{dangling_seats, undefined_variables};

--- a/dealer-parser/src/script_params.rs
+++ b/dealer-parser/src/script_params.rs
@@ -29,6 +29,35 @@
 //! it scans an empty buffer and vanishes: `average $2 controls(west)` quietly
 //! becomes a valid statement that has lost its label. `$` marks the spot too
 //! plainly for that — an unfilled parameter is refused.
+//!
+//! # What a script says about its own parameters
+//!
+//! Refusing an unfilled `$n` is right, and on its own it means a parameterised
+//! script cannot be run at all without knowing, from outside the file, which
+//! parameters it wants and what they should be. `NTscripted.dls` handed to
+//! someone without its invocation is unrunnable, and nothing in it says what
+//! `$3` was meant to be.
+//!
+//! So a script may declare its own:
+//!
+//! ```text
+//! # param 0 = west          # the seat that opens
+//! # param 1 = 15            # minimum HCP
+//! # param 4 = 5xxx + x5xx   # the shape responder shows
+//! ```
+//!
+//! A whole-line comment, because the declaration has to survive the trip to BBO
+//! and to the original dealer, whose lexers skip a `#` line entirely — the same
+//! reason the `HandType_` convention is a variable name rather than a keyword.
+//! The description is whatever follows a second `#`, an exact split rather than
+//! a run of spaces because `#` cannot appear inside a value the language would
+//! accept, where `5xxx + x5xx` is full of single spaces.
+//!
+//! The precedence is `--param` if given, else the declared default, else the
+//! error. Which makes the default documentation that cannot drift from the
+//! thing it documents, and gives a front end something to label a field with
+//! and somewhere to start it — `dealer --params` on the command line, fields
+//! beside the editor in the browser.
 
 /// What the command line supplied for `$0` to `$9`.
 #[derive(Debug, Default, Clone)]
@@ -64,36 +93,221 @@ impl ScriptParams {
 
     /// Which parameters were supplied but never mentioned by the script.
     pub fn unused(&self, source: &str) -> Vec<usize> {
+        let used = uses(source);
         (0..10)
-            .filter(|i| self.values[*i].is_some() && !mentions(source, *i))
+            .filter(|i| self.values[*i].is_some() && !used.iter().any(|(j, _)| j == i))
             .collect()
     }
 }
 
-/// Whether `$i` appears anywhere the substitution would reach.
-fn mentions(source: &str, index: usize) -> bool {
+/// One `# param N = VALUE` line: what the script itself says a parameter is.
+///
+/// A comment rather than syntax, because the declaration has to survive the
+/// trip to BBO and to the original dealer, whose lexers skip a `#` line whole.
+/// A syntax form would be cleaner to validate and would stop the script running
+/// anywhere else, which is the opposite of the point — a scenario that carries
+/// its own defaults is one you can hand to someone without the invocation that
+/// goes with it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParamDecl {
+    /// Which parameter, 0 to 9.
+    pub index: usize,
+    /// The source to put where `$n` stands when nothing else supplies it.
+    pub default: String,
+    /// What it is for, in the writer's words. Everything after the second `#`.
+    pub description: Option<String>,
+    /// The line the declaration is on, for an error that has to point at it.
+    pub line: usize,
+}
+
+/// A parameter a script has something to say about: one it uses, one it
+/// declares, or both.
+///
+/// This is what a front end needs to ask for the ones that are missing — the
+/// `$n` occurrences alone give it nowhere to put a label and no sensible
+/// starting value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptParam {
+    pub index: usize,
+    /// The declared default, if the script carries one.
+    pub default: Option<String>,
+    pub description: Option<String>,
+    /// Where the declaration is, if there is one.
+    pub declared_on: Option<usize>,
+    /// Where the parameter is first used. `None` means it is declared and never
+    /// mentioned, which is usually a typo in one or the other.
+    pub used_on: Option<usize>,
+}
+
+/// Every `# param n = ...` line the script carries, indexed by parameter.
+///
+/// Only a whole-line comment counts. A `#` after code on the same line is a
+/// remark about that line, and reading a declaration out of one would mean a
+/// script's behaviour depended on where a comment happened to sit.
+pub fn declarations(source: &str) -> Result<[Option<ParamDecl>; 10], String> {
+    let mut found: [Option<ParamDecl>; 10] = Default::default();
+    for (offset, raw) in source.lines().enumerate() {
+        let line = offset + 1;
+        let Some(rest) = pragma_body(raw) else {
+            continue;
+        };
+        let decl = parse_declaration(rest, line, raw)?;
+        if let Some(first) = &found[decl.index] {
+            return Err(format!(
+                "`${}` is declared twice, on lines {} and {}. Leave one.",
+                decl.index, first.line, decl.line
+            ));
+        }
+        let index = decl.index;
+        found[index] = Some(decl);
+    }
+    Ok(found)
+}
+
+/// What follows `param` on a declaration line, or `None` if this is not one.
+///
+/// `param` is a magic word, so its case is not part of it. Three things keep an
+/// ordinary comment from becoming a declaration, and they matter more than they
+/// look — a comment misread as a malformed declaration is a hard error, on a
+/// line whose author never meant to declare anything:
+///
+/// - the word ends there, so `parameters` is not it, or documenting the feature
+///   inside a script would change what the script does;
+/// - a number follows it, so the `# Param: ...` and `# alias: ...` headers the
+///   Practice-Bidding-Scenarios corpus carries stay comments;
+/// - and the whole line is the comment, checked by the caller, because a `#`
+///   after code is a remark about that line.
+///
+/// Past those it *is* a declaration, and anything wrong with it is reported
+/// rather than skipped: silently ignoring `# param 0 west` is how a script ends
+/// up unrunnable with a line in it that looks as though it should have worked.
+fn pragma_body(raw: &str) -> Option<&str> {
+    let trimmed = raw.trim_start();
+    let body = trimmed
+        .strip_prefix('#')
+        .or_else(|| trimmed.strip_prefix("//"))?
+        .trim_start();
+    if !body.get(..5)?.eq_ignore_ascii_case("param") {
+        return None;
+    }
+    let rest = &body[5..];
+    // Whitespace, then the parameter number, written `$3` or `3`.
+    let after_word = rest.strip_prefix(|c: char| c.is_whitespace())?.trim_start();
+    let digits = after_word.strip_prefix('$').unwrap_or(after_word);
+    digits
+        .starts_with(|c: char| c.is_ascii_digit())
+        .then_some(rest)
+}
+
+fn parse_declaration(rest: &str, line: usize, raw: &str) -> Result<ParamDecl, String> {
+    let complain = |what: &str| {
+        format!(
+            "{what}, on line {line}:\n       {}\n       \
+             A declaration reads `# param 1 = 15 # minimum HCP`: the number, `=`, the \
+             source to stand in for `$1`, and anything after a second `#` as its \
+             description.",
+            raw.trim()
+        )
+    };
+
+    let (head, value) = rest
+        .split_once('=')
+        .ok_or_else(|| complain("a parameter declaration needs an `=`"))?;
+    let head = head.trim().strip_prefix('$').unwrap_or(head.trim());
+    let index: usize = head
+        .parse()
+        .map_err(|_| complain(&format!("`{head}` is not a parameter number")))?;
+    if index > 9 {
+        return Err(complain(&format!(
+            "there is no `${index}`; script parameters run from 0 to 9"
+        )));
+    }
+
+    // The description is whatever follows a second `#`. An exact split rather
+    // than a run of spaces: `#` cannot appear inside a value the language would
+    // accept, where a value like `5xxx + x5xx` is full of single spaces and a
+    // gap rule would have to guess which one ended it.
+    let (default, description) = match value.split_once('#') {
+        Some((v, d)) => (v.trim(), Some(d.trim())),
+        None => (value.trim(), None),
+    };
+    if default.is_empty() {
+        return Err(complain(&format!("`${index}` is declared with no default")));
+    }
+
+    Ok(ParamDecl {
+        index,
+        default: default.to_string(),
+        description: description.filter(|d| !d.is_empty()).map(|d| d.to_string()),
+        line,
+    })
+}
+
+/// Every `$n` the substitution would reach, as `(index, line)`, in order.
+fn uses(source: &str) -> Vec<(usize, usize)> {
     let chars: Vec<char> = source.chars().collect();
+    let mut out = Vec::new();
     let mut at = 0;
+    let mut line = 1;
     while at < chars.len() {
         if let Some(end) = crate::fdshape::skippable(&chars, at) {
+            line += chars[at..end].iter().filter(|c| **c == '\n').count();
             at = end;
             continue;
         }
-        if chars[at] == '$' && chars.get(at + 1) == Some(&char::from(b'0' + index as u8)) {
-            return true;
+        if chars[at] == '\n' {
+            line += 1;
+        } else if chars[at] == '$' {
+            if let Some(digit) = chars.get(at + 1).and_then(|c| c.to_digit(10)) {
+                out.push((digit as usize, line));
+                at += 2;
+                continue;
+            }
         }
         at += 1;
     }
-    false
+    out
 }
 
-/// Replace every `$0`-`$9` with the text the command line gave for it.
+/// What a script wants filled in, ordered by parameter number.
+///
+/// Both halves of it: the parameters it uses, so a front end knows what to ask
+/// for, and the ones it only declares, so a declaration that has lost its `$n`
+/// to an edit is visible rather than silently doing nothing.
+pub fn script_parameters(source: &str) -> Result<Vec<ScriptParam>, String> {
+    let declared = declarations(source)?;
+    let used = uses(source);
+    Ok((0..10)
+        .filter_map(|index| {
+            let decl = declared[index].as_ref();
+            let used_on = used.iter().find(|(i, _)| *i == index).map(|(_, l)| *l);
+            if decl.is_none() && used_on.is_none() {
+                return None;
+            }
+            Some(ScriptParam {
+                index,
+                default: decl.map(|d| d.default.clone()),
+                description: decl.and_then(|d| d.description.clone()),
+                declared_on: decl.map(|d| d.line),
+                used_on,
+            })
+        })
+        .collect())
+}
+
+/// Replace every `$0`-`$9` with the text standing behind it.
+///
+/// `--param` first, then the script's own `# param n = ...` declaration, and
+/// only then the error — so a script carrying its own defaults runs with no
+/// switches at all, and one switch overrides one default without disturbing the
+/// rest.
 ///
 /// Comments and quoted strings are stepped over, as the reference's lexer does:
 /// its `{qstring}` rule matches the whole string before `{scriptvar}` ever sees
 /// the `$`, which is why its own example has to pass a parameter *including*
 /// the quotes to get a string in — `-2 '"Controls West > 15 hcp"'`.
 pub fn substitute(source: &str, params: &ScriptParams) -> Result<String, String> {
+    let declared = declarations(source)?;
     let chars: Vec<char> = source.chars().collect();
     let mut out = String::with_capacity(source.len());
     let mut at = 0;
@@ -115,11 +329,16 @@ pub fn substitute(source: &str, params: &ScriptParams) -> Result<String, String>
             ));
         };
         let index = digit as usize;
-        let Some(value) = &params.values[index] else {
+        let value = params.values[index]
+            .as_deref()
+            .or(declared[index].as_ref().map(|d| d.default.as_str()));
+        let Some(value) = value else {
             return Err(format!(
                 "the script uses `${index}` and nothing supplies it{}\n       \
                  Pass it on the command line: --param {index}=<text>. DealerV2_4 spells \
-                 this `-{index} <text>`, which is dealer.exe's swapping switch here.",
+                 this `-{index} <text>`, which is dealer.exe's swapping switch here.\n       \
+                 Or give the script its own default, so it runs without one: \
+                 `# param {index} = <text>  # what it means`.",
                 near(&chars, at)
             ));
         };
@@ -226,6 +445,156 @@ mod tests {
         assert!(p.set("10=west").is_err());
         assert!(p.set("1=west").is_ok());
         assert!(p.set("1=east").is_err(), "twice over is a mistake");
+    }
+
+    #[test]
+    fn a_script_can_carry_its_own_defaults() {
+        // The point of the whole thing: no switches, and it still runs.
+        let script = "# param 0 = west   # the seat that opens\n\
+                      # param 1 = 15     # minimum HCP\n\
+                      condition hcp($0) >= $1\n";
+        assert_eq!(
+            substitute(script, &params(&[])).expect("the script supplies them"),
+            "# param 0 = west   # the seat that opens\n\
+             # param 1 = 15     # minimum HCP\n\
+             condition hcp(west) >= 15\n"
+        );
+    }
+
+    #[test]
+    fn a_switch_beats_a_declared_default() {
+        // And overriding one leaves the others alone, which is what makes a
+        // declared default usable as a starting point rather than all or
+        // nothing.
+        let script = "# param 0 = west  # the seat\n\
+                      # param 1 = 15    # minimum\n\
+                      condition hcp($0) >= $1\n";
+        let filled = substitute(script, &params(&["1=20"])).expect("substitutes");
+        assert!(
+            filled.ends_with("condition hcp(west) >= 20\n"),
+            "got: {filled}"
+        );
+    }
+
+    #[test]
+    fn a_declaration_is_read_from_either_comment_marker() {
+        for marker in ["#", "//"] {
+            let script = format!("{marker} PARAM $3 = north\ncondition hcp($3) > 1\n");
+            let filled = substitute(&script, &params(&[])).expect("substitutes");
+            assert!(
+                filled.ends_with("condition hcp(north) > 1\n"),
+                "got: {filled}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_default_may_be_a_shape_full_of_spaces() {
+        // Why the description is split on `#` rather than on a run of spaces:
+        // this value has three of them and none of them ends it.
+        let decls =
+            declarations("# param 4 = 5xxx + x5xx   # what responder shows\n").expect("declares");
+        let four = decls[4].as_ref().expect("$4");
+        assert_eq!(four.default, "5xxx + x5xx");
+        assert_eq!(four.description.as_deref(), Some("what responder shows"));
+    }
+
+    #[test]
+    fn a_declaration_without_a_description_is_still_a_declaration() {
+        let decls = declarations("# param 2 = 14\n").expect("declares");
+        let two = decls[2].as_ref().expect("$2");
+        assert_eq!(two.default, "14");
+        assert_eq!(two.description, None);
+        assert_eq!(two.line, 1);
+    }
+
+    #[test]
+    fn prose_about_parameters_is_not_a_declaration() {
+        // `param` is a magic word, but a comment that merely starts with a
+        // longer word beginning `param` is not one — otherwise documenting the
+        // feature inside a script would change what the script does.
+        for line in [
+            "# parameters are filled with --param\n",
+            "# params: see the reference\n",
+            // A number is what makes it a declaration, so the `# Param: ...`
+            // headers the Practice-Bidding-Scenarios corpus carries stay
+            // comments. A declaration is refused when malformed, and refusing
+            // one of these would stop a script that never meant to declare
+            // anything.
+            "# Param: the seat that opens\n",
+            "# param x = west\n",
+            "condition hcp(north) > 1 # param 0 = west\n",
+        ] {
+            let script = format!("{line}condition 1\n");
+            let decls = declarations(&script).expect("no declarations");
+            assert!(decls.iter().all(Option::is_none), "in: {line}");
+        }
+    }
+
+    #[test]
+    fn a_malformed_declaration_is_refused_rather_than_ignored() {
+        // Silently skipping these is how a script ends up unrunnable with a
+        // line in it that looks like it should have worked.
+        for source in [
+            "# param 0 west\n",    // no `=`
+            "# param 12 = west\n", // out of range
+            "# param 0 =\n",       // nothing to stand in
+            "# param 0 =   # only a description\n",
+        ] {
+            let err = declarations(source).expect_err("should refuse");
+            assert!(err.contains("line 1"), "should point at it: {err}");
+            assert!(
+                err.contains("`# param 1 = 15"),
+                "should show the form: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn declaring_the_same_parameter_twice_is_refused() {
+        let err = declarations("# param 0 = west\n# param 0 = east\n").expect_err("refuses");
+        assert!(err.contains("lines 1 and 2"), "got: {err}");
+    }
+
+    #[test]
+    fn an_unfilled_parameter_says_both_ways_to_fill_it() {
+        let err = substitute("condition hcp($0) > 1\n", &params(&[])).expect_err("refuses");
+        assert!(err.contains("--param 0="), "the switch: {err}");
+        assert!(err.contains("# param 0 ="), "the declaration: {err}");
+    }
+
+    #[test]
+    fn what_a_script_wants_is_reported_for_a_front_end() {
+        let script = "# param 0 = west   # the seat that opens\n\
+                      # param 7 = north  # left over from an edit\n\
+                      condition hcp($0) >= $1\n";
+        let wanted = script_parameters(script).expect("reads");
+        assert_eq!(wanted.len(), 3);
+
+        // Declared and used.
+        assert_eq!(wanted[0].index, 0);
+        assert_eq!(wanted[0].default.as_deref(), Some("west"));
+        assert_eq!(
+            wanted[0].description.as_deref(),
+            Some("the seat that opens")
+        );
+        assert_eq!(wanted[0].declared_on, Some(1));
+        assert_eq!(wanted[0].used_on, Some(3));
+
+        // Used and undeclared: what a front end has to ask for.
+        assert_eq!(wanted[1].index, 1);
+        assert_eq!(wanted[1].default, None);
+        assert_eq!(wanted[1].used_on, Some(3));
+
+        // Declared and never used: a declaration that has lost its `$7`.
+        assert_eq!(wanted[2].index, 7);
+        assert_eq!(wanted[2].used_on, None);
+    }
+
+    #[test]
+    fn a_use_inside_a_comment_is_not_a_use() {
+        let wanted = script_parameters("# $3 was here\ncondition 1\n").expect("reads");
+        assert!(wanted.is_empty(), "got: {wanted:?}");
     }
 
     #[test]

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -222,6 +222,15 @@ struct Args {
     #[arg(long = "param", value_name = "N=TEXT")]
     param: Vec<String>,
 
+    /// List the script parameters and their declared defaults, without running
+    ///
+    /// A parameterised script is unrunnable without knowing what it wants, so
+    /// this reads the script and stops: every `$n` it uses, the default its
+    /// `# param n = ...` line declares, and what that line says it is for. With
+    /// `--stats-json`, the same thing as JSON for a build script to fill in.
+    #[arg(long = "params")]
+    params: bool,
+
     /// Report the statistics as JSON instead of tables, for a tool to read
     ///
     /// Use with `-q` for a stdout that is nothing but JSON. The per-average
@@ -691,6 +700,125 @@ fn leveling_summary(levelling: &dealer_run::LevelingReport) -> String {
     out
 }
 
+/// What `--params` prints: everything the script says about its own `$n`.
+///
+/// A parameterised script handed on without its invocation is unrunnable, and
+/// the `$n` occurrences alone say nothing about what they were meant to be. So
+/// this is the declared default beside the use, with a line number for a
+/// parameter that has one and neither.
+///
+/// JSON on request, because the same information is what a build script needs
+/// to fill the parameters programmatically, and parsing the columns back out
+/// would be its own small tragedy.
+fn report_parameters(script: &str, file: Option<&str>, as_json: bool) -> Result<String, String> {
+    let wanted = dealer_parser::script_parameters(script)?;
+
+    if as_json {
+        let rows: Vec<String> = wanted
+            .iter()
+            .map(|p| {
+                let quoted = |value: &Option<String>| match value {
+                    Some(text) => json_string(text),
+                    None => "null".to_string(),
+                };
+                let line = |value: Option<usize>| match value {
+                    Some(n) => n.to_string(),
+                    None => "null".to_string(),
+                };
+                format!(
+                    "    {{\"index\": {}, \"default\": {}, \"description\": {}, \
+                     \"declared_on\": {}, \"used_on\": {}}}",
+                    p.index,
+                    quoted(&p.default),
+                    quoted(&p.description),
+                    line(p.declared_on),
+                    line(p.used_on)
+                )
+            })
+            .collect();
+        return Ok(format!(
+            "{{\n  \"params\": [\n{}\n  ]\n}}\n",
+            rows.join(",\n")
+        ));
+    }
+
+    if wanted.is_empty() {
+        return Ok(match file {
+            Some(name) => format!("{} uses no script parameters.\n", name),
+            None => "This script uses no parameters.\n".to_string(),
+        });
+    }
+
+    // The default column is as wide as the widest default, so the descriptions
+    // line up and the whole thing reads as a table rather than as a list.
+    let width = wanted
+        .iter()
+        .map(|p| p.default.as_deref().unwrap_or(NO_DEFAULT).chars().count())
+        .max()
+        .unwrap_or(0);
+
+    let mut out = match file {
+        Some(name) => format!("Script parameters of {}:\n\n", name),
+        None => "Script parameters:\n\n".to_string(),
+    };
+    let mut missing = Vec::new();
+    for param in &wanted {
+        let value = param.default.as_deref().unwrap_or(NO_DEFAULT);
+        let note = match (param.used_on, param.declared_on) {
+            // Declared and never mentioned: usually a `$7` lost to an edit, and
+            // invisible without saying so, since nothing fails.
+            (None, Some(line)) => format!("declared on line {} and never used", line),
+            _ => param.description.clone().unwrap_or_default(),
+        };
+        out.push_str(&format!(
+            "  ${}  {:width$}",
+            param.index,
+            value,
+            width = width
+        ));
+        if !note.is_empty() {
+            out.push_str("  ");
+            out.push_str(&note);
+        }
+        out.push('\n');
+        if param.default.is_none() && param.used_on.is_some() {
+            missing.push(param.index);
+        }
+    }
+
+    out.push('\n');
+    if missing.is_empty() {
+        out.push_str("Every parameter has a default, so the script runs as it stands.\n");
+    } else {
+        out.push_str(&format!(
+            "Nothing supplies {}, so the script will not run until something does:\n  {}\n\
+             Or declare a default in the script, so it runs on its own and on BBO:\n  \
+             # param {} = <text>  # what it means\n",
+            and_list(&missing),
+            missing
+                .iter()
+                .map(|i| format!("--param {}=<text>", i))
+                .collect::<Vec<_>>()
+                .join(" "),
+            missing[0],
+        ));
+    }
+    Ok(out)
+}
+
+/// Stands in the default column for a parameter that has none.
+const NO_DEFAULT: &str = "(none)";
+
+/// `$1`, `$1 and $4`, `$1, $4 and $7`.
+fn and_list(indexes: &[usize]) -> String {
+    let names: Vec<String> = indexes.iter().map(|i| format!("${}", i)).collect();
+    match names.split_last() {
+        None => String::new(),
+        Some((last, [])) => last.clone(),
+        Some((last, rest)) => format!("{} and {}", rest.join(", "), last),
+    }
+}
+
 fn main() {
     let args = Args::parse();
 
@@ -857,6 +985,21 @@ fn main() {
     let untrimmed = constraint_str.clone();
     let constraint_str = constraint_str.trim();
 
+    // Answer "what does this script want?" and stop. Before the levelling
+    // preparation below, because it is a question about the file as written.
+    if args.params {
+        match report_parameters(constraint_str, args.input_file.as_deref(), args.stats_json) {
+            Ok(report) => {
+                print!("{}", report);
+                std::process::exit(0);
+            }
+            Err(message) => {
+                eprintln!("Error: {}", message);
+                std::process::exit(1);
+            }
+        }
+    }
+
     // Refuse a scenario that cannot receive a levelling block before dealing
     // anything: measuring is a hundred thousand deals, and none of it is worth
     // doing if the answer has nowhere to go.
@@ -935,6 +1078,19 @@ fn main() {
                 "Warning: --param {} was given and the script never mentions `${}`",
                 index, index
             );
+        }
+        // The mirror of the warning above: a `# param 7 = ...` line whose `$7`
+        // an edit took away does nothing at all, and nothing else would say so.
+        // A malformed declaration is not reported here: `preprocess_all` below
+        // fails on it with the same message, rather than this saying it twice.
+        if let Ok(wanted) = dealer_parser::script_parameters(constraint_str) {
+            for param in wanted.iter().filter(|p| p.used_on.is_none()) {
+                eprintln!(
+                    "Warning: line {} declares `${}` and the script never mentions it",
+                    param.declared_on.unwrap_or(0),
+                    param.index
+                );
+            }
         }
         let preprocessed = match dealer_parser::preprocess_all(constraint_str, &params) {
             Ok(text) => text,

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -112,22 +112,6 @@ pub const REMAINING: &[WorkItem] = &[
     // DealerV2_4's own words, from reading its lexer and yacc rather than a
     // summary of them, and measured against its 61-script Regression suite.
     WorkItem {
-        what: "Defaults for script parameters, and a way to enter them",
-        done_when: None,
-        issue: Some(17),
-        effort: Effort::Medium,
-        value: Value::Medium,
-        note: Some(
-            "A `$n` nothing supplies is an error naming the line, which is right — \
-             DealerV2_4 scans an empty buffer instead, so `average $2 controls(west)` \
-             quietly loses its label. But it also means a parameterised script cannot run \
-             at all without the invocation that goes with it, and nothing in the file says \
-             what `$3` was meant to be. The browser has no way to supply one, so such a \
-             scenario fails to parse there on a line the reader cannot act on. A default \
-             would have to survive the trip to BBO, so a comment pragma rather than syntax.",
-        ),
-    },
-    WorkItem {
         what: "`printns` and `printside(side)`",
         done_when: None,
         issue: None,

--- a/dealer/src/switches.rs
+++ b/dealer/src/switches.rs
@@ -242,7 +242,24 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
              so only the switch differs — a script written for it is unchanged. A parameter \
              is source rather than a value: a compass, a number, a shape, even a function \
              name, so `$9($0)` with `--param 9=hcp --param 0=west` is `hcp(west)`. Unlike \
-             DealerV2_4, a `$n` nothing supplies is an error rather than an empty space.",
+             DealerV2_4, a `$n` nothing supplies is an error rather than an empty space — \
+             unless the script declares its own default with a `# param 1 = 15` comment, \
+             which takes effect when no switch overrides it.",
+        ),
+    },
+    SwitchRow {
+        short: "",
+        long: "--params",
+        group: "Reporting",
+        what: "List the script parameters and their declared defaults, without running",
+        dealer_exe: Origin::Absent,
+        dealer_v2: Origin::Absent,
+        note: Some(
+            "A parameterised script handed on without the invocation that goes with it is \
+             otherwise unrunnable: nothing in the file says what `$3` was meant to be. This \
+             reads the script and stops, listing every `$n` it uses, the default its \
+             `# param n = ...` line declares and what that line says it is for. With \
+             `--stats-json`, the same as JSON for a build script to fill in.",
         ),
     },
     SwitchRow {

--- a/dealer/tests/script_statements.rs
+++ b/dealer/tests/script_statements.rs
@@ -198,6 +198,101 @@ fn a_parameter_fills_a_shape_before_it_is_expanded() {
 }
 
 #[test]
+fn a_script_carrying_its_own_defaults_runs_with_no_switches() {
+    // The whole point of the declaration: NTscripted.dls handed to someone
+    // without the invocation that goes with it used to be unrunnable, and
+    // nothing in the file said what `$1` was meant to be.
+    let script = "\
+# param 0 = west   # the seat that opens
+# param 1 = 12     # minimum HCP
+# param 2 = 14     # maximum HCP
+# param 9 = hcp    # how strength is counted
+NTshape = shape($0, any 4333 + any 4432 + any 5332 - 5xxx - x5xx)
+condition NTshape and ($9($0) >= $1) and ($9($0) <= $2)
+action printoneline
+";
+    let (out, err, status) = run(&["-p", "20", "-g", "3000000", "-s", "1"], script);
+    assert_eq!(status, 0, "stderr was: {err}");
+    assert_eq!(out.lines().count(), 20);
+
+    // And a switch still wins, one parameter at a time: this is the same
+    // script asking for the strong notrump instead.
+    let (stronger, err, status) = run(
+        &[
+            "-p", "20", "-g", "3000000", "-s", "1", "--param", "1=15", "--param", "2=17",
+        ],
+        script,
+    );
+    assert_eq!(status, 0, "stderr was: {err}");
+    assert_eq!(stronger.lines().count(), 20);
+    assert_ne!(out, stronger);
+}
+
+#[test]
+fn params_lists_what_a_script_wants_without_running_it() {
+    let (out, err, status) = run(
+        &["--params"],
+        "# param 0 = west   # the seat that opens\ncondition hcp($0) >= $1\naction printoneline\n",
+    );
+    assert_eq!(status, 0, "stderr was: {err}");
+    assert!(out.contains("$0"), "stdout was: {out}");
+    assert!(out.contains("west"), "the declared default: {out}");
+    assert!(
+        out.contains("the seat that opens"),
+        "the description: {out}"
+    );
+    // `$1` is used and undeclared, which is the thing a caller has to supply.
+    assert!(out.contains("$1"), "stdout was: {out}");
+    assert!(out.contains("--param 1="), "should say how: {out}");
+    // Listing is not running.
+    assert!(!out.contains(" n "), "should not have dealt: {out}");
+}
+
+#[test]
+fn params_reports_as_json_for_a_tool() {
+    let (out, err, status) = run(
+        &["--params", "--stats-json"],
+        "# param 0 = west  # the seat\ncondition hcp($0) >= $1\n",
+    );
+    assert_eq!(status, 0, "stderr was: {err}");
+    let json: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+    let params = json["params"].as_array().expect("an array");
+    assert_eq!(params.len(), 2);
+    assert_eq!(params[0]["index"], 0);
+    assert_eq!(params[0]["default"], "west");
+    assert_eq!(params[0]["description"], "the seat");
+    assert_eq!(params[1]["index"], 1);
+    assert!(params[1]["default"].is_null(), "nothing declares `$1`");
+}
+
+#[test]
+fn a_declaration_nothing_uses_is_a_warning_not_an_error() {
+    // The mirror of `a_parameter_nothing_uses_is_a_warning_not_an_error`: a
+    // declaration whose `$7` an edit took away does nothing, and without this
+    // nothing would say so.
+    let (out, err, status) = run(
+        &["-p", "1", "-s", "1"],
+        "# param 7 = north  # left over from an edit\ncondition hcp(north) >= 10\n\
+         action printoneline\n",
+    );
+    assert_eq!(status, 0, "stderr was: {err}");
+    assert!(err.contains("declares `$7`"), "stderr was: {err}");
+    assert_eq!(out.lines().count(), 1);
+}
+
+#[test]
+fn a_malformed_declaration_is_refused() {
+    // Skipping it silently is how a script ends up unrunnable with a line in it
+    // that looks as though it should have worked.
+    let (_, err, status) = run(
+        &["-p", "1", "-s", "1"],
+        "# param 0 west\ncondition hcp($0) >= 10\n",
+    );
+    assert_eq!(status, 1);
+    assert!(err.contains("line 1"), "should point at it: {err}");
+}
+
+#[test]
 fn a_malformed_parameter_is_refused() {
     for spec in ["west", "x=west", "10=west"] {
         let (_, err, status) = run(&["-p", "1", "-s", "1", "--param", spec], "condition 1\n");

--- a/docs/FILTER_LANGUAGE_STATUS.md
+++ b/docs/FILTER_LANGUAGE_STATUS.md
@@ -244,6 +244,46 @@ writing the call out longhand in several places, or asking about several
 denominations, costs one search each however it is spelled and wherever it
 appears.
 
+## Script parameters
+
+`$0` to `$9` are **filled in as text before the script is parsed**, which is the
+opposite of a variable: a parameter is a piece of source, so it can be a number,
+a compass, a shape, or even a function name. DealerV2_4's own `NTscripted.dls`
+is one script for both notrump ranges and either side of the table:
+
+```
+NTshape = shape($0, any 4333 + any 4432 + any 5332 - 5xxx - x5xx)
+condition NTshape && ($9($0) >= $1) && ($9($0) <= $2)
+```
+
+where `$9($0)` becomes `hcp(west)`. The substitution runs before the
+`shape{...}` expander, so a parameter may stand inside one.
+
+Three ways to supply one, in this order:
+
+1. `--param 1=west` on the command line, or the field beside the editor in the
+   browser. DealerV2_4 spells this `-1 west`; those letters are dealer.exe's
+   swapping switches here, so only the switch differs — the script is unchanged.
+2. The script's own declaration, in a whole-line comment:
+
+   ```
+   # param 0 = west          # the seat that opens
+   # param 1 = 15            # minimum HCP
+   # param 4 = 5xxx + x5xx   # the shape responder shows
+   ```
+
+   The value runs to a second `#`, and anything after that is a description of
+   what the parameter is for. A comment, not syntax, so the script still runs on
+   BBO and on the original dealer, whose lexers skip the line entirely.
+3. Nothing, which is an error naming the line. DealerV2_4 scans an empty buffer
+   instead, so `average $2 controls(west)` there quietly becomes a valid
+   statement that has lost its label.
+
+`dealer --params script.dlr` lists what a script wants, its defaults and its
+descriptions, without running it; with `--stats-json` the same as JSON. The
+browser reads the same declarations to label its fields and to start them at the
+declared values.
+
 ## Comments
 
 `#` and `//` to end of line, `/* */` across lines. A `# key: value` line at the

--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -49,8 +49,9 @@ cover this build too: it is the same generator.
 
 | Export | Returns | Notes |
 |---|---|---|
-| `generate(script, seed, produce, max_generate, format)` | JSON | `format` is `"oneline"` or `"printall"` |
-| `check_script(script)` | JSON | Never throws — safe to call per keystroke |
+| `generate(script, seed, produce, max_generate, format, auto_level, round_robin, params, on_progress)` | JSON | `format` is `"oneline"`, `"printall"` or `"pbn"`; `params` fills `$0`-`$9` |
+| `check_script(script, params)` | JSON | Never throws — safe to call per keystroke |
+| `script_params(script)` | JSON | What the script says about its own `$0`-`$9` |
 | `language_info()` | JSON | Full vocabulary for completion and hover |
 | `version()` | string | Engine version |
 
@@ -117,6 +118,35 @@ Statistics still accumulate over every matching deal, so `produced` can exceed
 Returns JSON rather than throwing, so an editor can call it on every keystroke.
 Line and column come from the parser itself, so editor diagnostics agree with the
 engine by construction — not by regex approximation.
+
+### `script_params`
+
+```json
+{
+  "ok": true,
+  "error": null,
+  "params": [
+    {"index": 0, "default": "west", "description": "the seat that opens",
+     "declared_on": 1, "used_on": 4},
+    {"index": 1, "default": null, "description": null,
+     "declared_on": null, "used_on": 4}
+  ]
+}
+```
+
+Every parameter the script uses, declares, or both — ordered by number. This is
+what lets a page ask for the ones it needs: the `$n` occurrences alone give it
+nowhere to put a label and no starting value, which is what a script's own
+`# param 0 = west   # the seat that opens` line supplies.
+
+`default` is `null` where nothing declares one, and that parameter must be
+supplied or the run fails. `used_on` is `null` for a declaration the script never
+mentions — harmless, but usually a `$7` lost to an edit, so worth showing.
+
+Parameters reach `generate` and `check_script` as `--param`'s own `N=TEXT`
+strings, so a value copied out of a browser field pastes straight into a
+terminal. A parameter left out falls back to the script's declared default.
+`ok` is false only for a malformed declaration line.
 
 ### `language_info`
 

--- a/docs/command_line_comparison.md
+++ b/docs/command_line_comparison.md
@@ -24,7 +24,7 @@ UPDATE_DOCS=1 cargo test -p dealer
 
 <!-- BEGIN GENERATED: switches -->
 
-dealer3 implements **37 of the 48 switches** listed here. The dealer3 column is read from the argument parser itself, so it cannot drift; the other two columns are reference data (see `dealer/src/switches.rs` for their provenance).
+dealer3 implements **38 of the 49 switches** listed here. The dealer3 column is read from the argument parser itself, so it cannot drift; the other two columns are reference data (see `dealer/src/switches.rs` for their provenance).
 
 In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed and then refused with an explanation, so a script using it gets told rather than ignored. In the other two columns ✅ means the same meaning, ⚠️ a different one, and — not present at all.
 
@@ -43,7 +43,7 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 | `--level-budget` | Budget when levelling, in deals dealt per deal kept | ✅ | — | — | When a target costs more than this, exactness is relaxed rather than the rarest type sacrificed: every type moves the same fraction toward its target. |
 | `--level-measure` | Most deals to produce while characterizing a scenario | ✅ | — | — | A ceiling, not a target: measuring stops as soon as the rarest hand type has been seen enough times to divide by, which is what sets the precision of the whole levelling. How many deals that takes depends on how rare that type is — ten thousand for one at 5% of qualifying deals, a million for one at 0.2% — so it is worked out rather than chosen. |
 | `--level-timeout` | Seconds to spend characterizing a scenario before giving up | ✅ | — | — | Reaching it is not an error: the levelling is written with whatever was measured, and the shortfall is reported and stamped into the file. |
-| `--param` | Fill a script parameter: `--param 1=west` puts `west` where `$1` stands | ✅ | — | ⚠️ -0 to -9 set $0 to $9 | DealerV2_4's spelling collides with dealer.exe's swapping switches, which win, so only the switch differs — a script written for it is unchanged. A parameter is source rather than a value: a compass, a number, a shape, even a function name, so `$9($0)` with `--param 9=hcp --param 0=west` is `hcp(west)`. Unlike DealerV2_4, a `$n` nothing supplies is an error rather than an empty space. |
+| `--param` | Fill a script parameter: `--param 1=west` puts `west` where `$1` stands | ✅ | — | ⚠️ -0 to -9 set $0 to $9 | DealerV2_4's spelling collides with dealer.exe's swapping switches, which win, so only the switch differs — a script written for it is unchanged. A parameter is source rather than a value: a compass, a number, a shape, even a function name, so `$9($0)` with `--param 9=hcp --param 0=west` is `hcp(west)`. Unlike DealerV2_4, a `$n` nothing supplies is an error rather than an empty space — unless the script declares its own default with a `# param 1 = 15` comment, which takes effect when no switch overrides it. |
 | `--rnd-seed` | Shift the stream `rnd()` draws from | ✅ | — | — | `rnd()` is reproducible without it. The original draws from the generator it shuffles with, so calling it there changes the deals; dealer3 keeps the two apart. |
 | `-0` | No swapping (the default) | ✅ | ✅ | ⚠️ -x MODE | The three swapping switches override one another, so the last one wins. |
 | `-2` | Two-way swapping: deal each shuffle again with East and West exchanged | ✅ | ✅ | ⚠️ -x MODE | Refused alongside a predeal to East or West, which it would move. The original allows it and loses the predealt cards without saying so. |
@@ -79,6 +79,7 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 
 | Switch | What it does | dealer3 | dealer.exe | DealerV2_4 | Notes |
 |---|---|---|---|---|---|
+| `--params` | List the script parameters and their declared defaults, without running | ✅ | — | — | A parameterised script handed on without the invocation that goes with it is otherwise unrunnable: nothing in the file says what `$3` was meant to be. This reads the script and stops, listing every `$n` it uses, the default its `# param n = ...` line declares and what that line says it is for. With `--stats-json`, the same as JSON for a build script to fill in. |
 | `--stats-json` | Report the statistics as JSON instead of tables | ✅ | — | — | For a tool rather than a reader: full precision, and the sample size behind each average. Pair with `-q` for a stdout that is nothing but JSON. See `docs/leveling-guide.md`. |
 | `-C`, `--CSV` | Write a CSV report to a file | ✅ | — | ✅ | Appends by default; `w:filename` truncates. Driven by the `csvrpt` statement. |
 | `-T`, `--title` | Title for PBN output | ✅ | — | ✅ |  |

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -158,9 +158,11 @@ shipped, it named `-l` twice for two different features, and it offered
 letters are dealer.exe's swapping switches and already taken.
 
 So what remains of it is in **What is left** below, which is generated from
-`dealer/src/roadmap.rs` and checked against the argument parser — `-M`,
-`-Z`, DL52, library mode and script parameters are all rows in that table,
-with the switch collisions written down where they belong.
+`dealer/src/roadmap.rs` and checked against the argument parser — `-M`, `-Z`,
+DL52 and library mode are all rows in that table, with the switch collisions
+written down where they belong. Script parameters used to be a row there too,
+and are now finished: `--param` fills one, a `# param 0 = west` comment declares
+what it should be when nothing does, and `--params` lists what a script wants.
 
 ---
 
@@ -208,7 +210,10 @@ See `CHANGELOG.md` for the migration note.
       solved by `bridge-solver` and remembered per deal (#14)
 - [ ] Library mode - `--input-deals` covers the common case; `-l` is rejected
 - [ ] Export formats (`-Z` zrd, DL52)
-- [ ] Script parameters (`$0`-`$9`)
+- [x] Script parameters (`$0`-`$9`) - **COMPLETED**. `--param 1=west` rather than
+      DealerV2_4's `-1`, which is dealer.exe's swapping switch; a script declares
+      its own defaults in a `# param 1 = 15` comment, which the original's lexer
+      skips, so a parameterised scenario still runs on BBO (#17)
 
 ### Unplanned, and shipped anyway
 Five switches arrived without ever appearing in this document: `--input-deals`,
@@ -260,7 +265,6 @@ Priority is derived from effort and value rather than written down beside them.
 
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
-| 🟢 Someday | Defaults for script parameters, and a way to enter them | Medium | Medium | [#17](https://github.com/bridge-craftwork/Dealer3/issues/17) | A `$n` nothing supplies is an error naming the line, which is right — DealerV2_4 scans an empty buffer instead, so `average $2 controls(west)` quietly loses its label. But it also means a parameterised script cannot run at all without the invocation that goes with it, and nothing in the file says what `$3` was meant to be. The browser has no way to supply one, so such a scenario fails to parse there on a line the reader cannot act on. A default would have to survive the trip to BBO, so a comment pragma rather than syntax. |
 | 🔵 Unlikely | Contract tokens in `score()`, e.g. `3N` for the code 34 | Low | Low |  | DealerV2_4 spells them `[xz][1-7][CDHSN][x]{0,2}` — `x4Hx` is four hearts doubled — so pick a spelling knowing that one exists. |
 | 🔵 Unlikely | Upper-case the honour cards in output | Low | Low |  | Cosmetic. |
 | 🔵 Unlikely | `par(side)`: the par contract | Low | Low |  | Needs all 20 double-dummy results, which bridge-solver already provides for `tricks()`, `score()` and `imps()`. DealerV2_4 sets its vulnerability with `-P`, which has a row of its own in the switch table. |

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -411,6 +411,10 @@ impl RunHost for Page<'_> {
 /// average and 6/1/5/4/4 without anything having gone wrong, where a round is
 /// four. Refused alongside `auto_level`, which asks for the same thing the
 /// other way.
+// The argument list is the JS calling convention: wasm_bindgen exports these
+// positionally, and folding them into a settings object would move the naming
+// out of the type system and into a hand-written cast on both sides.
+#[allow(clippy::too_many_arguments)]
 #[wasm_bindgen]
 pub fn generate(
     script: &str,
@@ -420,6 +424,7 @@ pub fn generate(
     format: &str,
     auto_level: bool,
     round_robin: bool,
+    params: Vec<String>,
     on_progress: Option<js_sys::Function>,
 ) -> Result<String, JsError> {
     let format = Format::parse(format)?;
@@ -435,8 +440,9 @@ pub fn generate(
     // than once and a single bar would appear to restart.
     let progress = Progress::new(on_progress);
 
+    let params = script_params_from(&params).map_err(|e| JsError::new(&e))?;
     let preprocessed =
-        dealer_parser::preprocess_all(script, &Default::default()).map_err(|e| JsError::new(&e))?;
+        dealer_parser::preprocess_all(script, &params).map_err(|e| JsError::new(&e))?;
     let program = dealer_parser::parse_program(&preprocessed)
         .map_err(|e| JsError::new(&format!("Parse error: {}", e)))?;
 
@@ -502,7 +508,7 @@ pub fn generate(
             // gets the same deals more slowly.
             threads: threads_available(),
             batch: 0,
-            params: Default::default(),
+            params: params.clone(),
             round_robin,
             leveling: auto_level.then_some(LevelingOptions {
                 // The target mix comes out of the script, exactly as it does on
@@ -844,8 +850,20 @@ struct CheckResult {
 /// keystroke without exception handling. The line and column come from the
 /// parser itself, so squiggles agree with the engine by construction.
 #[wasm_bindgen]
-pub fn check_script(script: &str) -> String {
-    let preprocessed = match dealer_parser::preprocess_all(script, &Default::default()) {
+pub fn check_script(script: &str, params: Vec<String>) -> String {
+    let params = match script_params_from(&params) {
+        Ok(params) => params,
+        Err(message) => {
+            return serde_json::to_string(&CheckResult {
+                ok: false,
+                error: Some(message),
+                line: None,
+                column: None,
+            })
+            .unwrap_or_default()
+        }
+    };
+    let preprocessed = match dealer_parser::preprocess_all(script, &params) {
         Ok(text) => text,
         // The editor squiggles this the same as a parse error, which is what it
         // is from the writer's point of view.
@@ -1131,6 +1149,78 @@ pub fn language_info() -> String {
         },
     };
     serde_json::to_string(&info).unwrap_or_else(|_| "{}".to_string())
+}
+
+/// Read the page's parameter fields, which arrive in `--param`'s own spelling.
+///
+/// The same `N=TEXT` the command line takes, so there is one place that decides
+/// what a parameter spec is, and a value copied out of a browser field pastes
+/// straight into a terminal.
+fn script_params_from(specs: &[String]) -> Result<dealer_parser::ScriptParams, String> {
+    let mut params = dealer_parser::ScriptParams::default();
+    for spec in specs {
+        // A field left empty is not a value; the script's own default, or the
+        // error, should stand.
+        if spec
+            .split_once('=')
+            .is_none_or(|(_, value)| value.is_empty())
+        {
+            continue;
+        }
+        params.set(spec)?;
+    }
+    Ok(params)
+}
+
+#[derive(Serialize)]
+struct ParamInfo {
+    index: usize,
+    default: Option<String>,
+    description: Option<String>,
+    declared_on: Option<usize>,
+    used_on: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct ParamsResult {
+    ok: bool,
+    /// Present only when `ok` is false: a malformed `# param` line.
+    error: Option<String>,
+    params: Vec<ParamInfo>,
+}
+
+/// What a script says about its own `$0`-`$9`, for the page to ask with.
+///
+/// Without this the browser could find the `$n` occurrences and have nothing to
+/// label them with and no sensible starting value — so a parameterised scenario
+/// simply failed to parse, naming a line the reader could not act on.
+///
+/// Returns JSON rather than throwing, for the same reason `check_script` does:
+/// this runs as the script is edited.
+#[wasm_bindgen]
+pub fn script_params(script: &str) -> String {
+    let result = match dealer_parser::script_parameters(script) {
+        Ok(wanted) => ParamsResult {
+            ok: true,
+            error: None,
+            params: wanted
+                .into_iter()
+                .map(|p| ParamInfo {
+                    index: p.index,
+                    default: p.default,
+                    description: p.description,
+                    declared_on: p.declared_on,
+                    used_on: p.used_on,
+                })
+                .collect(),
+        },
+        Err(message) => ParamsResult {
+            ok: false,
+            error: Some(message),
+            params: Vec::new(),
+        },
+    };
+    serde_json::to_string(&result).unwrap_or_default()
 }
 
 /// Engine version, so a page can show which build it is running.

--- a/web/README.md
+++ b/web/README.md
@@ -216,9 +216,29 @@ Rolling before rather than after is what made a separate "new seed" button
 unnecessary — there is no other reason to want one. A restored session keeps its
 seed, so a reload reproduces what was there.
 
+## Script parameters
+
+A script using `$0`-`$9` gets a row of fields above the editor, one per
+parameter it mentions, and **only then** — nearly every script has none, and a
+panel that is always there would cost a line of script for nothing.
+
+Each field is labelled with what the script's own
+`# param 0 = west   # the seat that opens` line says, and starts empty with that
+default as its placeholder. So clearing a field returns to the declared default
+rather than blanking the parameter, and only a parameter with no default and no
+value stops the run — that one is marked, and Run says which it is waiting for.
+
+Before this the browser had no way to supply a parameter at all, so a
+parameterised scenario failed to parse here with an error naming a line the
+reader could not act on. The `$n` occurrences alone were not enough to build a
+form from: they give nowhere to put a label and no sensible starting value,
+which is what the declarations supply. `dealer --params` prints the same
+information in a terminal.
+
 ## Session persistence
 
-The script in the editor and the parameters beside it are kept in
+The script in the editor, the values in its parameter fields, and the settings
+beside them are kept in
 `localStorage`, so a return visit picks up where the last one left off. The
 starter script only appears on a genuinely first visit.
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -115,7 +115,12 @@
             Auto-level
           </label>
 
-          <button class="run" :disabled="!engineReady || running || !scriptValid" @click="run">
+          <button
+            class="run"
+            :disabled="!engineReady || running || !scriptValid || paramsMissing.length > 0"
+            :title="runHint"
+            @click="run"
+          >
             {{ running ? 'Running…' : runLabel }}
           </button>
           <!-- Appears with the bars rather than the instant Run is pressed:
@@ -151,7 +156,22 @@
           </div>
         </div>
 
-        <ScriptEditor v-show="editorTab === 'script'" v-model="script" @validity="onValidity" />
+        <!-- Above the editor rather than among the run controls: these belong
+             to the script, not to the run — a different script wants different
+             ones, and the same script wants the same ones every time. -->
+        <ScriptParams
+          v-show="editorTab === 'script'"
+          v-model="paramValues"
+          :script="script"
+          :engine-ready="engineReady"
+          @change="onParams"
+        />
+        <ScriptEditor
+          v-show="editorTab === 'script'"
+          v-model="script"
+          :params="paramSpecs"
+          @validity="onValidity"
+        />
         <ScriptViewer v-if="editorTab === 'leveled'" :script="leveledScript" />
       </section>
 
@@ -184,6 +204,7 @@
 import { computed, ref, watch, onMounted, nextTick } from 'vue'
 import ScenarioPicker from '@/components/ScenarioPicker.vue'
 import ScriptEditor from '@/components/ScriptEditor.vue'
+import ScriptParams from '@/components/ScriptParams.vue'
 import ScriptViewer from '@/components/ScriptViewer.vue'
 import ResultsPanel from '@/components/ResultsPanel.vue'
 import PrintView from '@/components/PrintView.vue'
@@ -229,6 +250,21 @@ const roundRobin = ref(restored?.roundRobin ?? false)
 // truncated run is a worse outcome than a second of waiting.
 const maxGenerate = ref(restored?.maxGenerate ?? 1000000)
 const format = ref(restored?.format || 'oneline')
+
+// What has been typed into the parameter fields, by parameter number. Empty
+// means "use whatever the script declares", so clearing a field returns to the
+// default rather than blanking the parameter.
+const paramValues = ref(restored?.paramValues || {})
+/// The same thing in `--param`'s spelling, ready for the engine.
+const paramSpecs = ref([])
+/// Parameters the script uses that nothing supplies. The run would fail on the
+/// first of them, so Run is held rather than offering it.
+const paramsMissing = ref([])
+
+function onParams({ specs, missing }) {
+  paramSpecs.value = specs
+  paramsMissing.value = missing
+}
 
 const engineReady = ref(false)
 const engineVersion = ref('')
@@ -391,6 +427,16 @@ watch(hasHandTypes, (has) => {
 
 const runLabel = computed(() => (editorTab.value === 'leveled' ? 'Run leveled' : 'Run'))
 
+// A disabled button with no explanation is the worst of both: says the run
+// cannot happen and not what would let it.
+const runHint = computed(() => {
+  if (!paramsMissing.value.length) return ''
+  const names = paramsMissing.value.map((i) => `$${i}`).join(', ')
+  return `Fill in ${names} above — the script uses ${
+    paramsMissing.value.length > 1 ? 'them' : 'it'
+  } and declares no default.`
+})
+
 // Ticked for you the first time a script with hand types appears, and left
 // alone afterwards.
 watch(hasHandTypes, (has) => {
@@ -425,7 +471,18 @@ onMounted(async () => {
 // synchronous — it would otherwise sit on the typing path.
 let saveTimer = null
 watch(
-  [script, seed, produce, roundRobin, maxGenerate, format, selectedFile, autoLevel, newSeedEachRun],
+  [
+    script,
+    seed,
+    produce,
+    roundRobin,
+    maxGenerate,
+    format,
+    selectedFile,
+    autoLevel,
+    newSeedEachRun,
+    paramValues,
+  ],
   () => {
     clearTimeout(saveTimer)
     saveTimer = setTimeout(() => {
@@ -439,6 +496,7 @@ watch(
         scenario: selectedFile.value,
         autoLevel: autoLevel.value,
         newSeedEachRun: newSeedEachRun.value,
+        paramValues: paramValues.value,
       })
     }, 400)
   },
@@ -491,6 +549,7 @@ async function onDownload(kind) {
         roundRobin: roundRobinAsked.value,
         maxGenerate: maxGenerate.value,
         format: 'pbn',
+        params: paramSpecs.value,
       })
       downloadText(
         resultFilename(name, seed.value, 'pbn'),
@@ -504,6 +563,7 @@ async function onDownload(kind) {
         roundRobin: roundRobinAsked.value,
         maxGenerate: maxGenerate.value,
         format: format.value === 'pbn' ? 'oneline' : format.value,
+        params: paramSpecs.value,
       })
       // `printes` first, as it appears on screen: leaving it out would drop
       // what the script printed from the file the user saves.
@@ -570,6 +630,7 @@ async function run() {
       roundRobin: roundRobinAsked.value,
       maxGenerate: maxGenerate.value,
       format: format.value,
+      params: paramSpecs.value,
       autoLevel: !onLeveled && autoLevel.value && hasHandTypes.value,
       signal: abort.signal,
       onProgress: (report) => {

--- a/web/src/components/ScriptEditor.vue
+++ b/web/src/components/ScriptEditor.vue
@@ -19,12 +19,12 @@
 // here means the engine will reject the script — not that a regex guessed. The
 // line and column come straight from pest.
 import { ref, onMounted, onBeforeUnmount, watch, shallowRef } from 'vue'
-import { EditorState } from '@codemirror/state'
+import { EditorState, StateEffect } from '@codemirror/state'
 import { EditorView, keymap, lineNumbers, highlightActiveLine } from '@codemirror/view'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { bracketMatching } from '@codemirror/language'
 import { autocompletion, closeBrackets } from '@codemirror/autocomplete'
-import { linter, lintGutter } from '@codemirror/lint'
+import { linter, lintGutter, forceLinting } from '@codemirror/lint'
 // A dark editor on a light page. Syntax palettes are built for dark grounds —
 // the same colours that read clearly there are washed out on white, which is
 // what the default highlight style looked like here.
@@ -35,6 +35,11 @@ import CopyButton from './CopyButton.vue'
 
 const props = defineProps({
   modelValue: { type: String, default: '' },
+  /// What stands behind the script's `$0`-`$9`, in `--param`'s `N=TEXT`
+  /// spelling. The linter needs them: without them every parameterised script
+  /// squiggles on its first `$n`, which is exactly the error the fields exist
+  /// to answer.
+  params: { type: Array, default: () => [] },
 })
 const emit = defineEmits(['update:modelValue', 'validity'])
 
@@ -64,6 +69,14 @@ function offsetOf(doc, line, column) {
   return Math.min(info.from + Math.max(column - 1, 0), info.to)
 }
 
+// Filling a parameter field changes what the script means without touching a
+// character of it. CodeMirror only re-lints on a document change, so the
+// squiggle on `$9` outlived the value that answered it — and `forceLinting` is
+// a no-op in that state, since it only hurries along a lint the document
+// already asked for. `needsRefresh` is the supported way in: this effect
+// carries no payload, it only says the answer would be different now.
+const paramsChanged = StateEffect.define()
+
 // The linter runs on a debounce CodeMirror manages, and is the single place that
 // decides validity — the status bar and the Run button both read from it.
 const dlrLinter = linter((v) => {
@@ -75,7 +88,7 @@ const dlrLinter = linter((v) => {
     return []
   }
 
-  const result = checkScript(text)
+  const result = checkScript(text, props.params)
   if (result.ok) {
     diagnostic.value = null
     emit('validity', { ok: true, empty: false })
@@ -101,7 +114,11 @@ const dlrLinter = linter((v) => {
       message: result.error,
     },
   ]
-}, { delay: 150 })
+}, {
+  delay: 150,
+  needsRefresh: (update) =>
+    update.transactions.some((tr) => tr.effects.some((e) => e.is(paramsChanged))),
+})
 
 onMounted(async () => {
   // The vocabulary and the diagnostics both come from the engine, so the editor
@@ -156,6 +173,22 @@ watch(
     if (!v || v.state.doc.toString() === value) return
     v.dispatch({ changes: { from: 0, to: v.state.doc.length, insert: value } })
   },
+)
+
+// Filling a parameter field changes what the script means, and the linter runs
+// on document changes only — so without this the squiggle stays on `$1` after
+// the value that answers it has been typed.
+watch(
+  () => props.params,
+  () => {
+    if (!view.value) return
+    // The dispatch is what makes the lint pending; forcing it then skips the
+    // debounce, so the squiggle clears as the field is filled rather than a
+    // moment later.
+    view.value.dispatch({ effects: paramsChanged.of(null) })
+    forceLinting(view.value)
+  },
+  { deep: true },
 )
 
 onBeforeUnmount(() => view.value?.destroy())

--- a/web/src/components/ScriptParams.vue
+++ b/web/src/components/ScriptParams.vue
@@ -1,0 +1,167 @@
+<template>
+  <div v-if="params.length || error" class="params">
+    <div v-if="error" class="params-error">{{ error }}</div>
+    <template v-else>
+      <div class="params-head">
+        <span class="params-title">Parameters</span>
+        <span class="params-hint">{{ hint }}</span>
+      </div>
+      <div class="params-fields">
+        <!-- A declaration nothing uses gets no field: there is nothing for a
+             value to reach, and an input that cannot affect the run is worse
+             than a note saying so. -->
+        <div v-for="p in params" :key="p.index" class="param" :class="{ needed: needed(p) }">
+          <template v-if="p.usedOn">
+            <label class="param-name" :for="`param-${p.index}`">${{ p.index }}</label>
+            <input
+              :id="`param-${p.index}`"
+              class="param-input"
+              type="text"
+              :value="values[p.index] || ''"
+              :placeholder="p.default == null ? 'needs a value' : p.default"
+              :title="title(p)"
+              spellcheck="false"
+              @input="set(p.index, $event.target.value)"
+            />
+          </template>
+          <template v-else>
+            <span class="param-name">${{ p.index }}</span>
+            <span class="param-stale" :title="title(p)">declared on line {{ p.declaredOn }}, unused</span>
+          </template>
+          <span v-if="note(p)" class="param-desc">{{ note(p) }}</span>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+// The fields for a script's `$0`-`$9`.
+//
+// Without these a parameterised scenario simply failed to parse here, with an
+// error naming a line the reader could not act on and no way to act on it. The
+// `$n` occurrences alone are not enough to build a form from: they give nowhere
+// to put a label and no sensible starting value, which is what the script's own
+// `# param 0 = west   # the seat that opens` lines supply.
+//
+// A field left empty is not an empty value — it means "use what the script
+// says", so clearing a field returns to the declared default rather than
+// blanking the parameter. Only a parameter with no default and no value stops
+// the run, and that is the one this marks.
+import { computed, ref, watch } from 'vue'
+import { scriptParams } from '@/lib/engine.js'
+
+const props = defineProps({
+  script: { type: String, default: '' },
+  /// `{ 0: 'west', 1: '15' }` — what has been typed, by parameter number.
+  modelValue: { type: Object, default: () => ({}) },
+  /// The engine has to have loaded before the script can be read.
+  engineReady: { type: Boolean, default: false },
+})
+const emit = defineEmits(['update:modelValue', 'change'])
+
+const params = ref([])
+const error = ref('')
+
+const values = computed(() => props.modelValue || {})
+
+function analyse() {
+  if (!props.engineReady) return
+  const result = scriptParams(props.script || '')
+  // A malformed `# param` line. Shown here rather than only as a parse failure,
+  // because this is the pane it is about.
+  error.value = result.ok ? '' : result.error || ''
+  params.value = result.ok ? result.params : []
+  announce()
+}
+
+/// What the run needs: `--param`'s own `N=TEXT` spelling, and whether anything
+/// is still missing.
+function announce() {
+  const used = params.value.filter((p) => p.usedOn)
+  const specs = used
+    .filter((p) => (values.value[p.index] || '').trim() !== '')
+    .map((p) => `${p.index}=${values.value[p.index].trim()}`)
+  const missing = used
+    .filter((p) => p.default == null && (values.value[p.index] || '').trim() === '')
+    .map((p) => p.index)
+  emit('change', { specs, missing })
+}
+
+watch(() => [props.script, props.engineReady], analyse, { immediate: true })
+watch(() => props.modelValue, announce, { deep: true })
+
+function set(index, text) {
+  emit('update:modelValue', { ...values.value, [index]: text })
+}
+
+function needed(p) {
+  return p.usedOn && p.default == null && (values.value[p.index] || '').trim() === ''
+}
+
+/// The description belongs under the field; a parameter with no description and
+/// nothing declaring a default still needs a line saying why it is marked.
+function note(p) {
+  if (!p.usedOn) return ''
+  if (needed(p)) return p.description || 'nothing declares a default for this one'
+  return p.description || ''
+}
+
+function title(p) {
+  if (!p.usedOn) return 'Nothing in the script uses this parameter.'
+  if (p.default == null) {
+    return `The script uses $${p.index} on line ${p.usedOn} and declares no default. ` +
+      `Give it one here, or in the script: # param ${p.index} = <text>`
+  }
+  return `Declared on line ${p.declaredOn} as \`${p.default}\`. Leave empty to use that.`
+}
+
+const hint = computed(() =>
+  params.value.some((p) => needed(p))
+    ? 'The script cannot run until the marked fields have values.'
+    : 'Leave a field empty to use the default the script declares.',
+)
+</script>
+
+<style scoped>
+.params {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-subtle);
+}
+.params-head { display: flex; align-items: baseline; gap: 8px; }
+.params-title { font-size: 12px; font-weight: 600; }
+.params-hint { font-size: 11px; color: var(--fg-muted); }
+.params-error {
+  font-size: 12px;
+  color: var(--danger);
+  font-family: var(--mono);
+  white-space: pre-wrap;
+}
+
+.params-fields { display: flex; flex-wrap: wrap; gap: 8px 14px; margin-top: 5px; }
+
+.param { display: grid; grid-template-columns: auto 1fr; gap: 0 6px; align-items: center; }
+.param-name { font-family: var(--mono); font-size: 12px; color: var(--fg-muted); }
+.param-input {
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 2px 5px;
+  width: 13ch;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--bg);
+  color: var(--fg);
+}
+.param-stale { font-size: 11px; color: var(--fg-muted); font-style: italic; }
+/* Marked rather than merely empty: this is the one that stops the run, and the
+   placeholder alone reads like any other unfilled field. */
+.needed .param-input { border-color: var(--warn); background: var(--warn-subtle); }
+.needed .param-desc { color: var(--warn-fg); }
+.param-desc {
+  grid-column: 2;
+  font-size: 11px;
+  color: var(--fg-muted);
+  max-width: 30ch;
+}
+</style>

--- a/web/src/lib/engine.js
+++ b/web/src/lib/engine.js
@@ -6,6 +6,7 @@
 
 import init, {
   check_script as wasmCheck,
+  script_params as wasmScriptParams,
   language_info as wasmLanguageInfo,
   version as wasmVersion,
 } from '@/wasm/dealer3_wasm.js'
@@ -108,7 +109,11 @@ function runInWorker(script, options) {
         maxGenerate: options.maxGenerate,
         format: options.format,
         autoLevel: options.autoLevel,
-        roundRobin: options.roundRobin,
+        // A plain copy: the caller's array is a Vue ref's, and a reactive
+        // proxy cannot be structured-cloned — postMessage fails outright with
+        // "[object Object] could not be cloned", which says nothing about
+        // where it came from.
+        params: Array.from(options.params || []),
       },
     })
   })
@@ -155,6 +160,10 @@ export async function generate(
     /// Divide `produce` among the script's `HandType_` variables — one of each
     /// per round — instead of taking deals as they come.
     roundRobin = false,
+    /// What to put where `$0`-`$9` stand, in `--param`'s own `N=TEXT` spelling.
+    /// A parameter left out here falls back to the script's own `# param`
+    /// default, and fails the run if it has none.
+    params = [],
     /// Called with `{ phase, produced, generated, target }` as the run goes.
     onProgress = null,
     /// Resolves — or rejects — if the caller abandons the run.
@@ -168,6 +177,7 @@ export async function generate(
     format,
     autoLevel,
     roundRobin,
+    params,
     onProgress,
     signal,
   }))
@@ -214,9 +224,34 @@ export async function generate(
  * column come from the parser itself, so editor markers agree with the engine
  * rather than approximating it.
  */
-export function checkScript(script) {
+export function checkScript(script, params = []) {
   assertReady('checkScript')
-  return JSON.parse(wasmCheck(script))
+  return JSON.parse(wasmCheck(script, params))
+}
+
+/**
+ * What a script says about its own `$0`-`$9`: `{ ok, error, params }`, where
+ * each entry is `{ index, default, description, declaredOn, usedOn }`.
+ *
+ * This is what lets the page ask for the parameters a script wants. The `$n`
+ * occurrences on their own give it nowhere to put a label and no sensible
+ * starting value, which is why a parameterised scenario used to fail here with
+ * an error naming a line the reader could not act on.
+ */
+export function scriptParams(script) {
+  assertReady('scriptParams')
+  const raw = JSON.parse(wasmScriptParams(script))
+  return {
+    ok: raw.ok,
+    error: raw.error,
+    params: raw.params.map((p) => ({
+      index: p.index,
+      default: p.default,
+      description: p.description,
+      declaredOn: p.declared_on,
+      usedOn: p.used_on,
+    })),
+  }
 }
 
 /** The language's vocabulary, for highlighting and completion. */

--- a/web/src/lib/engine.worker.js
+++ b/web/src/lib/engine.worker.js
@@ -82,6 +82,7 @@ self.onmessage = async (event) => {
       options.format,
       options.autoLevel,
       options.roundRobin,
+      options.params || [],
       onProgress,
     )
     self.postMessage({ id, type: 'done', raw, threads: pool.threads })

--- a/web/src/lib/session.js
+++ b/web/src/lib/session.js
@@ -48,6 +48,13 @@ export function loadSession() {
       autoLevel: typeof v.autoLevel === 'boolean' ? v.autoLevel : undefined,
       newSeedEachRun:
         typeof v.newSeedEachRun === 'boolean' ? v.newSeedEachRun : undefined,
+      // What was typed into the script's parameter fields, by parameter
+      // number. Restored with the script, since a parameterised scenario is
+      // only half itself without them.
+      paramValues:
+        v.paramValues && typeof v.paramValues === 'object' && !Array.isArray(v.paramValues)
+          ? v.paramValues
+          : {},
     }
   } catch {
     // Malformed: drop it rather than tripping over it on every load.

--- a/web/src/lib/session.test.js
+++ b/web/src/lib/session.test.js
@@ -22,6 +22,7 @@ const session = {
   maxGenerate: 100000,
   format: 'printall',
   scenario: 'Weak_2_Bids',
+  paramValues: { 0: 'west', 1: '15' },
 }
 
 describe('saveSession / loadSession', () => {
@@ -36,6 +37,12 @@ describe('saveSession / loadSession', () => {
     const { roundRobin, ...older } = session
     localStorage.setItem('dealer3:session:v1', JSON.stringify(older))
     expect(loadSession().roundRobin).toBe(false)
+  })
+
+  it('reads a session saved before script parameters existed as none', () => {
+    const { paramValues, ...older } = session
+    localStorage.setItem('dealer3:session:v1', JSON.stringify(older))
+    expect(loadSession().paramValues).toEqual({})
   })
 
   it('returns null when nothing is stored', () => {


### PR DESCRIPTION
Closes #17, both halves.

## The declaration

A script can now say what its own `\$0`-`\$9` are, in a whole-line comment:

```
# param 0 = west          # the seat that opens
# param 1 = 15            # minimum HCP
# param 4 = 5xxx + x5xx   # the shape responder shows
```

A comment rather than syntax, because it has to survive the trip to BBO and to
the original dealer, whose lexers skip a `#` line entirely — the same reason
`HandType_` is a variable name rather than a keyword. The value runs to a second
`#` and the rest is its description: an exact split rather than a run of spaces,
since `#` cannot appear inside a value the language accepts, where `5xxx + x5xx`
is full of single spaces.

Precedence is `--param`, then the declaration, then the error we raised before.
Filling happens inside `substitute`, so it stays ahead of the shape expander as
it must, and every front end gained it at once.

**Not mistaking a comment for one.** Two guards, because a comment misread as a
malformed declaration is a hard error on a line nobody meant as one: the word
must end there (`parameters` is not it) and a number must follow (`# Param: ...`
and `# alias: ...` are not). Past those it *is* a declaration and a malformed one
is refused rather than skipped — silently ignoring `# param 0 west` is how a
script ends up unrunnable with a line in it that looks as though it should have
worked. Swept all 1400 Practice-Bidding-Scenarios files: none refused, none
gains a parameter it never had.

## Entering them

- `dealer --params script.dlr` lists what a script wants, its defaults and its
  descriptions, without running it. With `--stats-json`, the same as JSON — the
  information a build script needs to fill them programmatically.
- The browser gets a field per parameter above the editor, labelled from the
  declaration and placeholdered with its default — and **only when the script
  has any**, since nearly none do and a panel always there would cost a line of
  script for nothing. Clearing a field returns to the declared default rather
  than blanking the parameter; only one with no default and no value holds Run,
  and the button says which it is waiting for.

## Two bugs the unit tests could not have caught

Found by driving the page, per the standing lesson that the browser is where the
wiring bugs live:

- `forceLinting` is a no-op unless the document changed, so a filled field left
  its own squiggle standing and Run stayed disabled. The linter's `needsRefresh`
  hook is the supported way in.
- The specs array is a Vue ref's, and a reactive proxy cannot be
  structured-cloned — `postMessage` failed outright with a message that says
  nothing about where it came from. Copied at the boundary.

## Verified

- 482 Rust tests, 129 web tests; `cargo fmt` and `clippy -D warnings` clean in
  both workspaces.
- In a real browser: a script with only declarations runs with nothing supplied;
  a field overrides one default without disturbing the others; clearing returns
  to the default; values survive a reload; a script with no parameters gets no
  panel and the editor keeps the height.
- Docs regenerated from the code, plus a "Script parameters" section in
  `FILTER_LANGUAGE_STATUS.md`, `script_params` in `WASM.md`, the panel in
  `web/README.md`, and #17's row deleted from the roadmap matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)