### PR TITLE
A malformed board in --input-deals took the whole run down

### DIFF
--- a/dealer-core/src/convert.rs
+++ b/dealer-core/src/convert.rs
@@ -18,15 +18,39 @@ impl From<crate::Hand> for bridge_types::Hand {
     }
 }
 
-impl From<&bridge_types::Hand> for crate::Hand {
-    fn from(hand: &bridge_types::Hand) -> Self {
-        crate::Hand::from_cards(hand.cards().to_vec())
+// Inbound is fallible where outbound is not, and the asymmetry is the point.
+// A `crate::Hand` holds at most thirteen cards, so anything this program builds
+// converts out cleanly; a `bridge_types::Hand` read from a file has whatever the
+// file said. `Hand::from_cards` asserts, and an assert on untrusted input is a
+// panic — a PBN board with a fourteen-card hand took the whole run down with
+// `a hand cannot hold more than 13 cards` and no mention of the file it came
+// from.
+//
+// Fewer than thirteen is *not* refused here: a partial hand is a real thing
+// mid-predeal. Whether a whole deal is complete is a question about the deal,
+// and [`crate::Deal::check_complete`] answers it where completeness is required.
+
+impl TryFrom<&bridge_types::Hand> for crate::Hand {
+    type Error = String;
+
+    fn try_from(hand: &bridge_types::Hand) -> Result<Self, Self::Error> {
+        let cards = hand.cards();
+        if cards.len() > crate::hand::MAX_CARDS {
+            return Err(format!(
+                "a hand cannot hold more than {} cards, and this one has {}",
+                crate::hand::MAX_CARDS,
+                cards.len()
+            ));
+        }
+        Ok(crate::Hand::from_cards(cards.to_vec()))
     }
 }
 
-impl From<bridge_types::Hand> for crate::Hand {
-    fn from(hand: bridge_types::Hand) -> Self {
-        crate::Hand::from_cards(hand.cards().to_vec())
+impl TryFrom<bridge_types::Hand> for crate::Hand {
+    type Error = String;
+
+    fn try_from(hand: bridge_types::Hand) -> Result<Self, Self::Error> {
+        (&hand).try_into()
     }
 }
 
@@ -59,20 +83,33 @@ impl From<crate::Deal> for bridge_types::Deal {
     }
 }
 
-impl From<&bridge_types::Deal> for crate::Deal {
-    fn from(deal: &bridge_types::Deal) -> Self {
+impl TryFrom<&bridge_types::Deal> for crate::Deal {
+    type Error = String;
+
+    fn try_from(deal: &bridge_types::Deal) -> Result<Self, Self::Error> {
         let mut dc_deal = crate::Deal::new();
-        *dc_deal.hand_mut(Position::North) = deal.hand(bridge_types::Direction::North).into();
-        *dc_deal.hand_mut(Position::East) = deal.hand(bridge_types::Direction::East).into();
-        *dc_deal.hand_mut(Position::South) = deal.hand(bridge_types::Direction::South).into();
-        *dc_deal.hand_mut(Position::West) = deal.hand(bridge_types::Direction::West).into();
-        dc_deal
+        for (position, direction) in [
+            (Position::North, bridge_types::Direction::North),
+            (Position::East, bridge_types::Direction::East),
+            (Position::South, bridge_types::Direction::South),
+            (Position::West, bridge_types::Direction::West),
+        ] {
+            *dc_deal.hand_mut(position) = deal
+                .hand(direction)
+                .try_into()
+                // Which seat, because a file with one bad board says nothing
+                // about which board or which hand without it.
+                .map_err(|e| format!("{}: {}", position, e))?;
+        }
+        Ok(dc_deal)
     }
 }
 
-impl From<bridge_types::Deal> for crate::Deal {
-    fn from(deal: bridge_types::Deal) -> Self {
-        (&deal).into()
+impl TryFrom<bridge_types::Deal> for crate::Deal {
+    type Error = String;
+
+    fn try_from(deal: bridge_types::Deal) -> Result<Self, Self::Error> {
+        (&deal).try_into()
     }
 }
 
@@ -88,7 +125,7 @@ mod tests {
         hand.add_card(Card::new(Suit::Hearts, Rank::King));
 
         let bt_hand: bridge_types::Hand = (&hand).into();
-        let back: crate::Hand = bt_hand.into();
+        let back: crate::Hand = bt_hand.try_into().expect("two cards fit in a hand");
 
         assert_eq!(hand.len(), back.len());
         assert_eq!(hand.hcp(), back.hcp());
@@ -103,7 +140,7 @@ mod tests {
             .add_card(Card::new(Suit::Hearts, Rank::King));
 
         let bt_deal: bridge_types::Deal = (&deal).into();
-        let back: crate::Deal = bt_deal.into();
+        let back: crate::Deal = bt_deal.try_into().expect("a deal that came from one");
 
         assert_eq!(
             deal.hand(Position::North).len(),

--- a/dealer-core/src/deal.rs
+++ b/dealer-core/src/deal.rs
@@ -30,6 +30,35 @@ impl Deal {
         }
     }
 
+    /// Whether this really is a deal: four hands of thirteen, no card twice.
+    ///
+    /// `Deal::new()` is empty and hands fill up one card at a time, so the type
+    /// cannot enforce this — a partial deal is a real thing mid-predeal. Where
+    /// completeness *is* required, it has to be asked for, and reading deals
+    /// from a file is the case that matters: everything downstream assumes a
+    /// full deck. A board a card short otherwise ran and reported statistics
+    /// over a twelve-card hand with nothing to say it had.
+    pub fn check_complete(&self) -> Result<(), String> {
+        let mut seen = [false; 52];
+        for position in Position::ALL {
+            let hand = self.hand(position);
+            if hand.len() != 13 {
+                return Err(format!(
+                    "{} has {} cards, and a hand has 13",
+                    position,
+                    hand.len()
+                ));
+            }
+            for card in hand.cards() {
+                let index = card.to_index() as usize;
+                if std::mem::replace(&mut seen[index], true) {
+                    return Err(format!("{} appears more than once", card));
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Get a mutable reference to a hand by position
     pub fn hand_mut(&mut self, position: Position) -> &mut Hand {
         match position {
@@ -57,6 +86,56 @@ impl Default for Deal {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn a_whole_deal_passes_the_completeness_check() {
+        let mut deal = Deal::new();
+        for (i, position) in Position::ALL.iter().enumerate() {
+            for rank in 0..13 {
+                deal.hand_mut(*position).add_card(
+                    crate::Card::from_index((i * 13 + rank) as u8).expect("a card index"),
+                );
+            }
+        }
+        assert_eq!(deal.check_complete(), Ok(()));
+    }
+
+    #[test]
+    fn a_hand_short_of_a_card_is_not_a_whole_deal() {
+        // The case that used to run: a board a card short reported statistics
+        // over a twelve-card hand without a word.
+        let mut deal = Deal::new();
+        for (i, position) in Position::ALL.iter().enumerate() {
+            let cards = if i == 3 { 12 } else { 13 };
+            for rank in 0..cards {
+                deal.hand_mut(*position).add_card(
+                    crate::Card::from_index((i * 13 + rank) as u8).expect("a card index"),
+                );
+            }
+        }
+        let err = deal.check_complete().expect_err("should refuse");
+        assert!(err.contains("West"), "should name the seat: {err}");
+        assert!(err.contains("12"), "should say how many: {err}");
+    }
+
+    #[test]
+    fn a_card_dealt_twice_is_not_a_whole_deal() {
+        let mut deal = Deal::new();
+        for (i, position) in Position::ALL.iter().enumerate() {
+            for rank in 0..13 {
+                // West gets North's first card instead of his own last.
+                let index = if i == 3 && rank == 12 {
+                    0
+                } else {
+                    i * 13 + rank
+                };
+                deal.hand_mut(*position)
+                    .add_card(crate::Card::from_index(index as u8).expect("a card index"));
+            }
+        }
+        let err = deal.check_complete().expect_err("should refuse");
+        assert!(err.contains("more than once"), "got: {err}");
+    }
     use super::*;
 
     // Deal generation is covered in `fast_deal.rs`, which owns the generator.

--- a/dealer-core/src/hand.rs
+++ b/dealer-core/src/hand.rs
@@ -19,7 +19,7 @@ pub struct Hand {
 
 /// A hand holds thirteen cards. Building one with more is a corrupt deal rather
 /// than a condition to report, so it is asserted rather than returned.
-const MAX_CARDS: usize = 13;
+pub(crate) const MAX_CARDS: usize = 13;
 
 /// What the unused slots hold. Never read: every accessor goes through `len`.
 /// A fixed value rather than anything meaningful so that two hands with the same

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -1490,19 +1490,45 @@ fn main() {
             // against an expected total.
             let mut skipped = 0usize;
             const MAX_SKIP_WARNINGS: usize = 10;
-            let mut deals = Vec::new();
-            for result in DealReader::new(stream) {
-                match result {
-                    Ok(deal) => deals.push(deal.into()),
-                    Err(e) => {
-                        skipped += 1;
-                        if skipped <= MAX_SKIP_WARNINGS {
-                            eprintln!("Warning: skipping unreadable deal: {}", e);
-                            if skipped == MAX_SKIP_WARNINGS {
-                                eprintln!("Warning: further skips will not be reported");
-                            }
-                        }
+            let mut deals: Vec<Deal> = Vec::new();
+            // Counts what the reader handed over, so a warning can say which
+            // board — the reader's own position, not the index in `deals`,
+            // which skips are already pulling out of step.
+            let mut board = 0usize;
+            let complain = |skipped: &mut usize, what: String| {
+                *skipped += 1;
+                if *skipped <= MAX_SKIP_WARNINGS {
+                    eprintln!("Warning: {}", what);
+                    if *skipped == MAX_SKIP_WARNINGS {
+                        eprintln!("Warning: further skips will not be reported");
                     }
+                }
+            };
+            for result in DealReader::new(stream) {
+                board += 1;
+                match result {
+                    // A deal the reader accepted can still be one this program
+                    // cannot use: a hand of fourteen does not fit, and used to
+                    // end the run with `a hand cannot hold more than 13 cards`
+                    // and no mention of the file it came from. A deal a card
+                    // short fitted and was worse — it ran, and reported
+                    // statistics over a twelve-card hand without a word.
+                    Ok(deal) => match Deal::try_from(deal) {
+                        Ok(deal) => match deal.check_complete() {
+                            Ok(()) => deals.push(deal),
+                            Err(e) => complain(
+                                &mut skipped,
+                                format!("skipping deal {} — it is not a whole deal: {}", board, e),
+                            ),
+                        },
+                        Err(e) => {
+                            complain(&mut skipped, format!("skipping deal {} — {}", board, e))
+                        }
+                    },
+                    Err(e) => complain(
+                        &mut skipped,
+                        format!("skipping unreadable deal {}: {}", board, e),
+                    ),
                 }
             }
             if skipped > 0 {

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -219,8 +219,11 @@ pub const REMAINING: &[WorkItem] = &[
         effort: Effort::Low,
         value: Value::Low,
         note: Some(
-            "DealerV2_4 spells them `[xz][1-7][CDHSN][x]{0,2}` — `x4Hx` is four hearts \
-             doubled — so pick a spelling knowing that one exists.",
+            "**The spelling is not a free choice.** The original has the token already — \
+             `[x][1-7][CDHSN]` in `scan.l`, feeding `score(VULN, CONTRACT, expr)` in \
+             `defs.y` — so `x4H` is dealer.exe's own and compatibility settles it. \
+             DealerV2_4 extends that to `[xz][1-7][CDHSN][x]{0,2}`, where the `z` prefix \
+             and the trailing `x`s make `x4Hx` four hearts doubled.",
         ),
     },
     WorkItem {
@@ -229,7 +232,12 @@ pub const REMAINING: &[WorkItem] = &[
         issue: None,
         effort: Effort::Medium,
         value: Value::Low,
-        note: Some("Rejected loudly today; the same thing can be written in the condition."),
+        note: Some(
+            "The original's, not DealerV2_4's: `predealarg : SUIT '(' COMPASS ')' CMPEQ \
+             NUMBER` in `defs.y` calls `bias_deal`, which biases the shuffle rather than \
+             fixing cards. Rejected loudly today; the same thing can be written in the \
+             condition, at the cost of dealing and discarding instead of dealing to fit.",
+        ),
     },
     WorkItem {
         what: "`--bbo-strict`: warn when a script will behave differently on BBO",

--- a/dealer/tests/input_deals.rs
+++ b/dealer/tests/input_deals.rs
@@ -263,6 +263,46 @@ fn a_board_a_card_short_is_skipped_rather_than_run() {
     assert_eq!(count_deals(&out.stdout), 0, "stdout:\n{}", out.stdout);
 }
 
+/// A teaching-material board: the two hands the student sees, `-` for the rest.
+///
+/// Legal PBN and not a deal. It used to read as nothing at all — a whole file of
+/// these came back as an empty file, with no warning and no deal.
+const PARTIAL_BOARD: &str = "\
+[Event \"Stayman\"]
+[Board \"1\"]
+[Deal \"W:- KT82.74.AK63.AJ7 - A4.KJ98.T872.865\"]
+";
+
+#[test]
+fn a_board_with_only_two_hands_is_reported_rather_than_ignored() {
+    let corpus = temp_file("partial", PARTIAL_BOARD);
+    let script = temp_file("script-partial", "condition 1\n");
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-p",
+            "1",
+        ],
+        None,
+    );
+
+    assert!(out.success, "stderr:\n{}", out.stderr);
+    assert!(
+        out.stderr.contains("2 of the four hands"),
+        "should say what is missing:\n{}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("skipped 1"),
+        "should count it:\n{}",
+        out.stderr
+    );
+    assert_eq!(count_deals(&out.stdout), 0, "stdout:\n{}", out.stdout);
+}
+
 #[test]
 fn unrecognised_lines_are_ignored() {
     // DealReader skips anything it cannot parse as a deal, which is what allows

--- a/dealer/tests/input_deals.rs
+++ b/dealer/tests/input_deals.rs
@@ -188,6 +188,81 @@ fn reads_pbn_deal_tags() {
     assert_eq!(count_deals(&out.stdout), 1, "stdout:\n{}", out.stdout);
 }
 
+/// A PBN board whose West holds fourteen cards, the rest of it well formed.
+///
+/// The reader accepts it — a hand of any length parses — and it is this program
+/// that cannot use it, which is why the check has to be here rather than there.
+const FOURTEEN_CARD_BOARD: &str = "\
+[Board \"1\"]
+[Deal \"N:AKQJ.AKQ.AKQ.AKQ 432.432.432.5432 T98.T98.T98.T987 7655.J765.J765.J6\"]
+";
+
+/// The same board a card short instead: West with twelve.
+const TWELVE_CARD_BOARD: &str = "\
+[Board \"1\"]
+[Deal \"N:AKQJ.AKQ.AKQ.AKQ 432.432.432.5432 T98.T98.T98.T987 765.J765.J765.J\"]
+";
+
+#[test]
+fn a_hand_of_fourteen_is_skipped_rather_than_taking_the_run_down() {
+    // It used to panic: `a hand cannot hold more than 13 cards`, with no
+    // mention of the file it came from, let alone which board or which seat.
+    let corpus = temp_file("fourteen", FOURTEEN_CARD_BOARD);
+    let script = temp_file("script-fourteen", "condition 1\n");
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-p",
+            "1",
+        ],
+        None,
+    );
+
+    assert!(out.success, "should not panic; stderr:\n{}", out.stderr);
+    assert!(!out.stderr.contains("panicked"), "stderr:\n{}", out.stderr);
+    assert!(
+        out.stderr.contains("West"),
+        "should name the seat:\n{}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("14"),
+        "should say how many:\n{}",
+        out.stderr
+    );
+    assert_eq!(count_deals(&out.stdout), 0, "stdout:\n{}", out.stdout);
+}
+
+#[test]
+fn a_board_a_card_short_is_skipped_rather_than_run() {
+    // Worse than the panic while it lasted: this one fitted, so it ran and
+    // reported statistics over a twelve-card hand with nothing to say it had.
+    let corpus = temp_file("twelve", TWELVE_CARD_BOARD);
+    let script = temp_file("script-twelve", "condition 1\n");
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-p",
+            "1",
+        ],
+        None,
+    );
+
+    assert!(out.success, "stderr:\n{}", out.stderr);
+    assert!(
+        out.stderr.contains("not a whole deal"),
+        "stderr:\n{}",
+        out.stderr
+    );
+    assert_eq!(count_deals(&out.stdout), 0, "stdout:\n{}", out.stdout);
+}
+
 #[test]
 fn unrecognised_lines_are_ignored() {
     // DealReader skips anything it cannot parse as a deal, which is what allows

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -265,7 +265,7 @@ Priority is derived from effort and value rather than written down beside them.
 
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
-| 🔵 Unlikely | Contract tokens in `score()`, e.g. `3N` for the code 34 | Low | Low |  | DealerV2_4 spells them `[xz][1-7][CDHSN][x]{0,2}` — `x4Hx` is four hearts doubled — so pick a spelling knowing that one exists. |
+| 🔵 Unlikely | Contract tokens in `score()`, e.g. `3N` for the code 34 | Low | Low |  | **The spelling is not a free choice.** The original has the token already — `[x][1-7][CDHSN]` in `scan.l`, feeding `score(VULN, CONTRACT, expr)` in `defs.y` — so `x4H` is dealer.exe's own and compatibility settles it. DealerV2_4 extends that to `[xz][1-7][CDHSN][x]{0,2}`, where the `z` prefix and the trailing `x`s make `x4Hx` four hearts doubled. |
 | 🔵 Unlikely | Upper-case the honour cards in output | Low | Low |  | Cosmetic. |
 | 🔵 Unlikely | `par(side)`: the par contract | Low | Low |  | Needs all 20 double-dummy results, which bridge-solver already provides for `tricks()`, `score()` and `imps()`. DealerV2_4 sets its vulnerability with `-P`, which has a row of its own in the switch table. |
 | 🔵 Unlikely | `printns` and `printside(side)` | Low | Low |  | dealer3 has `printew`; DealerV2_4 routes all three through one action. |
@@ -274,7 +274,7 @@ Priority is derived from effort and value rather than written down beside them.
 | 🔵 Unlikely | Double-dummy solver mode | Medium | Low |  | DealerV2_4's `-M`, which prints a double-dummy table per deal. The solver behind it is in place; this is the switch and its output format. |
 | 🔵 Unlikely | Export in DL52 format | Medium | Low |  | DealerV2_4 spells it `-l`, which is dealer.exe's library switch — so as with the script parameters, the spelling here would have to differ. |
 | 🔵 Unlikely | Export in RP zrd format | Medium | Low |  |  |
-| 🔵 Unlikely | The length-bias form of `predeal`, `spades(north) == 5` | Medium | Low |  | Rejected loudly today; the same thing can be written in the condition. |
+| 🔵 Unlikely | The length-bias form of `predeal`, `spades(north) == 5` | Medium | Low |  | The original's, not DealerV2_4's: `predealarg : SUIT '(' COMPASS ')' CMPEQ NUMBER` in `defs.y` calls `bias_deal`, which biases the shuffle rather than fixing cards. Rejected loudly today; the same thing can be written in the condition, at the cost of dealing and discarding instead of dealing to fit. |
 | 🔵 Unlikely | Two-dimensional `frequency` | Medium | Low |  | The original takes a second expression and range and prints marginals. |
 | 🔵 Unlikely | `--bbo-strict`: warn when a script will behave differently on BBO | Medium | Low | [#13](https://github.com/bridge-craftwork/Dealer3/issues/13) | Rick judged it unlikely to bite. |
 | 🔵 Unlikely | `bktfreq`: frequency in buckets, one and two dimensional | Medium | Low |  | Adjacent to the two-dimensional `frequency` below but not the same thing: that one is the original's, this one groups a range into buckets. |


### PR DESCRIPTION
Depends on [bridge-encodings#5](https://github.com/bridge-craftwork/bridge-encodings/pull/5), merged.

## The panic

A PBN board whose West held fourteen cards ended the run:

```
thread 'main' panicked at dealer-core/src/hand.rs:67:
a hand cannot hold more than 13 cards
```

with no mention of the file it came from, let alone which board or which seat.
`Hand::add_card` asserts — rightly, since every internal caller deals from a
52-card deck and going over means the deck is wrong — but `--input-deals` reads
whatever a file says, and an assert on untrusted input is a panic.

The conversion was the wrong shape: `From<&bridge_types::Deal> for Deal` cannot
fail, and the thing it converts can. It is now `TryFrom`, failing where a hand
does not fit and naming the seat. Outbound stays `From` — a hand this program
built always fits — and the asymmetry is the point.

## The quieter half

Probing the panic's scope turned up the same bug wearing a better disguise. A
board a card **short** fitted, so it ran and reported statistics over a
twelve-card hand without a word.

That needed a different check: `< 13` cannot be refused at the conversion,
because a partial hand is a real thing mid-predeal. `Deal::check_complete` asks
the question where completeness is actually required — four hands of thirteen,
no card twice — and the reader asks it for every board. Duplicates fall out of
the same pass.

## And the third case

A board that gives only two hands, `-` for the rest, read as **nothing at all**:
teaching material, legal PBN, and twenty-five such boards in one file came back
as an empty file. Fixed upstream in bridge-encodings so a `[Deal ...]` tag that
cannot be read is an error rather than a skipped line; this PR pins the
end-to-end behaviour.

## All four now behave alike

Same warning channel, same counter, same summary as the unreadable deals the
reader already reported:

```
Warning: skipping deal 1 — West: a hand cannot hold more than 13 cards, and this one has 14
Warning: skipping deal 1 — it is not a whole deal: West has 12 cards, and a hand has 13
Warning: skipping deal 1 — it is not a whole deal: ♠A appears more than once
Warning: skipping unreadable deal 1: PBN parse error: line 9: the board gives 2 of the four hands...
```

Warn-and-skip rather than a hard error, for consistency with what was already
there — and the total is reported, so a caller can compare it against what they
expected.

## Verified

- 488 tests pass; `cargo fmt` and `clippy -D warnings` clean in both workspaces.
- Five new tests: three in dealer-core for `check_complete`, three integration
  tests driving the real binary for the fourteen-card, twelve-card and two-hand
  boards.
- No regression on real input: the committed 181-deal corpus still reads all 181,
  and nothing previously accepted is now refused.

## Also

Two provenance notes in the roadmap, corrected against the original's sources
rather than the notes they came from:

- Contract tokens in `score()` were down as DealerV2_4's. dealer.exe has them
  already — `[x][1-7][CDHSN]` in `scan.l`, feeding `score(VULN, CONTRACT, expr)`
  in `defs.y` — so the spelling is not a free choice, compatibility settles it,
  and V2_4 only extends it with the `z` prefix and the doubling suffix.
- The length-bias `predeal` is likewise the original's, `bias_deal` in `defs.y`,
  which biases the shuffle rather than fixing cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)