### PR TITLE
score() takes dealer.exe's contract and vulnerability words

### DIFF
--- a/dealer-eval/src/lib.rs
+++ b/dealer-eval/src/lib.rs
@@ -1317,11 +1317,13 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
 
         Function::Score => {
             // score(vulnerability, contract, tricks)
-            // vulnerability: 0 = non-vul, 1 = vul
-            // contract: encoded as level * 10 + strain + doubled_flag * 100
+            // vulnerability: 0 = non-vul, 1 = vul, or the words `nv` and `vul`
+            // contract: the word `x3N`, or the number that word stands for —
+            //   level * 5 + strain, plus 40 for each level of doubling, which
+            //   is what both references encode (tree.h's MAKECONTRACT, and
+            //   DealerV2_4's make_contract).
             //   strain: 0=C, 1=D, 2=H, 3=S, 4=NT
-            //   doubled_flag: 0=undoubled, 1=doubled, 2=redoubled
-            //   Examples: 3NT = 34, 4S = 43, 3NT doubled = 134, 4Sx = 143, 4Sxx = 243
+            //   Examples: 3NT = 19, 4S = 23, 4Sx = 63, 4Sxx = 103
             // tricks: 0-13
             if args.len() != 3 {
                 return Err(EvalError::InvalidArgumentCount {
@@ -1338,11 +1340,18 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
             // Parse vulnerability
             let vulnerable = vul_arg != 0;
 
-            // Parse contract code
-            let doubled_flag = contract_code / 100;
-            let remainder = contract_code % 100;
-            let level = remainder / 10;
-            let strain_num = remainder % 10;
+            // Parse contract code. A negative code would divide towards zero
+            // and land inside a valid range, so it is refused up front.
+            if contract_code < 0 {
+                return Err(EvalError::InvalidArgument(format!(
+                    "Invalid contract: {} (must not be negative)",
+                    contract_code
+                )));
+            }
+            let doubled_flag = contract_code / 40;
+            let remainder = contract_code % 40;
+            let level = remainder / 5;
+            let strain_num = remainder % 5;
 
             // Validate level
             if !(1..=7).contains(&level) {
@@ -1352,19 +1361,14 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
                 )));
             }
 
-            // Parse strain
+            // Parse strain. The remainder of a division by five cannot be
+            // anything else, so there is no failing arm to write.
             let strain = match strain_num {
                 0 => Strain::Clubs,
                 1 => Strain::Diamonds,
                 2 => Strain::Hearts,
                 3 => Strain::Spades,
-                4 => Strain::NoTrump,
-                _ => {
-                    return Err(EvalError::InvalidArgument(format!(
-                        "Invalid strain: {} (must be 0=C, 1=D, 2=H, 3=S, 4=NT)",
-                        strain_num
-                    )));
-                }
+                _ => Strain::NoTrump,
             };
 
             // Parse doubled state
@@ -2801,28 +2805,106 @@ mod tests {
         let deal = gen.next_deal();
         let ctx = EvalContext::new(&deal);
 
-        // score(0, 34, 9) = 3NT non-vul making exactly = 400
-        // Contract code: 34 = level 3, strain 4 (NT)
-        let ast = parse("score(0, 34, 9)").unwrap();
+        // score(nv, x3N, 9) = 3NT non-vul making exactly = 400
+        // Contract code: 19 = 3 * 5 + 4 (NT)
+        let ast = parse("score(nv, x3N, 9)").unwrap();
         assert_eq!(eval(&ast, &ctx).unwrap(), 400);
 
-        // score(1, 34, 9) = 3NT vul making exactly = 600
-        let ast = parse("score(1, 34, 9)").unwrap();
+        // score(vul, x3N, 9) = 3NT vul making exactly = 600
+        let ast = parse("score(vul, x3N, 9)").unwrap();
         assert_eq!(eval(&ast, &ctx).unwrap(), 600);
 
-        // score(0, 43, 10) = 4S non-vul making exactly = 420
-        // Contract code: 43 = level 4, strain 3 (Spades)
-        let ast = parse("score(0, 43, 10)").unwrap();
+        // score(nv, x4S, 10) = 4S non-vul making exactly = 420
+        // Contract code: 23 = 4 * 5 + 3 (spades)
+        let ast = parse("score(nv, x4S, 10)").unwrap();
         assert_eq!(eval(&ast, &ctx).unwrap(), 420);
 
-        // score(0, 34, 8) = 3NT down 1 = -50
-        let ast = parse("score(0, 34, 8)").unwrap();
+        // score(nv, x3N, 8) = 3NT down 1 = -50
+        let ast = parse("score(nv, x3N, 8)").unwrap();
         assert_eq!(eval(&ast, &ctx).unwrap(), -50);
 
-        // score(0, 143, 9) = 4S doubled down 1 = -100
-        // Contract code: 143 = doubled (100) + level 4, strain 3 (Spades)
-        let ast = parse("score(0, 143, 9)").unwrap();
+        // score(nv, x4Sx, 9) = 4S doubled down 1 = -100
+        // Contract code: 63 = doubled (40) + 4 * 5 + 3 (spades)
+        let ast = parse("score(nv, x4Sx, 9)").unwrap();
         assert_eq!(eval(&ast, &ctx).unwrap(), -100);
+    }
+
+    /// The number a contract word stands for, and the word itself, must reach
+    /// the same score. Both spellings are supported on purpose — the word is
+    /// what a script written for dealer.exe uses, the number is what a
+    /// `--param` can supply — so neither may drift from the other.
+    #[test]
+    fn a_contract_word_and_its_number_agree() {
+        use dealer_parser::parse;
+
+        let mut gen = FastDealGenerator::new(1);
+        let deal = gen.next_deal();
+        let ctx = EvalContext::new(&deal);
+
+        for (word, code) in [
+            ("x1C", 5),
+            ("x3N", 19),
+            ("x4S", 23),
+            ("x7N", 39),
+            ("x3Nx", 59),
+            ("x4Sxx", 103),
+            // The sigil carries no meaning, so `z` and `x` are one contract.
+            ("z4S", 23),
+        ] {
+            for tricks in 0..=13 {
+                let by_word = parse(&format!("score(nv, {}, {})", word, tricks)).unwrap();
+                let by_number = parse(&format!("score(0, {}, {})", code, tricks)).unwrap();
+                assert_eq!(
+                    eval(&by_word, &ctx).unwrap(),
+                    eval(&by_number, &ctx).unwrap(),
+                    "{} and {} disagree at {} tricks",
+                    word,
+                    code,
+                    tricks
+                );
+            }
+        }
+    }
+
+    /// `nv` and `vul` are recognised only where `score` takes them, so a script
+    /// may still use either as a variable name anywhere else. The same goes for
+    /// a name shaped like a contract.
+    #[test]
+    fn the_score_words_are_not_reserved_elsewhere() {
+        use dealer_parser::parse_program;
+
+        for script in [
+            "vul = 3\ncondition hcp(north) >= vul\n",
+            "nv = 2\ncondition hcp(north) >= nv\n",
+            "x3N = 20\ncondition hcp(north) >= x3N\n",
+        ] {
+            assert!(
+                parse_program(script).is_ok(),
+                "the name in `{}` should still be an ordinary variable",
+                script.lines().next().unwrap_or_default()
+            );
+        }
+    }
+
+    /// Case follows both references exactly: lowercase sigil and suffix,
+    /// uppercase strain, level 1 to 7. Anything else is a name the script never
+    /// defined, which is reported rather than guessed at.
+    #[test]
+    fn a_misspelled_contract_is_not_quietly_accepted() {
+        use dealer_parser::parse;
+
+        let mut gen = FastDealGenerator::new(1);
+        let deal = gen.next_deal();
+        let ctx = EvalContext::new(&deal);
+
+        for word in ["X3N", "x3n", "x8N", "x0N", "x3NX", "x3Nxxx", "3N"] {
+            let script = format!("score(nv, {}, 9)", word);
+            let refused = match parse(&script) {
+                Err(_) => true,
+                Ok(ast) => eval(&ast, &ctx).is_err(),
+            };
+            assert!(refused, "`{}` should not be read as a contract", word);
+        }
     }
 
     /// The cycle guard in `reaches_rnd`. A variable referring to itself cannot
@@ -2899,8 +2981,8 @@ mod tests {
         let ctx = EvalContext::new(&deal);
 
         // Use tricks() result in score() calculation
-        // score(0, 34, tricks(north, 4)) = score for 3NT non-vul based on DD tricks
-        let ast = parse("score(0, 34, tricks(north, 4))").unwrap();
+        // score(nv, x3N, tricks(north, 4)) = 3NT non-vul on the double-dummy result
+        let ast = parse("score(nv, x3N, tricks(north, 4))").unwrap();
         let score = eval(&ast, &ctx).unwrap();
 
         // The score should be:

--- a/dealer-eval/tests/alias_spellings_agree.rs
+++ b/dealer-eval/tests/alias_spellings_agree.rs
@@ -125,8 +125,8 @@ fn aliases_agree_when_given_a_suit() {
 fn notrump_is_the_strain_number_four() {
     let deal = &deals()[0];
     // 3NT making nine tricks, not vulnerable.
-    let by_number = evaluate("condition score(0, 34, 9)\n", deal);
-    let by_word = evaluate("condition score(0, 30 + notrump, 9)\n", deal);
+    let by_number = evaluate("condition score(0, 19, 9)\n", deal);
+    let by_word = evaluate("condition score(0, 15 + notrump, 9)\n", deal);
     assert_eq!(by_word, by_number, "`notrump` must be the number 4");
     assert_eq!(by_number, 400);
 

--- a/dealer-eval/tests/doc_examples_evaluate.rs
+++ b/dealer-eval/tests/doc_examples_evaluate.rs
@@ -66,46 +66,71 @@ fn every_operator_example_evaluates() {
     }
 }
 
-/// The documented value of `score(0, 34, 9)` — 3NT, not vulnerable, making — is
-/// stated as 400 in the reference. Check the engine agrees, so the one example
-/// carrying a number cannot quietly become wrong.
+/// The documented value of `score(nv, x3N, 9)` — 3NT, not vulnerable, making —
+/// is stated as 400 in the reference. Check the engine agrees, so the one
+/// example carrying a number cannot quietly become wrong.
 #[test]
 fn the_score_example_gives_the_number_it_claims() {
     let deal = reference_deal();
     assert_eq!(
-        evaluate("condition score(0, 34, 9)\n", &deal).expect("score should evaluate"),
+        evaluate("condition score(nv, x3N, 9)\n", &deal).expect("score should evaluate"),
         400,
         "the `score` entry tells readers that 3NT making nine tricks scores 400"
     );
 }
 
-/// The `score` entry describes an encoding — level × 10 + strain, plus 100
-/// doubled or 200 redoubled — which is the most intricate claim on the
-/// reference page and the easiest to get subtly wrong. Every part of it is
-/// checked here against scores that are a matter of record.
+/// The `score` entry describes both spellings — the contract as a word, and the
+/// encoding level × 5 + strain plus 40 per level of doubling that the word
+/// stands for. That is the most intricate claim on the reference page and the
+/// easiest to get subtly wrong, so every part of it is checked here against
+/// scores that are a matter of record, in both spellings.
 #[test]
 fn the_documented_contract_encoding_is_the_real_one() {
     let deal = reference_deal();
     for (script, expected, what) in [
         (
-            "condition score(0, 34, 9)\n",
+            "condition score(nv, x3N, 9)\n",
             400,
             "3NT not vulnerable, making",
         ),
-        ("condition score(1, 34, 9)\n", 600, "3NT vulnerable, making"),
         (
-            "condition score(0, 43, 10)\n",
+            "condition score(0, 19, 9)\n",
+            400,
+            "the same, written as numbers",
+        ),
+        (
+            "condition score(vul, x3N, 9)\n",
+            600,
+            "3NT vulnerable, making",
+        ),
+        (
+            "condition score(nv, x4S, 10)\n",
             420,
             "four spades not vulnerable, making",
         ),
-        ("condition score(0, 134, 9)\n", 550, "3NT doubled, making"),
         (
-            "condition score(0, 243, 10)\n",
+            "condition score(0, 23, 10)\n",
+            420,
+            "the same, written as numbers",
+        ),
+        ("condition score(nv, x3Nx, 9)\n", 550, "3NT doubled, making"),
+        (
+            "condition score(0, 59, 9)\n",
+            550,
+            "the same, written as numbers",
+        ),
+        (
+            "condition score(nv, x4Sxx, 10)\n",
             880,
             "four spades redoubled, making",
         ),
         (
-            "condition score(0, 134, 7)\n",
+            "condition score(0, 103, 10)\n",
+            880,
+            "the same, written as numbers",
+        ),
+        (
+            "condition score(nv, x3Nx, 7)\n",
             -300,
             "3NT doubled, two down",
         ),

--- a/dealer-parser/src/grammar.pest
+++ b/dealer-parser/src/grammar.pest
@@ -167,7 +167,8 @@ multiplicative = { unary ~ (mul_op ~ unary)* }
 unary = { "-" ~ unary | not_op ~ unary | primary }
 
 primary = _{
-    function_call  // Must be first to parse function(args)
+    score_call     // Before function_call: score's own argument spellings
+    | function_call  // Must be first to parse function(args)
     | paren_expr
     | shape_pattern
     | card
@@ -182,6 +183,44 @@ paren_expr = { "(" ~ expr ~ ")" }
 
 // Function calls: hcp(north), hearts(south,spades), hascard(south,AS)
 function_call = { function_name ~ "(" ~ expr ~ ("," ~ expr)* ~ ")" }
+
+// `score` is the one function whose arguments the original does not read as
+// expressions. Its rule is `SCORE '(' VULN ',' CONTRACT ',' expr ')'`
+// (defs.y:331): the first two arguments are lexer tokens, so only the trick
+// count can be computed. dealer3 accepts either the token or the number the
+// token stands for, the same way `tricks` takes either a suit word or its
+// index — the tokens are what a script written elsewhere will use, and the
+// numbers are what a `--param` can supply.
+//
+// Tried ahead of `function_call`, and falling through to it when the shape
+// does not fit, so `score(0, 34)` still reaches the evaluator's argument-count
+// error rather than becoming a syntax error.
+score_call = { score_name ~ "(" ~ score_arg ~ "," ~ score_arg ~ "," ~ expr ~ ")" }
+score_name = @{ "score" ~ !(ASCII_ALPHANUMERIC | "_") }
+score_arg = _{ contract_token | vuln_token | expr }
+
+// A contract, written as one word: `x3N`, `x4H`, `x7Sxx`.
+//
+// The leading character is a sigil, not a meaning — it is there so the lexer
+// can tell the word from a number, and `make_contract` in both references is
+// handed the string *after* it. dealer.exe allows only `x` (scan.l:101);
+// DealerV2_4 adds `z` as an interchangeable second sigil and the trailing
+// `x`s for doubled and redoubled (dealflex.l:403). `z4H` and `x4H` are the
+// same contract.
+//
+// Case follows the references exactly: lowercase sigil and suffix, uppercase
+// strain. Accepting `X3n` here would let a script run in dealer3 and fail on
+// BBO, which is the sort of difference #13 exists to warn about rather than
+// something to create.
+contract_token = @{
+    ("x" | "z") ~ '1'..'7' ~ ("C" | "D" | "H" | "S" | "N") ~ "x"{0,2}
+    ~ !(ASCII_ALPHANUMERIC | "_")
+}
+
+// Vulnerability for `score`, as the original spells it (scan.l:47-48).
+// Recognised only in that argument position, so a script may still have a
+// variable named `vul` anywhere else.
+vuln_token = @{ ("nv" | "vul") ~ !(ASCII_ALPHANUMERIC | "_") }
 
 // Longest spelling first, always. `function_call` is `function_name ~ "("`, and
 // PEG does not retry an alternation once a branch has matched: `hcp` ahead of

--- a/dealer-parser/src/parser.rs
+++ b/dealer-parser/src/parser.rs
@@ -628,6 +628,43 @@ fn build_statement(pair: Pair<Rule>) -> Result<Statement, ParseError> {
     }
 }
 
+/// Encode a contract token such as `x3N` or `x4Hxx` as a number.
+///
+/// The grammar has already checked the shape, so the only work here is the
+/// arithmetic both references do: `level * 5 + strain`, plus 40 for each level
+/// of doubling. The leading sigil carries no meaning and is skipped, exactly as
+/// `make_contract` skips it in dealer.exe and in DealerV2_4.
+fn contract_code(token: &str) -> Result<i32, ParseError> {
+    let mut chars = token.chars();
+    chars.next(); // the sigil, `x` or `z`
+
+    let level = match chars.next().and_then(|c| c.to_digit(10)) {
+        Some(level) => level as i32,
+        None => {
+            return Err(ParseError {
+                message: format!("Contract has no level: {}", token),
+            })
+        }
+    };
+
+    let strain = match chars.next() {
+        Some('C') => 0,
+        Some('D') => 1,
+        Some('H') => 2,
+        Some('S') => 3,
+        Some('N') => 4,
+        _ => {
+            return Err(ParseError {
+                message: format!("Contract has no strain: {}", token),
+            })
+        }
+    };
+
+    let doubled = chars.filter(|c| *c == 'x').count() as i32;
+
+    Ok(40 * doubled + level * 5 + strain)
+}
+
 /// Parse a single card from a string like "AS", "KH", "2C" (rank+suit format for hascard)
 fn parse_card(card_str: &str) -> Result<dealer_core::Card, ParseError> {
     if card_str.len() != 2 {
@@ -930,6 +967,34 @@ fn build_ast(pair: Pair<Rule>) -> Result<Expr, ParseError> {
             Err(ParseError {
                 message: "Unexpected function_name rule".to_string(),
             })
+        }
+
+        Rule::score_call => {
+            // score_name, then the three arguments. The first two may have
+            // arrived as tokens, which the rules below have already turned
+            // into the numbers they stand for.
+            let mut args = Vec::new();
+            for arg_pair in pair.into_inner() {
+                if arg_pair.as_rule() == Rule::score_name {
+                    continue;
+                }
+                args.push(build_ast(arg_pair)?);
+            }
+
+            Ok(Expr::call_multi(Function::Score, args))
+        }
+
+        Rule::contract_token => {
+            // Both references encode a contract as level * 5 + strain, plus 40
+            // per level of doubling, and dealer3 uses the same numbers so there
+            // is one encoding rather than two.
+            Ok(Expr::Literal(contract_code(pair.as_str())?))
+        }
+
+        Rule::vuln_token => {
+            // NON_VUL and VUL in tree.h are 0 and 1, which is what `score`
+            // already reads.
+            Ok(Expr::Literal(i32::from(pair.as_str() == "vul")))
         }
 
         Rule::position => {

--- a/dealer-parser/src/vocabulary.rs
+++ b/dealer-parser/src/vocabulary.rs
@@ -599,7 +599,7 @@ pub const FUNCTION_DOCS: &[FunctionDoc] = &[
         group: "Double-dummy and scoring",
         signature: "imp(scoredifference)",
         summary: "Singular spelling of `imps`.",
-        example: "imp(score(0, 43, 10) - score(0, 34, 9)) >= 1",
+        example: "imp(score(nv, x4S, 10) - score(nv, x3N, 9)) >= 1",
         alias_of: Some("imps"),
         note: None,
     },
@@ -608,15 +608,22 @@ pub const FUNCTION_DOCS: &[FunctionDoc] = &[
         group: "Double-dummy and scoring",
         signature: "score(vulnerable, contract, tricks)",
         summary: "Declarer's score for a contract played at that vulnerability and making that \
-                  many tricks. `vulnerable` is 0 or 1; `contract` is level × 10 + strain, plus \
-                  100 if doubled or 200 if redoubled; `tricks` is 0 to 13.",
-        example: "score(0, 34, 9) == 400",
+                  many tricks. `vulnerable` is the word `nv` or `vul`; `contract` is a word \
+                  such as `x3N`; `tricks` is 0 to 13.",
+        example: "score(nv, x3N, 9) == 400",
         alias_of: None,
         note: Some(
-            "Strain digits match `tricks`: 0 clubs, 1 diamonds, 2 hearts, 3 spades, 4 notrump. \
-             So 34 is 3NT, 43 is four spades, 143 is four spades doubled and 243 redoubled. \
-             The original dealer writes the contract as a token such as `3N`; dealer3 requires \
-             the number.",
+            "A contract is one word: a lowercase `x`, the level, and the strain as an \
+             uppercase letter of CDHSN. The `x` is a sigil rather than a meaning — it is \
+             what lets the word be told from a number — so doubling is written as a suffix: \
+             `x4Hx` is four hearts doubled and `x4Hxx` redoubled. `z` may be used in place \
+             of the leading `x`, as in DealerV2_4, and means exactly the same thing. Both \
+             the case and the level range are the references' own, so a word that runs here \
+             runs on BBO.\n\nEither argument may also be written as the number it stands \
+             for, which is what a `--param` can supply: 0 or 1 for the vulnerability, and \
+             level × 5 + strain for the contract, plus 40 for each level of doubling. Strain \
+             numbers match `tricks`: 0 clubs, 1 diamonds, 2 hearts, 3 spades, 4 notrump. So \
+             `x3N` is 19, `x4S` is 23, `x4Sx` is 63 and `x4Sxx` is 103.",
         ),
     },
     FunctionDoc {
@@ -624,7 +631,7 @@ pub const FUNCTION_DOCS: &[FunctionDoc] = &[
         group: "Double-dummy and scoring",
         signature: "imps(scoredifference)",
         summary: "Converts a difference between two scores into IMPs, by the standard table.",
-        example: "imps(score(0, 43, 10) - score(0, 34, 9)) >= 1",
+        example: "imps(score(nv, x4S, 10) - score(nv, x3N, 9)) >= 1",
         alias_of: None,
         note: None,
     },

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -213,20 +213,6 @@ pub const REMAINING: &[WorkItem] = &[
         note: Some("The original takes a second expression and range and prints marginals."),
     },
     WorkItem {
-        what: "Contract tokens in `score()`, e.g. `3N` for the code 34",
-        done_when: None,
-        issue: None,
-        effort: Effort::Low,
-        value: Value::Low,
-        note: Some(
-            "**The spelling is not a free choice.** The original has the token already — \
-             `[x][1-7][CDHSN]` in `scan.l`, feeding `score(VULN, CONTRACT, expr)` in \
-             `defs.y` — so `x4H` is dealer.exe's own and compatibility settles it. \
-             DealerV2_4 extends that to `[xz][1-7][CDHSN][x]{0,2}`, where the `z` prefix \
-             and the trailing `x`s make `x4Hx` four hearts doubled.",
-        ),
-    },
-    WorkItem {
         what: "The length-bias form of `predeal`, `spades(north) == 5`",
         done_when: None,
         issue: None,

--- a/dealer/tests/original_actions.rs
+++ b/dealer/tests/original_actions.rs
@@ -232,3 +232,40 @@ fn evalcontract_is_refused_rather_than_read_as_a_variable() {
     );
     assert_eq!(status, 1);
 }
+
+/// A `score` script in the original's own spelling, run through the reference
+/// binary and captured. Both binaries were given this file and printed these
+/// seven lines.
+///
+/// The contract and the vulnerability are lexer tokens in the original
+/// (`scan.l:47-48` and `scan.l:101`), not expressions, so until dealer3 learned
+/// the words this script was a parse error here and its numeric equivalent was
+/// a syntax error there — the one word neither dialect could read from the
+/// other. The capture is what keeps that shut.
+const REFERENCE_SCORES: &str = "\
+a_3N_nv_9: 400
+b_3N_vul_9: 600
+c_4S_nv_10: 420
+d_1C_nv_7: 70
+e_7N_vul_13: 2220
+f_5D_nv_9: -100
+g_6H_vul_12: 1430
+";
+
+#[test]
+fn score_reads_the_originals_contract_and_vulnerability_words() {
+    let script = format!(
+        "{FIXED_DEAL}condition 1
+action average \"a_3N_nv_9\" score(nv, x3N, 9),
+       average \"b_3N_vul_9\" score(vul, x3N, 9),
+       average \"c_4S_nv_10\" score(nv, x4S, 10),
+       average \"d_1C_nv_7\" score(nv, x1C, 7),
+       average \"e_7N_vul_13\" score(vul, x7N, 13),
+       average \"f_5D_nv_9\" score(nv, x5D, 9),
+       average \"g_6H_vul_12\" score(vul, x6H, 12)
+"
+    );
+    let (out, status) = run(&["-q", "-p", "1", "-s", "1"], &script);
+    assert_eq!(status, 0);
+    assert_eq!(out, REFERENCE_SCORES);
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`score()` now takes dealer.exe's own spellings.** The contract is a word —
+  `x3N`, `x4H`, `x7Sxx` — and the vulnerability is `nv` or `vul`, exactly as
+  `scan.l:47-48` and `scan.l:101` define them. `z` may replace the leading `x`,
+  as in DealerV2_4, and means the same thing: the sigil is there so the word can
+  be told from a number, and both references skip it before reading the
+  contract. Doubling is the trailing `x`s that DealerV2_4 added, `x4Hx` and
+  `x4Hxx`.
+  - This was the one word where dealer3 and the original could not read each
+    other's scripts. The original's grammar is
+    `SCORE '(' VULN ',' CONTRACT ',' expr ')'` (`defs.y:331`) — the first two
+    arguments are lexer tokens, so `score(nv, x3N, 9)` was a name dealer3 had
+    never heard of, and `score(0, 34, 9)` was a syntax error there. The same
+    script now runs on both binaries and prints the same numbers.
+  - Case is the references' own: lowercase sigil and suffix, uppercase strain,
+    level 1 to 7. `X3N` and `x3n` are refused rather than guessed at, so a word
+    that runs here runs on BBO.
+  - The words are recognised only where `score` takes them, so a script may
+    still have a variable named `vul`, `nv` or `x3N` anywhere else.
+  - Verified across all 2,940 combinations of vulnerability, doubling, level,
+    strain and trick count against both C implementations — `dealer.c:195` for
+    the undoubled ones and DealerV2_4's `dealeval_subs.c:744` for the doubled
+    and redoubled — with no differences. (#34)
+
 - **`--level`: level a scenario and deal it in one run.** `--write-leveled`
   writes the file and stops, which is what a scenario you keep and regenerate
   wants; `--level` goes on to deal what `-p` asked for from the levelled copy
@@ -19,6 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which has nothing to walk through.
 
 ### Changed
+- **Breaking: `score()`'s numeric contract code is now the references' encoding,
+  `level * 5 + strain`, plus 40 for each level of doubling.** dealer3 used to
+  read `level * 10 + strain` plus 100 or 200, so 3NT was 34 and is now 19, and
+  four spades doubled was 143 and is now 63. Numbers are still accepted
+  alongside the words, since the words are lexer constants in both references
+  and so can never be a variable or a `--param`; but there is now one encoding
+  in the world rather than two.
+  - A number between 5 and 39 is valid under both schemes and means different
+    contracts under each, so this cannot be detected and warned about. It is
+    safe only because `score()` arrived with the solver in this same unreleased
+    cycle and no script uses it yet. Anything written against the old numbers
+    must be respelled — preferably as the words.
 - **One generate loop, in `dealer-run`, for both front ends.** Dealing, testing
   the condition, classifying against `HandType_`/`LevelType_`, the `average` and
   `frequency` accumulators, the `printrpt`/`csvrpt` renderer, threading and the

--- a/docs/FILTER_LANGUAGE_STATUS.md
+++ b/docs/FILTER_LANGUAGE_STATUS.md
@@ -113,10 +113,10 @@ for the same predealt deal.
 | `dds(compass, strain)` | Another spelling of `tricks` | `dds(south, notrump) >= 9` |
 | | There it reaches the DDS library where `tricks` reaches GIB's solver; dealer3 solves everything through bridge-solver, so the two are one function with two names. Ten of DealerV2_4's regression scripts use it. | |
 | `trick(compass, strain)` | Another spelling of `tricks` | `trick(south, spades) >= 10` |
-| `imp(scoredifference)` | Another spelling of `imps` | `imp(score(0, 43, 10) - score(0, 34, 9)) >= 1` |
-| `score(vulnerable, contract, tricks)` | Declarer's score for a contract played at that vulnerability and making that many tricks. `vulnerable` is 0 or 1; `contract` is level × 10 + strain, plus 100 if doubled or 200 if redoubled; `tricks` is 0 to 13. | `score(0, 34, 9) == 400` |
-| | Strain digits match `tricks`: 0 clubs, 1 diamonds, 2 hearts, 3 spades, 4 notrump. So 34 is 3NT, 43 is four spades, 143 is four spades doubled and 243 redoubled. The original dealer writes the contract as a token such as `3N`; dealer3 requires the number. | |
-| `imps(scoredifference)` | Converts a difference between two scores into IMPs, by the standard table. | `imps(score(0, 43, 10) - score(0, 34, 9)) >= 1` |
+| `imp(scoredifference)` | Another spelling of `imps` | `imp(score(nv, x4S, 10) - score(nv, x3N, 9)) >= 1` |
+| `score(vulnerable, contract, tricks)` | Declarer's score for a contract played at that vulnerability and making that many tricks. `vulnerable` is the word `nv` or `vul`; `contract` is a word such as `x3N`; `tricks` is 0 to 13. | `score(nv, x3N, 9) == 400` |
+| | A contract is one word: a lowercase `x`, the level, and the strain as an uppercase letter of CDHSN. The `x` is a sigil rather than a meaning — it is what lets the word be told from a number — so doubling is written as a suffix: `x4Hx` is four hearts doubled and `x4Hxx` redoubled. `z` may be used in place of the leading `x`, as in DealerV2_4, and means exactly the same thing. Both the case and the level range are the references' own, so a word that runs here runs on BBO. Either argument may also be written as the number it stands for, which is what a `--param` can supply: 0 or 1 for the vulnerability, and level × 5 + strain for the contract, plus 40 for each level of doubling. Strain numbers match `tricks`: 0 clubs, 1 diamonds, 2 hearts, 3 spades, 4 notrump. So `x3N` is 19, `x4S` is 23, `x4Sx` is 63 and `x4Sxx` is 103. | |
+| `imps(scoredifference)` | Converts a difference between two scores into IMPs, by the standard table. | `imps(score(nv, x4S, 10) - score(nv, x3N, 9)) >= 1` |
 | `rnd(bound)` | A random whole number from zero up to, but not including, the bound. | `rnd(10) == 3` |
 | | Every mention draws again, including through a variable: `r = rnd(4)` used twice is two draws, as in the original. Drawn from a stream of its own, seeded from the deal, so the same seed gives the same answers however many threads are running; the original shares the generator it shuffles with, so calling it there changes the deals. `--rnd-seed` shifts the stream. Beware locally built dealer binaries: `rnd` divides by `RAND_MAX`, which describes `rand()` rather than the generator it actually calls, so a build without `STD_RAND` returns values far outside the bound, or negative ones. BBO's own build is correct. | |
 <!-- END GENERATED: functions -->
@@ -209,7 +209,6 @@ tracked by a generated table, so this section is maintained by hand.
 
 | Difference | Status |
 |---|---|
-| `score` takes a numeric contract code, not a token like `3N` | Documented, no issue |
 | `frequency` has no two-dimensional form | Documented, no issue |
 | `predeal` has no length-bias form (`spades(north) == 5`) | Documented, no issue |
 | `rnd()` is broken on locally built dealer binaries | Not ours: `rnd` divides by `RAND_MAX`, which describes `rand()` rather than the generator it calls. A build without `STD_RAND` returns values far outside the bound (Windows: `rnd(10)` averages 322,000) or negative ones (macOS: 43% below zero). BBO's build is correct, and dealer3 agrees with it. |

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -265,7 +265,6 @@ Priority is derived from effort and value rather than written down beside them.
 
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
-| 🔵 Unlikely | Contract tokens in `score()`, e.g. `3N` for the code 34 | Low | Low |  | **The spelling is not a free choice.** The original has the token already — `[x][1-7][CDHSN]` in `scan.l`, feeding `score(VULN, CONTRACT, expr)` in `defs.y` — so `x4H` is dealer.exe's own and compatibility settles it. DealerV2_4 extends that to `[xz][1-7][CDHSN][x]{0,2}`, where the `z` prefix and the trailing `x`s make `x4Hx` four hearts doubled. |
 | 🔵 Unlikely | Upper-case the honour cards in output | Low | Low |  | Cosmetic. |
 | 🔵 Unlikely | `par(side)`: the par contract | Low | Low |  | Needs all 20 double-dummy results, which bridge-solver already provides for `tricks()`, `score()` and `imps()`. DealerV2_4 sets its vulnerability with `-P`, which has a row of its own in the switch table. |
 | 🔵 Unlikely | `printns` and `printside(side)` | Low | Low |  | dealer3 has `printew`; DealerV2_4 routes all three through one action. |


### PR DESCRIPTION
Closes #34.

`score` was the one word where dealer3 and the original could not read each other's scripts. The original's grammar is `SCORE '(' VULN ',' CONTRACT ',' expr ')'` (`defs.y:331`) — the first two arguments are lexer tokens, not expressions.

| Script | dealer.exe, before | dealer3, before | dealer3, now |
|---|---|---|---|
| `score(nv, x3N, 9)` | runs | `name never defined: x3N` | runs |
| `score(0, 19, 9)` | syntax error | — | runs |

## What is accepted

- `nv` / `vul` for the vulnerability (`scan.l:47-48`).
- A contract as one word (`scan.l:101`): lowercase sigil, level 1-7, uppercase strain from CDHSN. `z` may replace the leading `x` as in DealerV2_4 — the sigil carries no meaning in either reference, since `make_contract` is handed the string *after* it, so `z4H` and `x4H` are one contract. Doubling is DealerV2_4's trailing `x`s: `x4Hx`, `x4Hxx`.
- Case is the references' own. `X3N` and `x3n` are refused rather than guessed at, so a word that runs here runs on BBO — being lenient would manufacture work for #13.
- The words are recognised **only** in score's argument positions, so a script may still have a variable named `vul`, `nv` or `x3N` anywhere else. There is a test for that.

## Breaking: the numeric encoding moved

Numbers still work alongside the words — a lexer token can never be a variable or a `--param`, and script parameters just shipped — but the encoding is now the references' `level * 5 + strain`, plus 40 per level of doubling. 3NT was 34 and is 19; four spades doubled was 143 and is 63.

A number in 5..39 is valid under both schemes and means different contracts under each, so this cannot be detected and warned about. It is safe only because `score()` arrived with the solver in this same unreleased cycle and nothing uses it yet.

## The arithmetic did not change

It did not need to. All 2,940 combinations of vulnerability, doubling, level, strain and trick count already agreed with `dealer.c:195` (undoubled) and DealerV2_4's `dealeval_subs.c:744` (doubled and redoubled), and still do after the change — verified through the token spelling this time, with zero differences.

A seven-line script in the original's spelling now runs on **both** binaries and prints the same seven numbers. That capture is `score_reads_the_originals_contract_and_vulnerability_words` in `dealer/tests/original_actions.rs`.

## Docs

`FILTER_LANGUAGE_STATUS.md` and the roadmap matrix regenerate from `vocabulary.rs` and `roadmap.rs`; the row in the hand-kept differences table is gone, and the roadmap note claiming DealerV2_4's `z` prefix means something went with the finished item. The web language reference reads the same vocabulary through the WASM build, so it follows on the next deploy.

492 tests pass; `cargo fmt` and `clippy -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)