### PR TITLE
A miscounted call generated the whole run and said nothing

### DIFF
--- a/dealer-eval/src/lib.rs
+++ b/dealer-eval/src/lib.rs
@@ -5,7 +5,9 @@ pub use counts::{CountError, CountRow, PointCounts};
 
 use dealer_core::{Card, Deal, Position, Suit};
 use dealer_dds::Denomination;
-use dealer_parser::{BinaryOp, Expr, Function, Program, ShapePattern, Statement, UnaryOp};
+use dealer_parser::{
+    BinaryOp, CsvTerm, EsTerm, Expr, Function, Program, ShapePattern, Statement, UnaryOp,
+};
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 
@@ -270,9 +272,13 @@ fn calculate_made_score(vulnerable: bool, contract: &Contract, overtricks: i32) 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EvalError {
     /// Function requires specific number of arguments
+    ///
+    /// The range is inclusive, and comes from `Function::arity`, so the two
+    /// cannot disagree about what a function takes.
     InvalidArgumentCount {
         function: String,
-        expected: usize,
+        min: usize,
+        max: usize,
         got: usize,
     },
     /// Invalid argument type or value
@@ -288,14 +294,16 @@ impl std::fmt::Display for EvalError {
         match self {
             EvalError::InvalidArgumentCount {
                 function,
-                expected,
+                min,
+                max,
                 got,
             } => {
-                write!(
-                    f,
-                    "Function {} expects {} arguments, got {}",
-                    function, expected, got
-                )
+                let expected = if min == max {
+                    format!("{}", min)
+                } else {
+                    format!("{} or {}", min, max)
+                };
+                write!(f, "{} takes {} arguments, not {}", function, expected, got)
             }
             EvalError::InvalidArgument(msg) => write!(f, "Invalid argument: {}", msg),
             EvalError::NotImplemented(feature) => write!(f, "Not implemented: {}", feature),
@@ -818,19 +826,135 @@ fn counted(
     }
 }
 
+/// Refuse a call whose argument count `Function::arity` does not allow.
+fn check_call_arity(function: &Function, got: usize) -> Result<(), EvalError> {
+    let (min, max) = function.arity();
+    if (min..=max).contains(&got) {
+        return Ok(());
+    }
+    Err(EvalError::InvalidArgumentCount {
+        function: function.name().to_string(),
+        min,
+        max,
+        got,
+    })
+}
+
+/// Check everything about an expression that can be known without a deal.
+///
+/// Today that is argument counts, which are a property of the script. Running
+/// this once, before the first card is dealt, is what keeps a miscounted call
+/// from being mistaken for a condition that simply never matches (#36).
+///
+/// Errors it cannot reach — a strain computed at run time that lands outside
+/// 0 to 4, say — are genuinely per-deal and are reported by the run when they
+/// happen, rather than discarded.
+pub fn check_static(expr: &Expr) -> Result<(), EvalError> {
+    match expr {
+        Expr::FunctionCall { func, args } => {
+            check_call_arity(func, args.len())?;
+            for arg in args {
+                check_static(arg)?;
+            }
+            Ok(())
+        }
+        Expr::BinaryOp { left, right, .. } => {
+            check_static(left)?;
+            check_static(right)
+        }
+        Expr::UnaryOp { expr, .. } => check_static(expr),
+        Expr::Ternary {
+            condition,
+            true_expr,
+            false_expr,
+        } => {
+            check_static(condition)?;
+            check_static(true_expr)?;
+            check_static(false_expr)
+        }
+        Expr::Literal(_)
+        | Expr::Position(_)
+        | Expr::ShapePattern(_)
+        | Expr::Card(_)
+        | Expr::Suit(_)
+        | Expr::Variable(_) => Ok(()),
+    }
+}
+
+/// Check every expression a program contains, before any deal is made.
+///
+/// Reaches the condition, each variable, and the expressions inside `average`,
+/// `frequency`, `printes`, `printrpt` and `csvrpt` — a miscounted call in a
+/// statistic used to surface only once a deal matched, so a script that matched
+/// nothing never reported it at all.
+///
+/// The name that comes back with the error is the statement it was found in, so
+/// a script with several can be told which one to look at.
+pub fn check_program(program: &Program) -> Result<(), (String, EvalError)> {
+    let at = |what: &str, expr: &Expr| check_static(expr).map_err(|e| (what.to_string(), e));
+
+    for statement in &program.statements {
+        match statement {
+            Statement::Assignment { name, expr } => {
+                check_static(expr).map_err(|e| (format!("`{}`", name), e))?
+            }
+            Statement::Expression(expr) | Statement::Condition(expr) => at("condition", expr)?,
+            Statement::Action {
+                averages,
+                frequencies,
+                printes,
+                print_reports,
+                ..
+            } => {
+                for average in averages {
+                    at("average", &average.expr)?;
+                }
+                for frequency in frequencies {
+                    at("frequency", &frequency.expr)?;
+                }
+                for terms in printes {
+                    for term in terms {
+                        if let EsTerm::Expression(expr) = term {
+                            at("printes", expr)?;
+                        }
+                    }
+                }
+                for terms in print_reports {
+                    check_csv_terms("printrpt", terms)?;
+                }
+            }
+            Statement::CsvReport(terms) => check_csv_terms("csvrpt", terms)?,
+            Statement::PrintReport(terms) => check_csv_terms("printrpt", terms)?,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// The expressions in a `csvrpt` or `printrpt` list; the other terms are
+/// literals and seats, with nothing to check.
+fn check_csv_terms(what: &str, terms: &[CsvTerm]) -> Result<(), (String, EvalError)> {
+    for term in terms {
+        if let CsvTerm::Expression(expr) = term {
+            check_static(expr).map_err(|e| (what.to_string(), e))?;
+        }
+    }
+    Ok(())
+}
+
 /// Evaluate a function call
 fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Result<i32, EvalError> {
+    // One check for every function, against `Function::arity`, rather than a
+    // count written out again in each arm below. `check_arity` walks the whole
+    // script before any deal is made and reports the same thing there, so in
+    // practice this arm is unreachable from a run — it stays because the
+    // evaluator is a public entry point of its own.
+    check_call_arity(function, args.len())?;
+
     match function {
         Function::Hcp => {
             // hcp(position) - total HCP for a hand
             // hcp(position, suit) - HCP in a specific suit
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "hcp".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -850,52 +974,24 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Hearts => {
-            if args.len() != 1 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "hearts".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
             Ok(hand.suit_length(dealer_core::Suit::Hearts) as i32)
         }
 
         Function::Spades => {
-            if args.len() != 1 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "spades".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
             Ok(hand.suit_length(dealer_core::Suit::Spades) as i32)
         }
 
         Function::Diamonds => {
-            if args.len() != 1 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "diamonds".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
             Ok(hand.suit_length(dealer_core::Suit::Diamonds) as i32)
         }
 
         Function::Clubs => {
-            if args.len() != 1 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "clubs".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
             Ok(hand.suit_length(dealer_core::Suit::Clubs) as i32)
@@ -904,13 +1000,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         Function::Controls => {
             // controls(position) - total controls for a hand
             // controls(position, suit) - controls in a specific suit
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "controls".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -934,13 +1023,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Shape => {
-            if args.len() != 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "shape".to_string(),
-                    expected: 2,
-                    got: args.len(),
-                });
-            }
             let position = eval_position_arg(&args[0], ctx)?;
             let pattern = match &args[1] {
                 Expr::ShapePattern(p) => p,
@@ -957,14 +1039,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Losers => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "losers".to_string(),
-                    expected: 1, // or 2 with suit
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -986,14 +1060,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::HasCard => {
-            if args.len() != 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "hascard".to_string(),
-                    expected: 2,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let card = eval_card_arg(&args[1])?;
             let hand = ctx.deal.hand(position);
@@ -1003,14 +1069,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
 
         // Alternative point counts (pt0-pt9 / readable synonyms)
         Function::Tens => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "tens".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1027,14 +1085,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Jacks => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "jacks".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1051,14 +1101,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Queens => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "queens".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1075,14 +1117,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Kings => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "kings".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1099,14 +1133,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Aces => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "aces".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1123,14 +1149,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Top2 => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "top2".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1147,14 +1165,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Top3 => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "top3".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1171,14 +1181,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Top4 => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "top4".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1195,14 +1197,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Top5 => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "top5".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1219,14 +1213,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::C13 => {
-            if args.is_empty() || args.len() > 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "c13".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1243,14 +1229,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Quality => {
-            if args.len() != 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "quality".to_string(),
-                    expected: 2,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let suit = eval_suit_arg(&args[1])?;
             let hand = ctx.deal.hand(position);
@@ -1259,14 +1237,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         }
 
         Function::Cccc => {
-            if args.len() != 1 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "cccc".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             let position = eval_position_arg(&args[0], ctx)?;
             let hand = ctx.deal.hand(position);
 
@@ -1277,13 +1247,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
             // tricks(position, denomination)
             // position: north/south/east/west
             // denomination: 0=C, 1=D, 2=H, 3=S, 4=NT (or use suit keywords)
-            if args.len() != 2 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "tricks".to_string(),
-                    expected: 2,
-                    got: args.len(),
-                });
-            }
 
             let declarer = eval_position_arg(&args[0], ctx)?;
 
@@ -1323,13 +1286,6 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
             //   doubled_flag: 0=undoubled, 1=doubled, 2=redoubled
             //   Examples: 3NT = 34, 4S = 43, 3NT doubled = 134, 4Sx = 143, 4Sxx = 243
             // tricks: 0-13
-            if args.len() != 3 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "score".to_string(),
-                    expected: 3,
-                    got: args.len(),
-                });
-            }
 
             let vul_arg = eval(&args[0], ctx)?;
             let contract_code = eval(&args[1], ctx)?;
@@ -1400,25 +1356,10 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
         Function::Rnd => {
             // rnd(bound) - a random number in 0..bound, drawn from a stream of
             // this deal's own rather than from the shuffle. See `rnd`.
-            if args.len() != 1 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "rnd".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
             Ok(ctx.next_random(eval(&args[0], ctx)?))
         }
 
         Function::Imps => {
-            if args.len() != 1 {
-                return Err(EvalError::InvalidArgumentCount {
-                    function: "imps".to_string(),
-                    expected: 1,
-                    got: args.len(),
-                });
-            }
-
             // Evaluate the score difference expression
             let score_diff = eval(&args[0], ctx)?;
 
@@ -2908,5 +2849,109 @@ mod tests {
         // - Negative if failing (tricks < 9): -50 per undertrick
         // We can't predict exact value, but it should be a valid bridge score
         eprintln!("3NT score with DD tricks: {}", score);
+    }
+}
+
+#[cfg(test)]
+mod arity_tests {
+    use super::*;
+    use dealer_core::{FastDealGenerator, Position};
+    use dealer_parser::vocabulary;
+
+    /// Every spelling the language accepts, as the function it names.
+    ///
+    /// Driven by `vocabulary::FUNCTIONS`, which is already held to the grammar
+    /// by `tests/vocabulary_matches_grammar.rs`, so a function added to the
+    /// language cannot slip past these checks by not being listed here.
+    fn every_function() -> Vec<Function> {
+        let mut seen = Vec::new();
+        for name in vocabulary::FUNCTIONS {
+            if let Some(function) = Function::parse(name) {
+                if !seen.contains(&function) {
+                    seen.push(function);
+                }
+            }
+        }
+        assert!(seen.len() > 20, "the vocabulary should name every function");
+        seen
+    }
+
+    /// `Function::arity` says what each function takes, and the evaluator now
+    /// asks it rather than counting for itself. This checks the table describes
+    /// the real thing from the outside: a call inside the range is never
+    /// refused *for its argument count*, and one outside it always is.
+    ///
+    /// Arguments are all seats, so a function wanting something else fails on
+    /// the argument's kind — which is the point. Only the count is under test.
+    #[test]
+    fn the_arity_table_is_what_the_evaluator_accepts() {
+        let mut gen = FastDealGenerator::new(1);
+        let deal = gen.next_deal();
+        let ctx = EvalContext::new(&deal);
+
+        for function in every_function() {
+            let (min, max) = function.arity();
+            for count in 0..=max + 1 {
+                let args: Vec<Expr> = (0..count)
+                    .map(|_| Expr::Position(Position::North))
+                    .collect();
+                let miscounted = matches!(
+                    eval_function(&function, &args, &ctx),
+                    Err(EvalError::InvalidArgumentCount { .. })
+                );
+                assert_eq!(
+                    miscounted,
+                    !(min..=max).contains(&count),
+                    "{} takes {}..={} but {} arguments were {}",
+                    function.name(),
+                    min,
+                    max,
+                    count,
+                    if miscounted { "refused" } else { "allowed" }
+                );
+            }
+        }
+    }
+
+    /// The name in the message is one the script could have written, so a
+    /// reader can search for it.
+    #[test]
+    fn every_function_names_itself_as_the_language_spells_it() {
+        for function in every_function() {
+            assert_eq!(
+                Function::parse(function.name()),
+                Some(function),
+                "`{}` is not a spelling the parser accepts",
+                function.name()
+            );
+        }
+    }
+
+    /// The walk has to reach an argument, not just the outermost call — a
+    /// miscounted call nested inside a good one is the same mistake.
+    #[test]
+    fn check_static_reaches_nested_calls() {
+        use dealer_parser::parse;
+
+        for script in [
+            "hcp(north, spades, clubs)",
+            "hcp(north) + hcp(south, spades, clubs)",
+            "hcp(north) > 10 ? 1 : shape(north)",
+            "!hascard(north)",
+            "-cccc(north, south)",
+        ] {
+            let ast = parse(script).expect("should parse");
+            assert!(
+                matches!(
+                    check_static(&ast),
+                    Err(EvalError::InvalidArgumentCount { .. })
+                ),
+                "`{}` miscounts a call and should be refused",
+                script
+            );
+        }
+
+        let good = parse("hcp(north) + hcp(south, spades) > shape(north, any 4333)").unwrap();
+        assert!(check_static(&good).is_ok());
     }
 }

--- a/dealer-parser/src/ast.rs
+++ b/dealer-parser/src/ast.rs
@@ -424,6 +424,80 @@ impl Function {
             _ => None,
         }
     }
+
+    /// The canonical spelling, for error messages.
+    ///
+    /// One of the names `parse` accepts, so a message never names a function
+    /// the script could not have written.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Function::Hcp => "hcp",
+            Function::Spades => "spades",
+            Function::Hearts => "hearts",
+            Function::Diamonds => "diamonds",
+            Function::Clubs => "clubs",
+            Function::Controls => "controls",
+            Function::Losers => "losers",
+            Function::Shape => "shape",
+            Function::HasCard => "hascard",
+            Function::Tens => "tens",
+            Function::Jacks => "jacks",
+            Function::Queens => "queens",
+            Function::Kings => "kings",
+            Function::Aces => "aces",
+            Function::Top2 => "top2",
+            Function::Top3 => "top3",
+            Function::Top4 => "top4",
+            Function::Top5 => "top5",
+            Function::C13 => "c13",
+            Function::Quality => "quality",
+            Function::Cccc => "cccc",
+            Function::Tricks => "tricks",
+            Function::Score => "score",
+            Function::Imps => "imps",
+            Function::Rnd => "rnd",
+        }
+    }
+
+    /// How many arguments the function takes, as an inclusive range.
+    ///
+    /// The single source of truth: the evaluator checks against this rather
+    /// than carrying a count of its own per function, and the check that used
+    /// to live in each arm ran only once a deal had been dealt. See #36 — an
+    /// argument count is a property of the script, not of a deal, so it is
+    /// knowable before the first card comes out.
+    pub fn arity(&self) -> (usize, usize) {
+        match self {
+            // A hand, or a hand and one of its suits.
+            Function::Hcp
+            | Function::Controls
+            | Function::Losers
+            | Function::Tens
+            | Function::Jacks
+            | Function::Queens
+            | Function::Kings
+            | Function::Aces
+            | Function::Top2
+            | Function::Top3
+            | Function::Top4
+            | Function::Top5
+            | Function::C13 => (1, 2),
+
+            // A hand, or a number.
+            Function::Spades
+            | Function::Hearts
+            | Function::Diamonds
+            | Function::Clubs
+            | Function::Cccc
+            | Function::Imps
+            | Function::Rnd => (1, 1),
+
+            // A hand and something about it.
+            Function::Shape | Function::HasCard | Function::Quality | Function::Tricks => (2, 2),
+
+            Function::Score => (3, 3),
+        }
+    }
 }
 
 impl Expr {

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -32,6 +32,7 @@ use dealer_core::{
     generate_deal_from_seed, generate_deal_from_seed_no_predeal, Deal, FastDealConfig,
     FastDealGenerator, SwapMode,
 };
+use dealer_eval::EvalError;
 
 /// Which pass a progress report belongs to.
 ///
@@ -311,8 +312,8 @@ impl Workers {
         &self,
         count: usize,
         build: &(dyn Fn(usize) -> Deal + Sync),
-        test: &(dyn Fn(&Deal) -> bool + Sync),
-    ) -> Vec<(Deal, bool)> {
+        test: &(dyn Fn(&Deal) -> Result<bool, EvalError> + Sync),
+    ) -> Vec<(Deal, Result<bool, EvalError>)> {
         let one = |index: usize| {
             let deal = build(index);
             let passed = test(&deal);
@@ -703,6 +704,16 @@ fn run_pass(
     let preprocessed = dealer_parser::preprocess_all(script, opts.params)?;
     let program =
         dealer_parser::parse_program(&preprocessed).map_err(|e| format!("Parse error: {}", e))?;
+    // Everything about the script that a deal cannot change, checked once here
+    // rather than per deal. An argument count is the main one: the evaluator
+    // raised it correctly before, but the condition discarded the error and
+    // read it as "this deal does not match", so a miscounted call generated the
+    // whole run, produced nothing, said nothing and exited 0 (#36).
+    dealer_eval::check_program(&program).map_err(|(what, e)| RunError::Eval {
+        what,
+        message: e.to_string(),
+    })?;
+
     let variables = dealer_eval::extract_variables(&program);
     let constraint = dealer_eval::extract_constraint(&program);
     let point_counts = dealer_eval::extract_point_counts(&program)
@@ -730,13 +741,15 @@ fn run_pass(
         }
     }
 
+    // What is left after `check_program` is genuinely per-deal — a strain
+    // computed at run time that lands outside 0 to 4, say. That is carried back
+    // rather than discarded, and stops the run where it happens.
     let test = |deal: &Deal| match constraint {
         Some(expr) => {
             dealer_eval::eval_with_context_and_counts(expr, &variables, deal, point_counts)
                 .map(|value| value != 0)
-                .unwrap_or(false)
         }
-        None => true,
+        None => Ok(true),
     };
 
     let workers = Workers::new(opts.threads);
@@ -784,6 +797,10 @@ fn run_pass(
             if from_stream {
                 generated += 1;
             }
+            let matched = matched.as_ref().map_err(|e| RunError::Eval {
+                what: "condition".to_string(),
+                message: e.to_string(),
+            })?;
             if !matched {
                 continue;
             }

--- a/dealer/tests/script_statements.rs
+++ b/dealer/tests/script_statements.rs
@@ -300,3 +300,53 @@ fn a_malformed_parameter_is_refused() {
         assert!(!err.is_empty());
     }
 }
+
+#[test]
+fn a_call_with_the_wrong_number_of_arguments_is_refused() {
+    // #36. The evaluator raised this correctly all along, but the condition
+    // read the error as "this deal does not match" and threw it away, so the
+    // run dealt everything `-g` allowed, produced nothing, said nothing and
+    // exited 0 — the same silent shape as `dealr west` above, one layer down.
+    let (out, err, status) = run(
+        &["-p", "1", "-s", "1", "-g", "50"],
+        "condition hcp(north, spades, clubs) == 1\n",
+    );
+    assert_eq!(status, 1, "stdout was: {out}");
+    assert!(err.contains("hcp"), "the function should be named: {err}");
+    assert!(
+        err.contains("1 or 2") && err.contains("not 3"),
+        "the counts should both be given: {err}"
+    );
+    assert!(out.is_empty(), "no deals should have been dealt");
+}
+
+#[test]
+fn a_miscounted_call_is_refused_before_any_deal_is_made() {
+    // The condition here matches nothing, which is what used to hide this: a
+    // statistic is evaluated only for a deal that matched, so the error was
+    // never reached. An argument count is a property of the script, so it is
+    // now settled before the first card comes out.
+    let (out, err, status) = run(
+        &["-p", "1", "-s", "1", "-g", "50"],
+        "condition hcp(north) >= 40\naction average \"a\" controls(north, spades, hearts)\n",
+    );
+    assert_eq!(status, 1, "stdout was: {out}");
+    assert!(
+        err.contains("average") && err.contains("controls"),
+        "the statement and the function should both be named: {err}"
+    );
+}
+
+#[test]
+fn a_function_that_takes_either_count_still_takes_both() {
+    // The check reads `Function::arity`, so getting a range wrong would refuse
+    // a legal script rather than accept a broken one. `hcp` is the one every
+    // script uses.
+    for script in [
+        "condition hcp(north) >= 10\n",
+        "condition hcp(north, spades) >= 3\n",
+    ] {
+        let (_, err, status) = run(&["-q", "-p", "1", "-s", "1"], script);
+        assert_eq!(status, 0, "`{script}` should run: {err}");
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   divide by, so its bar means something.
 
 ### Fixed
+- **A call with the wrong number of arguments produced no deals, no error and
+  exit 0.** The evaluator raised `InvalidArgumentCount` correctly, and the
+  condition turned it into "this deal does not match" — once per deal, for as
+  many deals as `-g` allowed. `condition hcp(north, spades, clubs) == 1`
+  generated the whole run and said nothing. It affected every function, in a
+  condition or in a statistic, and a statistic was worse: those are evaluated
+  only for a deal that matched, so a script whose condition matched nothing
+  never reported the mistake at all. (#36)
+  - An argument count is a property of the script, not of a deal, so it is now
+    settled before the first card is dealt. `dealer_eval::check_program` walks
+    the condition, every variable, and the expressions inside `average`,
+    `frequency`, `printes`, `printrpt` and `csvrpt`, and names the statement it
+    found the mistake in: `average: controls takes 1 or 2 arguments, not 3`.
+  - What is left is genuinely per-deal — a strain computed at run time that
+    lands outside 0 to 4, say — and is now carried back and reported rather
+    than discarded.
+  - `Function::arity` is the one place a count is written down. The evaluator
+    asks it instead of counting for itself in each of its 25 arms, so the two
+    cannot drift, and a test drives the whole vocabulary through it from the
+    outside. No measurable cost: two million deals take 1.07 seconds either way.
 - **`generated` counted one pass of a levelled run, not all of them.** It read
   `1,844` beside "levelled over 47,733 measured deals" — the same deals, counted
   honestly the second time. Both front ends now count every deal the run looked


### PR DESCRIPTION
Closes #36.

```
$ echo 'condition hcp(north, spades, clubs) == 1' | dealer -q -v -p 1 -s 1 -g 50
Generated 50 hands
Produced 0 hands
$ echo $?
0
```

The evaluator raised `InvalidArgumentCount` correctly all along. `dealer-run/src/run.rs` did:

```rust
dealer_eval::eval_with_context_and_counts(expr, &variables, deal, point_counts)
    .map(|value| value != 0)
    .unwrap_or(false)
```

which read the error as "this deal does not match", once per deal, for as many deals as `-g` allowed. It affected every function. In a statistic it was worse — those are evaluated only for a deal that *matched*, so a script whose condition matched nothing never reported the mistake at all.

This is the same silent shape the grammar's `statement_keyword` and `reserved_unsupported` rules exist for (`actionList = 1`, `control(north)`), still open one layer down.

## What changed

**An argument count is a property of the script, not of a deal**, so it is now settled before the first card is dealt. `dealer_eval::check_program` walks the condition, every variable, and the expressions inside `average`, `frequency`, `printes`, `printrpt` and `csvrpt`, and names the statement it was found in:

```
$ dealer script.dlr
Error: average: controls takes 1 or 2 arguments, not 3
$ echo $?
1
```

**What is left is genuinely per-deal** — a strain computed at run time that lands outside 0 to 4, say. That is carried back through `build_and_test` and reported, rather than discarded.

**`Function::arity` is now the one place a count is written down.** The evaluator asks it rather than counting for itself in each of its 25 arms, so the table and the behaviour cannot drift. A test drives every function in `vocabulary::FUNCTIONS` through it from the outside, asserting a call inside the range is never refused *for its count* and one outside it always is — so a wrong range would be caught as a legal script being refused, not just as a broken one being accepted.

`InvalidArgumentCount` gained `min`/`max` in place of a single `expected`, which several functions were already reporting wrongly (`hcp` claimed to expect 1 when it takes 1 or 2).

## Cost

None measurable. Two million deals through `hcp(north) >= 20 && controls(north, spades) >= 2`, single-threaded, best of three:

| | time |
|---|---|
| before | 1.07 s |
| after | 1.07 s |

## Tests

494 pass. Six new ones: three at the CLI in `dealer/tests/script_statements.rs` (a condition, a statistic whose condition matches nothing, and a check that a 1-or-2 function still takes both), and three in `dealer-eval` covering the arity table, the canonical names, and that the walk reaches nested calls rather than only the outermost one.

`cargo fmt` and `clippy -D warnings` clean; the wasm front end builds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)