### PR TITLE
A miscounted score() blamed its contract word, not the count

### DIFF
--- a/dealer-parser/src/grammar.pest
+++ b/dealer-parser/src/grammar.pest
@@ -192,10 +192,12 @@ function_call = { function_name ~ "(" ~ expr ~ ("," ~ expr)* ~ ")" }
 // index — the tokens are what a script written elsewhere will use, and the
 // numbers are what a `--param` can supply.
 //
-// Tried ahead of `function_call`, and falling through to it when the shape
-// does not fit, so `score(0, 34)` still reaches the evaluator's argument-count
-// error rather than becoming a syntax error.
-score_call = { score_name ~ "(" ~ score_arg ~ "," ~ score_arg ~ "," ~ expr ~ ")" }
+// Any number of arguments, so a miscounted call is still a `score` call and
+// the count is reported as one: `check_program` says "score takes 3 arguments,
+// not 2" before a card is dealt. Pinning the rule to three instead made
+// `score(nv, x3N)` fall through to `function_call`, where the two words are
+// nothing but undefined names — loud, but about the wrong thing.
+score_call = { score_name ~ "(" ~ score_arg ~ ("," ~ score_arg)* ~ ")" }
 score_name = @{ "score" ~ !(ASCII_ALPHANUMERIC | "_") }
 score_arg = _{ contract_token | vuln_token | expr }
 

--- a/dealer/tests/script_statements.rs
+++ b/dealer/tests/script_statements.rs
@@ -350,3 +350,42 @@ fn a_function_that_takes_either_count_still_takes_both() {
         assert_eq!(status, 0, "`{script}` should run: {err}");
     }
 }
+
+#[test]
+fn a_miscounted_score_is_reported_as_a_count_not_as_unknown_names() {
+    // `score` has a grammar rule of its own, because its first two arguments
+    // are words rather than expressions. When that rule demanded exactly three
+    // arguments, a call with two fell through to the ordinary function rule —
+    // where `nv` and `x3N` are nothing but names the script never defined. The
+    // error was loud but about the wrong thing.
+    for (script, got) in [
+        ("condition score(nv, x3N) == 400\n", "not 2"),
+        ("condition score(x3N) == 400\n", "not 1"),
+        ("condition score(nv, x3N, 9, 1) == 400\n", "not 4"),
+        // The numeric spelling reached the right error already; it must keep it.
+        ("condition score(0, 19) == 400\n", "not 2"),
+    ] {
+        let (_, err, status) = run(&["-q", "-p", "1", "-s", "1", "-g", "20"], script);
+        assert_eq!(status, 1, "`{script}` should be refused");
+        assert!(
+            err.contains("score takes 3 arguments") && err.contains(got),
+            "`{script}` should name the count, not the words: {err}"
+        );
+        assert!(
+            !err.contains("never defined"),
+            "`{script}` should not blame the contract words: {err}"
+        );
+    }
+}
+
+#[test]
+fn a_score_call_that_counts_right_still_runs() {
+    for script in [
+        "condition score(nv, x3N, 9) == 400\n",
+        "condition score(0, 19, 9) == 400\n",
+        "condition score(vul, x4Sxx, 10) == 1080\n",
+    ] {
+        let (_, err, status) = run(&["-q", "-p", "1", "-s", "1"], script);
+        assert_eq!(status, 0, "`{script}` should run: {err}");
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   divide by, so its bar means something.
 
 ### Fixed
+- **A miscounted `score` blamed its contract word instead of the count.**
+  `score(nv, x3N)` reported `names are used but never defined: nv, x3N`, because
+  `score`'s own grammar rule demanded exactly three arguments and a call with
+  two fell through to the ordinary function rule, where those two words are
+  nothing but names. The rule now takes any number of arguments, so the count is
+  reported as a count: `score takes 3 arguments, not 2`. Loud either way, but
+  about the right thing now.
 - **A call with the wrong number of arguments produced no deals, no error and
   exit 0.** The evaluator raised `InvalidArgumentCount` correctly, and the
   condition turned it into "this deal does not match" — once per deal, for as


### PR DESCRIPTION
Follow-up to #35 and #37, found while spot-checking the two together on `main`.

```
$ echo 'condition score(nv, x3N) == 400' | dealer -p 1 -s 1
Error: names are used but never defined: nv, x3N.
```

The real mistake is that `score` got two arguments. It read that way because the `score_call` rule from #35 demanded exactly three, so a two-argument call fell through to the ordinary `function_call` rule — where `nv` and `x3N` are nothing but names the script never defined.

## The change

One line of grammar:

```diff
-score_call = { score_name ~ "(" ~ score_arg ~ "," ~ score_arg ~ "," ~ expr ~ ")" }
+score_call = { score_name ~ "(" ~ score_arg ~ ("," ~ score_arg)* ~ ")" }
```

The count is left to `check_program`, which since #37 reports it before a card is dealt:

```
Error: condition: score takes 3 arguments, not 2
```

The fall-through this replaces existed only to reach that same error, so nothing is lost — and it now works for the token spelling as well as the numeric one.

| Script | before | after |
|---|---|---|
| `score(nv, x3N)` | `never defined: nv, x3N` | `score takes 3 arguments, not 2` |
| `score(x3N)` | `never defined: x3N` | `score takes 3 arguments, not 1` |
| `score(nv, x3N, 9, 1)` | `never defined: nv, x3N` | `score takes 3 arguments, not 4` |
| `score(0, 19)` | `score takes 3 arguments, not 2` | unchanged |

A token in the wrong position is loud too, thanks to #37 propagating what it used to discard — `score(x3N, nv, 9)` gives `Invalid contract level: 0 (must be 1-7)` rather than quietly matching nothing.

## Tests

500 pass. Two new ones in `dealer/tests/script_statements.rs`: one asserting all four miscounts name the count and do **not** say "never defined", and one that correctly-counted calls in both spellings still run.

`cargo fmt` and `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)