### PR TITLE
Correct the RNG story, the attribution, and the test workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,11 @@
 
 ## Project Overview
 
-dealer3 is a Rust implementation of dealer.exe (bridge hand generator) with full compatibility for the original dealer.exe command-line interface and support for DealerV2_4 enhancements.
+dealer3 is a Rust implementation of dealer.exe (bridge hand generator). It is
+compatible with the original's **script language and command-line interface**,
+and supports DealerV2_4 enhancements. It is deliberately **not** compatible with
+the original's deal sequence: a seed does not reproduce dealer.exe's boards,
+which is what went with legacy mode in 0.5.0.
 
 ## Current Status
 
@@ -72,14 +76,21 @@ private to `dealer-run`; a front end cannot see it, which is the point.
 
 ### Key Design Decisions
 
-1. **RNG Compatibility**: Uses exact GNU random() with 64-bit state matching dealer.exe binary
-   - **Critical Discovery**: dealer.exe uses 64-bit arithmetic throughout (not 32-bit!)
-   - Replicated via reverse-engineering using RNG probe tools
-   - State array: `i64[31]` with BSD TYPE_3 polynomial (x^31 + x^3 + 1)
-   - Non-standard LCG constant: `1103515145` (from Thorvald's dealer source)
-   - 64-bit arithmetic shift (sarq) + 64-bit LONG_MAX mask creates unique negative states
-   - 310-iteration warmup phase (10 * rand_deg)
-   - **Verified**: Seed 1 produces first value 269167349 (matches dealer.exe exactly)
+1. **RNG**: xoshiro256++, in `dealer-core/src/rng.rs`. A seed reproduces a
+   dealer3 run, not a dealer.exe one.
+   - The port of GNU `random()` that once did reproduce dealer.exe's deals was
+     extracted in 0.5.0 and lives in
+     [dealer-legacy-shuffle](https://github.com/bridge-craftwork/dealer-legacy-shuffle),
+     published on crates.io. Nothing in this workspace depends on it, and CI
+     asserts as much.
+   - **What this file used to say here was wrong.** It described dealer.exe as
+     doing 64-bit arithmetic. The binary is PE32/i386 — 32-bit — and Windows is
+     LLP64, so `long` is 32 bits there in any case. The 64-bit behaviour came
+     from Mach-O x86_64 objects built from the same `__random.c` on macOS, not
+     from dealer.exe. The deal sequences the old work predicted were still
+     correct: the two data models differ only in bit 31, and dealer indexes its
+     card table from bits 15..=30. The disassembly and captured vectors are in
+     dealer-legacy-shuffle's `PROVENANCE.md`; do not re-derive them.
 2. **Parse Once, Evaluate Many**: AST is Clone + Send + Sync for efficient parallel evaluation
 3. **Breaking Change (0.2.0)**: `-v` changed from vulnerability to verbose (matches dealer.exe)
    - Use `--vulnerable` (long form only) for vulnerability
@@ -206,7 +217,7 @@ Use SSH for all GitHub operations:
 
 ## Related Projects
 
-All located at `/Users/rick/Development/GitHub/`:
+All located alongside this repo, under the same GitHub directory:
 
 | Project | Description | Relationship |
 |---------|-------------|--------------|
@@ -228,8 +239,12 @@ deal — so it is safe to put in a probe. `scripts/dd-bench.sh` is the guard.
 
 ## Source Material & Reference Implementations
 
-### Original dealer.exe (Henk Uijterwaal)
-**Location**: `/Users/rick/Development/GitHub/Dealer-cleanup/`
+### Original dealer (Hans van Staveren; maintained by Henk Uijterwaal)
+**Location**: `../Dealer-cleanup/`
+
+The upstream README opens "Dealer by Hans van Staveren". Henk Uijterwaal
+maintained it through the era this code comes from — `pbn.c` is his, and the
+binary reports `$Author: henk $`, `$Revision: 1.24 $`, 2003-08-05.
 
 **Key Files**:
 - `dealer` - Reference C dealer binary (macOS build)
@@ -238,15 +253,21 @@ deal — so it is safe to put in a probe. `scripts/dd-bench.sh` is the guard.
 - `defs.y` - Bison parser grammar
 
 **Purpose**:
-- Compatibility testing - our output must match exactly
+- Compatibility testing — the script language and the CLI, not the deals
 - Reference for ambiguous behavior
-- RNG verification (we matched the 64-bit state implementation)
 
 ### Windows VM Access (for running dealer.exe)
-**IP Address**: `10.211.55.5`
-**Username**: `rick`
 
-**Preferred Method**: Use the shell aliases `win-dealer` and `compare-dealer` for all Windows dealer.exe testing.
+**The host and the login are not written down here.** They come from the
+environment — `WINDOWS_HOST` and `WINDOWS_USER`, set in `~/.zshrc` — and are read
+by `build-scripts-mac/config.py` in the Practice-Bidding-Scenarios repo, which
+`ssh_runner.py` uses. Do not put an address, a username or a hostname into any
+file in this repository; use the variables, or the wrappers below that already
+do.
+
+**Preferred Method**: Use the shell alias `win-dealer` to run dealer.exe. The
+`compare-dealer` alias is **superseded** — see "Testing Against dealer.exe"
+below for what replaced it and why.
 
 #### win-dealer - Run dealer.exe on Windows VM
 ```bash
@@ -263,43 +284,32 @@ win-dealer -t 60 -p 100 -s 42 large-test.dlr
 win-dealer -h
 ```
 
-#### compare-dealer - Compare dealer3 vs dealer.exe output
-```bash
-# Compare output from both dealers (uses development build by default)
-compare-dealer -p 10 -s 1 test.dlr
+#### compare-dealer — superseded, do not reach for it
+`scripts/compare-dealer.sh` diffed the two binaries' boards one for one. That
+only ever worked while `--legacy` could reproduce dealer.exe's deal sequence,
+which was removed in 0.5.0, so the diff is now meaningless. The script refuses
+to run without `COMPARE_DEALER_FORCE=1` and is kept only in case someone reworks
+it to compare through `--input-deals`.
 
-# Pipe conditions via stdin
-echo "shape(north, any 6xxx)" | compare-dealer -p 10 -s 1
+**If the wrappers are not enough**, go through `ssh_runner.py` in
+Practice-Bidding-Scenarios' `build-scripts-mac/` rather than calling `ssh`
+by hand. It reads the host and user from the environment, maps the drives (an
+SSH session does not inherit them) and converts a Mac path to its Windows one:
 
-# Show raw output from both runs
-compare-dealer -p 10 -s 1 -o test.dlr
-
-# Skip pretest (pretest runs -p 1 first to quickly detect failures)
-compare-dealer --no-pretest -p 100 -s 1 test.dlr
-
-# Use a specific Rust binary instead of development build
-compare-dealer -r /path/to/dealer -p 10 -s 1 test.dlr
-
-# Show help
-compare-dealer -h
+```python
+from ssh_runner import run_windows_command, mac_to_windows_path
+run_windows_command(f"dealer -p 10 -s 42 {mac_to_windows_path(path)}")
 ```
 
-**Manual SSH** (only if scripts don't work):
-```bash
-# Map G: drive and run dealer (drive mapping required each session)
-ssh rick@10.211.55.5 'net use G: "\\Mac\Home\Development\GitHub" >nul 2>&1 & dealer -p 10 -s 42 G:\dealer3\test.dlr'
-
-# Simple inline expressions (no drive mapping needed)
-ssh rick@10.211.55.5 "echo 'hcp(north) >= 20' | dealer -p 10 -s 1"
-```
+Write the script under the shared GitHub directory first, so the path converts.
 
 **Notes**:
 - The Windows VM has `dealer` in PATH at `C:\Dealer\dealer.exe`
-- G: drive maps to `/Users/rick/Development/GitHub` via Parallels shared folders
-- Files at `/Users/rick/Development/GitHub/dealer3/foo.dlr` become `G:\dealer3\foo.dlr`
+- The shared drive maps the Mac's GitHub directory via Parallels, so a file at
+  `$HOME/Development/GitHub/dealer3/foo.dlr` is reachable from Windows
 - Shell aliases defined in `~/.zshrc`, scripts in `scripts/` directory
 
-### DealerV2 (Hans van Staveren, expanded version)
+### DealerV2 (expanded version of the original)
 **Location**: `/tmp/dealerv2` (cloned locally)
 **GitHub**: https://github.com/dealerv2/Dealer-Version-2-
 **Purpose**: Reference for extended features (DDS, CSV export, additional switches)
@@ -311,35 +321,43 @@ ssh rick@10.211.55.5 "echo 'hcp(north) >= 20' | dealer -p 10 -s 1"
 
 ## Testing Against dealer.exe
 
-### Preferred Method: compare-dealer
-Use `compare-dealer` for all compatibility testing. It automatically:
-- Runs both Rust dealer3 and Windows dealer.exe with the same arguments
-- Compares deals, produced count, and generated count
-- Runs a quick pretest (-p 1) to catch failures fast
-- Shows timing comparison and warns if Rust is significantly slower
+### Preferred Method: test-filter.py
+The two programs no longer deal the same boards, so nothing is gained by
+diffing their output. What still compares cleanly is what a script *means*:
 
 ```bash
-# Basic comparison
-compare-dealer -p 10 -s 1 test.dlr
+# Have dealer.exe produce the deals a script matches, then check dealer3
+# accepts every one of them. Anything less than 100% is a real difference.
+scripts/test-filter.py -p 20 -s 1 test.dlr
 
-# With stdin input
-echo "hcp(north) >= 20" | compare-dealer -p 10 -s 1
+# Build a committed corpus for the regression tiers
+scripts/generate-corpus.py -p 20 -s 1 test.dlr
 
-# Show raw output to debug differences
-compare-dealer -p 10 -s 1 -o test.dlr
+# Run dealer.exe directly when you need to see its own output
+win-dealer -p 10 -s 1 test.dlr
 ```
 
+See `docs/REGRESSION_TESTING.md` for the tiers and how a corpus is replayed.
+
 ### Key Compatibility Tests
-1. **RNG sequence** - Same seed must produce identical deals
-2. **Output format** - PBN, printall, etc. must match exactly
-3. **Edge cases** - Predeal, rare constraints, boundary conditions
-4. **Statistics** - Generated/produced counts must match
+
+**Not deal-for-deal.** `compare-dealer` compared the two binaries' boards
+one for one, which needed legacy mode; that went in 0.5.0 and the script with
+it. What is compared now is what a script *means*:
+
+1. **Filter semantics** — `scripts/test-filter.py` has dealer.exe produce the
+   deals a script matches, then feeds those deals to dealer3 with the same
+   script; all of them should pass. It compares what a condition *means*, which
+   needs no shared deal sequence
+2. **Corpora** — `scripts/generate-corpus.py`, replayed by the regression tiers
+3. **Output format** — PBN, printall and the rest must match exactly
+4. **Edge cases** — predeal, rare constraints, boundary conditions
 
 ## Additional Working Directories
 
-- `/Users/rick/Development/GitHub/Dealer-cleanup/` - Reference C dealer source and binary
+- `../Dealer-cleanup/` - Reference C dealer source and binary
 - `/private/tmp` - Temporary workspace for test output and experiments
-- `/Users/rick/Development/GitHub/dealer3/` - This project (main working directory)
+- this repo - main working directory
 
 ## Quick Reference: Version History
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,12 +258,10 @@ binary reports `$Author: henk $`, `$Revision: 1.24 $`, 2003-08-05.
 
 ### Windows VM Access (for running dealer.exe)
 
-**The host and the login are not written down here.** They come from the
-environment — `WINDOWS_HOST` and `WINDOWS_USER`, set in `~/.zshrc` — and are read
-by `build-scripts-mac/config.py` in the Practice-Bidding-Scenarios repo, which
-`ssh_runner.py` uses. Do not put an address, a username or a hostname into any
-file in this repository; use the variables, or the wrappers below that already
-do.
+**The host and the login are `ssh_runner`'s business, not yours.** They are not
+written down here and are not meant to be read anywhere else — go through
+`win-dealer` or `ssh_runner.py`, which already know how to connect. Never put an
+address, a username or a hostname into a file in this repository.
 
 **Preferred Method**: Use the shell alias `win-dealer` to run dealer.exe. The
 `compare-dealer` alias is **superseded** — see "Testing Against dealer.exe"
@@ -293,8 +291,8 @@ it to compare through `--input-deals`.
 
 **If the wrappers are not enough**, go through `ssh_runner.py` in
 Practice-Bidding-Scenarios' `build-scripts-mac/` rather than calling `ssh`
-by hand. It reads the host and user from the environment, maps the drives (an
-SSH session does not inherit them) and converts a Mac path to its Windows one:
+by hand. It handles the connection, maps the drives (an SSH session does not
+inherit them) and converts a Mac path to its Windows one:
 
 ```python
 from ssh_runner import run_windows_command, mac_to_windows_path
@@ -309,7 +307,7 @@ Write the script under the shared GitHub directory first, so the path converts.
   `$HOME/Development/GitHub/dealer3/foo.dlr` is reachable from Windows
 - Shell aliases defined in `~/.zshrc`, scripts in `scripts/` directory
 
-### DealerV2 (expanded version of the original)
+### DealerV2 (Greg Morse's expanded version)
 **Location**: `/tmp/dealerv2` (cloned locally)
 **GitHub**: https://github.com/dealerv2/Dealer-Version-2-
 **Purpose**: Reference for extended features (DDS, CSV export, additional switches)

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ dealer3/
 of the original. The same seed does *not* reproduce dealer.exe's deals. Scripts
 port unchanged; specific deals do not. See the [CHANGELOG](docs/CHANGELOG.md).
 
-### DealerV2_4 (Thorvald Aagaard)
+### DealerV2_4 (Greg Morse)
 ✅ **Predeal switches** - `-N/-E/-S/-W` for command-line predeal
 ✅ **CSV export** - `-C` for analytics output
 ✅ **Title metadata** - `-T` for PBN output
@@ -248,7 +248,7 @@ domain.
 ## Credits
 
 - **Original dealer**: Hans van Staveren (public domain)
-- **DealerV2_4**: Thorvald Aagaard (GPLv3, independent implementation)
+- **DealerV2_4**: Greg Morse, with Thorvald Aagaard contributing (GPLv3, independent implementation)
 - **dealer3**: Rick Wilson (Unlicense)
 
 Key contributors to the dealer ecosystem:
@@ -261,7 +261,7 @@ Key contributors to the dealer ecosystem:
 
 - **GitHub**: https://github.com/bridge-craftwork/Dealer3
 - **Original dealer.exe**: http://www.bridgebase.com/tools/dealer/
-- **DealerV2_4**: https://github.com/ed2k/dealer
+- **DealerV2_4**: https://github.com/dealerv2/Dealer-Version-2-
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 [![CI](https://github.com/bridge-craftwork/Dealer3/workflows/CI/badge.svg)](https://github.com/bridge-craftwork/Dealer3/actions)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](http://unlicense.org/)
 
-A Rust implementation of the classic dealer.exe bridge hand generator, with full compatibility for dealer.exe and DealerV2_4 enhancements.
+A Rust implementation of the classic dealer.exe bridge hand generator. It runs
+dealer.exe's scripts and accepts its command line, and supports DealerV2_4
+enhancements. It does **not** reproduce dealer.exe's deals: a seed gives you a
+dealer3 sequence, not the original's.
 
 ## Features
 
@@ -239,16 +242,20 @@ This project is released into the **public domain** under [The Unlicense](LICENS
 
 You are free to use, modify, distribute, and incorporate this software for any purpose, with or without modification, with no restrictions.
 
-The original dealer.exe was also released into the public domain by Thomas Andrews.
+The original dealer was written by Hans van Staveren and dedicated to the public
+domain.
 
 ## Credits
 
-- **Original dealer.exe**: Thomas Andrews (public domain)
+- **Original dealer**: Hans van Staveren (public domain)
 - **DealerV2_4**: Thorvald Aagaard (GPLv3, independent implementation)
 - **dealer3**: Rick Wilson (Unlicense)
 
-Key contributors to dealer.exe ecosystem:
-- Henk Uijterwaal, Bruce Moore, Francois Dellacherie, Robin Barker, Danil Suits, Alex Martelli, Paul Hankin, and many others
+Key contributors to the dealer ecosystem:
+- Henk Uijterwaal, who maintained dealer through the era this work is based on
+  and wrote its PBN support
+- Bruce Moore, Francois Dellacherie, Robin Barker, Danil Suits, Alex Martelli,
+  Paul Hankin, and many others
 
 ## Links
 
@@ -263,4 +270,7 @@ For bugs, feature requests, or questions:
 
 ---
 
-**Note**: This is an independent implementation. It is not affiliated with BridgeBase Online or the original dealer.exe project, though it maintains full compatibility with dealer.exe for script portability.
+**Note**: This is an independent implementation. It is not affiliated with
+BridgeBase Online or the original dealer project, though it keeps compatibility
+with dealer.exe's script language and command line so that scripts are portable.
+Deal sequences are not portable and are not meant to be.

--- a/dealer-core/README.md
+++ b/dealer-core/README.md
@@ -86,4 +86,5 @@ dealer.exe's deals was removed in 0.5.0 and lives in
 
 ## License
 
-Apache-2.0
+This project is released into the **public domain** under
+[The Unlicense](../LICENSE).

--- a/dealer-core/README.md
+++ b/dealer-core/README.md
@@ -28,8 +28,8 @@ A `Hand` represents 13 cards with analysis functions:
 ### Deal
 A `Deal` represents a complete bridge deal with 4 hands (North, East, South, West).
 
-### DealGenerator
-Generates random deals using the gnurandom RNG for exact dealer.exe compatibility.
+### FastDealGenerator
+Generates random deals using xoshiro256++ (`src/rng.rs`).
 
 ## Usage
 
@@ -79,7 +79,10 @@ Tests include:
 
 ## Compatibility
 
-The deal generator uses the `gnurandom` crate which exactly matches dealer.exe's RNG implementation, ensuring identical deals for identical seeds.
+The deal generator uses xoshiro256++, so a seed reproduces a dealer3 run and
+**not** a dealer.exe one. The port of GNU `random()` that once did reproduce
+dealer.exe's deals was removed in 0.5.0 and lives in
+[dealer-legacy-shuffle](https://github.com/bridge-craftwork/dealer-legacy-shuffle).
 
 ## License
 

--- a/dealer-parser/README.md
+++ b/dealer-parser/README.md
@@ -110,4 +110,5 @@ All core parsing functionality is tested:
 
 ## License
 
-Apache-2.0
+This project is released into the **public domain** under
+[The Unlicense](../LICENSE).

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -868,6 +868,7 @@ fn main() {
         println!();
         println!("dealer2");
         println!("  Greg Morse (GPLv3, independent)");
+        println!("  Thorvald Aagaard");
         println!();
         println!("dealer3 (Rust edition)");
         println!("  Rick Wilson");

--- a/docs/DEALER_FUNCTIONALITY.md
+++ b/docs/DEALER_FUNCTIONALITY.md
@@ -97,8 +97,9 @@ Distribute as native executables for each platform.
 - Deal generation and evaluation engine
 - Output formatting
 
-### DealerV2_4 (Enhanced Version)
-**Repository:** https://github.com/ThorvaldAagaard/DealerV2_4
+### DealerV2_4 (Enhanced Version, Greg Morse)
+**Repository:** https://github.com/dealerv2/Dealer-Version-2-
+**Mirror:** https://github.com/ThorvaldAagaard/DealerV2_4
 **Additional Features:**
 - Extended constraint functions
 - Additional output formats

--- a/docs/DEALER_FUNCTIONALITY.md
+++ b/docs/DEALER_FUNCTIONALITY.md
@@ -75,11 +75,13 @@ Distribute as native executables for each platform.
 
 ### Compatibility Requirements
 
-**Legacy Compatibility (dealer.exe):**
-- Must produce identical output for identical inputs and seeds
-- Required for bridgebase.com integration
+**Compatibility with dealer.exe:**
+- Accept its scripts and its command line unchanged
 - Maintain existing input file format and syntax
 - Preserve output format for downstream tools
+- **Not** its deal sequence: a seed reproduces a dealer3 run, not a dealer.exe
+  one. That went with legacy mode in 0.5.0; see `docs/REGRESSION_TESTING.md`
+  for how filter semantics are checked without it
 
 **Version Compatibility Flag:**
 - Filter semantics verified against dealer.exe via the Tier 1 regression corpora

--- a/docs/MULTITHREADING_DESIGN.md
+++ b/docs/MULTITHREADING_DESIGN.md
@@ -100,14 +100,20 @@ Fast mode uses stateless deal generation where each deal depends only on its see
 
 Described here for historical context. Legacy mode preserved exact dealer.exe
 compatibility by using:
-- GNU random() with 64-bit state (matching dealer.exe binary behavior)
+- A port of GNU `random()`, which reproduced dealer.exe's deal sequence
 - Sequential shuffle-state-dependent generation
 - Single-threaded execution only
 
+That port now lives in
+[dealer-legacy-shuffle](https://github.com/bridge-craftwork/dealer-legacy-shuffle).
+Earlier revisions of this document described it as 64-bit and said dealer.exe
+was too; the binary is in fact PE32/i386, and the 64-bit behaviour came from
+macOS builds of the same source. See that repository's `PROVENANCE.md`.
+
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                    DealGenerator                            │
-│  - Owns single GnuRandom instance                           │
+│                    DealGenerator (removed)                  │
+│  - Owned a single legacy-shuffle RNG instance                │
 │  - Each deal depends on previous shuffle state              │
 │  - Must be sequential for determinism                       │
 └─────────────────────────────────────────────────────────────┘

--- a/docs/PERFORMANCE_OPTIMIZATION_ANALYSIS.md
+++ b/docs/PERFORMANCE_OPTIMIZATION_ANALYSIS.md
@@ -103,7 +103,7 @@ Like the C version does with `distrbitmaps`:
 
 ## Penguin Dealer Optimizations (5.3x Faster than dealer.exe)
 
-Analysis of `/Users/rick/Development/GitHub/penguin-dealer` reveals the following key optimizations:
+Analysis of `../penguin-dealer` reveals the following key optimizations:
 
 ### 1. Fast Random Number Generation - Lookup Table Instead of Modulo
 
@@ -308,10 +308,10 @@ When implementing these optimizations:
 - `dealer-core/src/rng.rs` - RNG implementation (candidate for fast_randint optimization)
 
 ### Reference Implementations
-- Original C: `/Users/rick/Development/GitHub/Dealer-cleanup/dealer.c`
-- Penguin: `/Users/rick/Development/GitHub/penguin-dealer/dealer.c`
-- Penguin fast RNG: `/Users/rick/Development/GitHub/penguin-dealer/fast_randint.c`
-- Penguin headers: `/Users/rick/Development/GitHub/penguin-dealer/dealer.h`
+- Original C: `../Dealer-cleanup/dealer.c`
+- Penguin: `../penguin-dealer/dealer.c`
+- Penguin fast RNG: `../penguin-dealer/fast_randint.c`
+- Penguin headers: `../penguin-dealer/dealer.h`
 
 ## Notes
 

--- a/docs/WINDOWS_BUILD_SUMMARY.md
+++ b/docs/WINDOWS_BUILD_SUMMARY.md
@@ -127,7 +127,8 @@ The Windows build is ready for distribution:
 
 ## Compatibility
 
-- ✅ **dealer.exe**: Fully compatible with original Thomas Andrews version
+- ✅ **dealer.exe**: Runs Hans van Staveren's original scripts and command line
+  (deal sequences differ; see the README)
 - ✅ **DealerV2_4**: Compatible with Thorvald Aagaard's enhancements
   - Predeal switches (`-N/-E/-S/-W`)
   - CSV export (`-C`)

--- a/docs/WINDOWS_BUILD_SUMMARY.md
+++ b/docs/WINDOWS_BUILD_SUMMARY.md
@@ -129,7 +129,7 @@ The Windows build is ready for distribution:
 
 - ✅ **dealer.exe**: Runs Hans van Staveren's original scripts and command line
   (deal sequences differ; see the README)
-- ✅ **DealerV2_4**: Compatible with Thorvald Aagaard's enhancements
+- ✅ **DealerV2_4**: Compatible with Greg Morse's enhancements
   - Predeal switches (`-N/-E/-S/-W`)
   - CSV export (`-C`)
   - Title metadata (`-T`)

--- a/docs/WINDOWS_SSH_SETUP.md
+++ b/docs/WINDOWS_SSH_SETUP.md
@@ -10,8 +10,11 @@ Setting up passwordless SSH from Mac to Windows 11 (Parallels) to run dealer.exe
 
 ## Your Public Key
 
-```
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPjEuOhCK7bGh1aDNjgp+0W1NsaNph0IXxZq+CZjl0TK rick@Ricks-Mac-Mini-M4-Pro.local
+Read it rather than copying it from here — this file is public, and a key
+carries the username and hostname that generated it:
+
+```bash
+cat ~/.ssh/id_ed25519.pub
 ```
 
 ## Windows SSH Server Configuration
@@ -178,7 +181,8 @@ Save this as `setup-ssh-key.ps1` and run as Administrator:
 
 ```powershell
 # Your public key (paste the actual key here)
-$publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPjEuOhCK7bGh1aDNjgp+0W1NsaNph0IXxZq+CZjl0TK rick@Ricks-Mac-Mini-M4-Pro.local"
+# Paste the output of `cat ~/.ssh/id_ed25519.pub` on the Mac.
+$publicKey = "ssh-ed25519 AAAA... user@host"
 
 # For administrators
 $authKeysFile = "C:\ProgramData\ssh\administrators_authorized_keys"

--- a/docs/command_line_comparison.md
+++ b/docs/command_line_comparison.md
@@ -2,7 +2,7 @@
 
 Three implementations of the same idea:
 
-1. **dealer.exe** — Henk Uijterwaal's original.
+1. **dealer.exe** — Hans van Staveren's original, maintained by Henk Uijterwaal.
 2. **dealer3** — this project.
 3. **DealerV2_4** — Thorvald Aagaard's expanded version.
 

--- a/docs/command_line_comparison.md
+++ b/docs/command_line_comparison.md
@@ -4,7 +4,7 @@ Three implementations of the same idea:
 
 1. **dealer.exe** — Hans van Staveren's original, maintained by Henk Uijterwaal.
 2. **dealer3** — this project.
-3. **DealerV2_4** — Thorvald Aagaard's expanded version.
+3. **DealerV2_4** — Greg Morse's expanded version.
 
 ## The table is generated
 

--- a/docs/dealer_vs_dealer2_switches.md
+++ b/docs/dealer_vs_dealer2_switches.md
@@ -1,6 +1,6 @@
 # dealer.exe vs DealerV2_4 Command-Line Switch Comparison
 
-This document compares command-line switches between the original dealer.exe (Hans van Staveren) and DealerV2_4 (Thorvald Aagaard), categorized by compatibility.
+This document compares command-line switches between the original dealer.exe (Hans van Staveren) and DealerV2_4 (Greg Morse), categorized by compatibility.
 
 ---
 

--- a/docs/dealer_vs_dealer2_switches.md
+++ b/docs/dealer_vs_dealer2_switches.md
@@ -1,6 +1,6 @@
 # dealer.exe vs DealerV2_4 Command-Line Switch Comparison
 
-This document compares command-line switches between the original dealer.exe (Thomas Andrews) and DealerV2_4 (Thorvald Aagaard), categorized by compatibility.
+This document compares command-line switches between the original dealer.exe (Hans van Staveren) and DealerV2_4 (Thorvald Aagaard), categorized by compatibility.
 
 ---
 

--- a/performance-pretest-2026-01-07.md
+++ b/performance-pretest-2026-01-07.md
@@ -1,7 +1,7 @@
 # Performance Pre-test Results
 
 **Date**: 2026-01-07
-**Test Case**: `/Users/rick/Development/GitHub/Practice-Bidding-Scenarios/dlr/gerber_by_opener.dlr`
+**Test Case**: `../Practice-Bidding-Scenarios/dlr/gerber_by_opener.dlr`
 **Parameters**: `-p 4 -s 42` (produce 4 deals, seed 42)
 
 ## Summary

--- a/scripts/windows/build-windows.sh
+++ b/scripts/windows/build-windows.sh
@@ -39,8 +39,9 @@ dealer3 - Windows 64-bit Version
 
 Bridge hand generator with constraint evaluation
 
-This is a Rust implementation of the classic dealer program by Thomas Andrews,
-compatible with both dealer.exe and DealerV2_4.
+This is a Rust implementation of the classic dealer program by Hans van
+Staveren. It runs dealer.exe's and DealerV2_4's scripts and command lines; it
+does not reproduce their deal sequences.
 
 QUICK START
 -----------

--- a/scripts/windows/setup-windows-ssh.ps1
+++ b/scripts/windows/setup-windows-ssh.ps1
@@ -1,8 +1,16 @@
 # PowerShell script to set up SSH key authentication on Windows
 # Run this as Administrator on your Windows 11 Parallels VM
 
-# Your Mac's public SSH key
-$publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPjEuOhCK7bGh1aDNjgp+0W1NsaNph0IXxZq+CZjl0TK rick@Ricks-Mac-Mini-M4-Pro.local"
+# Your Mac's public SSH key. Not committed: a public key carries the username and
+# hostname that generated it, and this repository is public.
+# Set MAC_PUBLIC_KEY, or paste the output of `cat ~/.ssh/id_ed25519.pub`.
+$publicKey = $env:MAC_PUBLIC_KEY
+if (-not $publicKey) {
+    Write-Host "ERROR: set MAC_PUBLIC_KEY to your Mac's public key first." -ForegroundColor Red
+    Write-Host "  On the Mac:  cat ~/.ssh/id_ed25519.pub" -ForegroundColor Yellow
+    Write-Host '  On Windows:  $env:MAC_PUBLIC_KEY = "ssh-ed25519 AAAA... user@host"' -ForegroundColor Yellow
+    exit 1
+}
 
 Write-Host "Setting up SSH key authentication on Windows..." -ForegroundColor Cyan
 Write-Host ""


### PR DESCRIPTION
The documentation sweep after the gnurandom extraction. Several claims were stale and some were false.

## The 64-bit claim is withdrawn

dealer.exe is **PE32/i386**. Windows is LLP64, so `long` is 32 bits there in any build — no dealer.exe of any bitness could have shown LP64 behaviour. The 64-bit behaviour came from Mach-O x86_64 objects built from the same `__random.c` on macOS.

The deal sequences that work predicted were still right: the two data models differ only in bit 31, and dealer indexes its card table from bits 15..=30. The claim was wrong about the binary, never about the boards. Disassembly and captured vectors are in dealer-legacy-shuffle's `PROVENANCE.md`; this repo cites it rather than re-deriving it.

## "Full compatibility" now says which

Script language and command line: yes. Deal sequence: no — that is precisely what went with legacy mode in 0.5.0. Fixed in `CLAUDE.md`, `README.md` (twice), `dealer-core/README.md`, `docs/WINDOWS_BUILD_SUMMARY.md` and `docs/DEALER_FUNCTIONALITY.md`.

## Attribution

The original dealer is **Hans van Staveren's**, not Thomas Andrews's — the upstream README opens "Dealer by Hans van Staveren". Worth noting `--credits` in `main.rs` has said so all along while five documents said otherwise. Henk Uijterwaal maintained it through this era and wrote its PBN support (`pbn.c`: "Added by Henk Uijterwaal, Feb 1999"; the binary reports `$Author: henk $`), so he is named for that rather than listed under "and many others".

## The compare-dealer workflow is replaced

`scripts/compare-dealer.sh` diffed boards one for one, which needed legacy mode. The script has carried a `SUPERSEDED` banner and a `COMPARE_DEALER_FORCE=1` guard since 0.5.0, while `CLAUDE.md` still called it "the preferred method for all compatibility testing" in two places. Now points at `test-filter.py` (have dealer.exe produce the deals a script matches, then check dealer3 accepts every one) and `generate-corpus.py`.

## Identifying details removed from tracked files

Not part of the original brief, added on request mid-review:

- A VM address and login in `CLAUDE.md`, plus two hand-written `ssh user@host` invocations. The host and user come from `WINDOWS_HOST` / `WINDOWS_USER` via `ssh_runner.py`, which is now what the file points at.
- An **SSH public key** and the `user@hostname` it carries, hard-coded in `docs/WINDOWS_SSH_SETUP.md` (twice) and `scripts/windows/setup-windows-ssh.ps1`. The script now reads `MAC_PUBLIC_KEY` and fails with instructions if unset.
- Absolute `/Users/<name>/...` paths in four files, rewritten as relative.

`.claude/settings.local.json` also contains the address, but it is untracked and never reaches GitHub, so it was left alone as instructed.

**This does not scrub history** — all of it remains in earlier commits. Rewriting that is a separate decision.

500 tests pass, including the generated-table checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)