### PR TITLE
-u is accepted and ignored, as it is in dealer.exe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,9 @@ private to `dealer-run`; a front end cannot see it, which is the point.
 2. **Parse Once, Evaluate Many**: AST is Clone + Send + Sync for efficient parallel evaluation
 3. **Breaking Change (0.2.0)**: `-v` changed from vulnerability to verbose (matches dealer.exe)
    - Use `--vulnerable` (long form only) for vulnerability
-4. **Deprecated Switches**: Parse and show helpful errors for `-2`, `-3`, `-e`, `-u`, `-l`
+4. **Deprecated Switches**: Parse and show helpful errors for `-e` and `-l`. `-2`
+   and `-3` are implemented (swapping modes); `-u` is accepted and ignored,
+   because it does nothing in dealer.exe either
 
 ## Implemented Features
 
@@ -109,7 +111,9 @@ private to `dealer-run`; a front end cannot see it, which is the point.
 - ✅ `-V` / `--version` - Version info (matches dealer.exe)
 - ✅ `-q` / `--quiet` - Quiet mode (matches dealer.exe)
 - ✅ `-m` / `--progress` - Progress meter every 10K deals (matches dealer.exe)
-- ✅ `-2`, `-3`, `-e`, `-u`, `-l` - Deprecated switches (helpful error messages)
+- ✅ `-e`, `-l` - Deprecated switches (helpful error messages)
+- ✅ `-2`, `-3` - Swapping modes (implemented)
+- ✅ `-u` - Accepted and ignored, as in dealer.exe
 
 ### Filter Language Features
 - ✅ **Functions**: hcp, controls, shape, hearts, spades, diamonds, clubs, losers, suit_quality, cccc

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -265,8 +265,8 @@ struct Args {
     #[arg(short = 'e', hide = true)]
     exhaust: bool,
 
-    /// DEPRECATED: Upper/lowercase toggle (cosmetic feature not implemented)
-    #[arg(short = 'u', hide = true)]
+    /// Accepted and ignored: honours are always upper case, as in dealer.exe
+    #[arg(short = 'u')]
     uppercase: bool,
 
     /// DEPRECATED: Library mode (conflicting meanings in dealer.exe vs DealerV2_4)
@@ -915,14 +915,13 @@ fn main() {
         std::process::exit(1);
     }
 
-    if args.uppercase {
-        eprintln!("Error: Switch '-u' (upper/lowercase toggle) is not supported in dealer3.");
-        eprintln!();
-        eprintln!("Reason: This is a cosmetic feature with low priority.");
-        eprintln!();
-        eprintln!("Suggestion: Remove the '-u' switch from your command.");
-        eprintln!("            dealer3 uses standard uppercase card symbols (AKQJT).");
-        std::process::exit(1);
+    // `-u` is accepted and does nothing, which is exactly what it does in
+    // dealer.exe: the flag it sets there is read only by the `representation`
+    // macro, and that macro is never invoked, so honours come out upper case
+    // either way. Refusing it would break a command line that works on BBO for
+    // no gain. Said aloud under `-v` so nobody thinks it took effect.
+    if args.uppercase && args.verbose {
+        eprintln!("Note: -u is accepted and ignored; honours are always upper case.");
     }
 
     if args.library {

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -243,14 +243,6 @@ pub const REMAINING: &[WorkItem] = &[
         note: Some("`--input-deals` already covers the common case in dealer3's own way."),
     },
     WorkItem {
-        what: "Upper-case the honour cards in output",
-        done_when: Some(DoneWhen::Switch("-u")),
-        issue: None,
-        effort: Effort::Low,
-        value: Value::Low,
-        note: Some("Cosmetic."),
-    },
-    WorkItem {
         what: "Export in RP zrd format",
         done_when: Some(DoneWhen::Switch("-Z")),
         issue: None,

--- a/dealer/src/switches.rs
+++ b/dealer/src/switches.rs
@@ -263,6 +263,15 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
         ),
     },
     SwitchRow {
+        short: "-u",
+        long: "",
+        group: "Output",
+        what: "Upper-case the honour cards in output",
+        dealer_exe: Origin::Same,
+        dealer_v2: Origin::Absent,
+        note: Some("Accepted and ignored, because it does nothing in dealer.exe either: `-u` sets a flag read only by the `representation` macro in `dealer.c`, and that macro is never invoked — every output path uses `ucrep` directly. Verified; the reference binary's output is byte-identical with and without it. dealer3's honours are upper case too, so the switch is accepted rather than refused and a command line carrying it still runs. `-v` says so."),
+    },
+    SwitchRow {
         short: "",
         long: "--interleave",
         group: "Output",
@@ -532,15 +541,6 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
     // Declared to clap as hidden arguments purely so the program can explain
     // itself. The dealer3 column derives "rejected" from that hidden flag, so
     // implementing one for real needs no bookkeeping here.
-    SwitchRow {
-        short: "-u",
-        long: "",
-        group: "Recognised but not supported",
-        what: "Upper-case the honour cards in output",
-        dealer_exe: Origin::Same,
-        dealer_v2: Origin::Absent,
-        note: Some("Cosmetic."),
-    },
     SwitchRow {
         short: "-e",
         long: "",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which has nothing to walk through.
 
 ### Changed
+- **`-u` is accepted and ignored rather than refused.** It does nothing in
+  dealer.exe either: `case 'u'` sets a flag read only by the `representation`
+  macro in `dealer.c`, and that macro is never invoked — every output path calls
+  `ucrep` directly, so honours are upper case with or without it. The reference
+  binary's output is byte-identical either way; `lcrep` appears exactly twice in
+  the file, its own definition and that dead macro. Refusing a switch that does
+  nothing broke a command line that works on BBO for no gain. `-v` prints a note
+  so nobody thinks it took effect.
+  - The roadmap row "Upper-case the honour cards in output" is deleted. dealer3
+    has always printed `AKQJT`; there was never anything behind it.
 - **Breaking: `score()`'s numeric contract code is now the references' encoding,
   `level * 5 + strain`, plus 40 for each level of doubling.** dealer3 used to
   read `level * 10 + strain` plus 100 or 200, so 3NT was 34 and is now 19, and

--- a/docs/DEPRECATED_SWITCHES.md
+++ b/docs/DEPRECATED_SWITCHES.md
@@ -47,27 +47,24 @@ Suggestion: Remove the '-e' switch from your command.
 
 ### 2. `-u` - Upper/Lowercase Toggle
 
-**Status**: ❌ Not Supported
-**Reason**: Cosmetic feature with low priority
+**Status**: ✅ Accepted and ignored — no longer deprecated
 
-**Error Message**:
-```
-Error: Switch '-u' (upper/lowercase toggle) is not supported in dealer3.
+**What it does in dealer.exe**: nothing. `case 'u'` sets `uppercase = 1`, which
+is read only by
 
-Reason: This is a cosmetic feature with low priority.
-
-Suggestion: Remove the '-u' switch from your command.
-            dealer3 uses standard uppercase card symbols (AKQJT).
+```c
+#define representation (uppercase ? ucrep : lcrep );
 ```
 
-**What it did in dealer.exe**:
-- Toggle between uppercase and lowercase for card symbols
-- Affects display only: AKQJT vs akqjt
+and that macro is never invoked anywhere in `dealer.c`. `lcrep` appears exactly
+twice in the file — its own definition and that dead macro — while every output
+path calls `ucrep` directly. Confirmed against the binary: its output is
+byte-identical with and without the switch, so honours are `AKQJT` either way.
 
-**Why not supported**:
-- Purely cosmetic feature
-- Low priority compared to functional features
-- dealer3 uses standard uppercase (AKQJT)
+**Why dealer3 accepts it**: refusing a switch that does nothing would break a
+command line that works on BBO, for no gain. dealer3 prints upper-case honours
+already, so `-u` changes nothing here either — which is the compatible answer.
+`-v` prints a note so nobody believes it took effect.
 - Could be added in future if there's demand
 
 ---
@@ -153,8 +150,8 @@ $ echo "hcp(north) >= 20" | dealer -e -p 1
 Error: Switch '-e' (exhaust mode) is not supported in dealer3.
 ...
 
-$ echo "hcp(north) >= 20" | dealer -u -p 1
-Error: Switch '-u' (upper/lowercase toggle) is not supported in dealer3.
+$ echo "hcp(north) >= 20" | dealer -u -v -p 1
+Note: -u is accepted and ignored; honours are always upper case.
 ...
 
 $ echo "hcp(north) >= 20" | dealer -l -p 1
@@ -176,14 +173,14 @@ Error: Switch '-l' (library mode) is not supported in dealer3.
 
 ### Affected Users
 - Users who tried experimental `-e` flag (likely none)
-- Users who customized card display with `-u` (likely rare)
+- Nobody: `-u` never changed dealer.exe's output either
 - Users who used library.dat with `-l` (advanced users only)
 
 ### Migration Path
 - **Swapping (`-2`, `-3`)**: nothing to do — they work. Only a predeal to a
   seat the swap moves is refused, and the original was silently wrong there.
 - **Exhaust (`-e`)**: Remove switch (feature never worked)
-- **Uppercase (`-u`)**: Remove switch (cosmetic only)
+- **Uppercase (`-u`)**: nothing to do; accepted and ignored, as in dealer.exe
 - **Library (`-l`)**: Remove switch, wait for future library support
 
 ---
@@ -191,7 +188,7 @@ Error: Switch '-l' (library mode) is not supported in dealer3.
 ## Future Considerations
 
 ### Could Be Added Later
-1. **Upper/lowercase toggle (`-u`)**: Low priority, cosmetic feature
+1. ~~**Upper/lowercase toggle (`-u`)**~~: accepted and ignored; it is a no-op in dealer.exe too
 2. **Library input (`--library-input`)**: If there's demand for library.dat support
 3. **DL52 export (`--dl52-output`)**: If there's demand for DealerV2_4 compatibility
 

--- a/docs/command_line_comparison.md
+++ b/docs/command_line_comparison.md
@@ -24,7 +24,7 @@ UPDATE_DOCS=1 cargo test -p dealer
 
 <!-- BEGIN GENERATED: switches -->
 
-dealer3 implements **38 of the 49 switches** listed here. The dealer3 column is read from the argument parser itself, so it cannot drift; the other two columns are reference data (see `dealer/src/switches.rs` for their provenance).
+dealer3 implements **39 of the 49 switches** listed here. The dealer3 column is read from the argument parser itself, so it cannot drift; the other two columns are reference data (see `dealer/src/switches.rs` for their provenance).
 
 In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed and then refused with an explanation, so a script using it gets told rather than ignored. In the other two columns ✅ means the same meaning, ⚠️ a different one, and — not present at all.
 
@@ -53,6 +53,7 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 
 | Switch | What it does | dealer3 | dealer.exe | DealerV2_4 | Notes |
 |---|---|---|---|---|---|
+| `-u` | Upper-case the honour cards in output | ✅ | ✅ | — | Accepted and ignored, because it does nothing in dealer.exe either: `-u` sets a flag read only by the `representation` macro in `dealer.c`, and that macro is never invoked — every output path uses `ucrep` directly. Verified; the reference binary's output is byte-identical with and without it. dealer3's honours are upper case too, so the switch is accepted rather than refused and a command line carrying it still runs. `-v` says so. |
 | `--interleave` | Order the output so each hand type appears before any repeats | ✅ | — | — | Needs `HandType_*` variables to classify against. Rare types are spread across the run rather than exhausted early. See `docs/leveling-guide.md`. |
 | `-f`, `--format` | Output format | ✅ | — | — | The original selects a format with an `action` statement instead. |
 | `-d`, `--dealer` | Dealer position | ✅ | — | — | The original uses the `dealer` statement, which dealer3 also accepts. |
@@ -101,7 +102,6 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 
 | Switch | What it does | dealer3 | dealer.exe | DealerV2_4 | Notes |
 |---|---|---|---|---|---|
-| `-u` | Upper-case the honour cards in output | ⚠️ rejected with a message | ✅ | — | Cosmetic. |
 | `-e` | Exhaust mode | ⚠️ rejected with a message | ⚠️ compiled out; prints "not included" | — | Never finished in the original either. |
 | `-l` | Replay deals from a library file | ⚠️ rejected with a message | ✅ | ⚠️ -l exports DL52 | `--input-deals` covers this use case in dealer3's own way. |
 | `--legacy` | The old single-threaded RNG mode | ⚠️ rejected with a message | — | — | Removed in 0.5.0; still parsed so a script using it gets an explanation. |

--- a/docs/command_line_switch_requirements.md
+++ b/docs/command_line_switch_requirements.md
@@ -27,7 +27,9 @@
 - ✅ `-T/--title TEXT` - Title metadata for PBN output (DealerV2_4 feature)
 - ✅ `--license` - Display license information
 - ✅ `--credits` - Display credits
-- ✅ `-2`, `-3`, `-e`, `-u`, `-l` - Deprecated switches (helpful errors)
+- ✅ `-e`, `-l` - Deprecated switches (helpful errors)
+- ✅ `-2`, `-3` - Swapping modes (implemented)
+- ✅ `-u` - Accepted and ignored, as in dealer.exe
 
 **Key Achievement**: dealer3 is now **fully compatible** with essential dealer.exe command-line behavior!
 
@@ -194,7 +196,7 @@ dealer --vulnerable none  # Vulnerability (long form only)
 - [x] Add `--vulnerable` long form
 - [x] Implement `-q` quiet mode
 - [x] Implement `-m` progress meter
-- [x] Implement deprecated switch detection (`-2`, `-3`, `-e`, `-u`, `-l`)
+- [x] Implement deprecated switch detection (`-e`, `-l`)
 - [x] Update all documentation
 - [x] Update README with migration guide
 - [x] Add CHANGELOG entry documenting breaking changes

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -265,7 +265,6 @@ Priority is derived from effort and value rather than written down beside them.
 
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
-| 🔵 Unlikely | Upper-case the honour cards in output | Low | Low |  | Cosmetic. |
 | 🔵 Unlikely | `par(side)`: the par contract | Low | Low |  | Needs all 20 double-dummy results, which bridge-solver already provides for `tricks()`, `score()` and `imps()`. DealerV2_4 sets its vulnerability with `-P`, which has a row of its own in the switch table. |
 | 🔵 Unlikely | `printns` and `printside(side)` | Low | Low |  | dealer3 has `printew`; DealerV2_4 routes all three through one action. |
 | 🔵 Unlikely | `trix(compass)` and `trix(deal)` | Low | Low |  | Tricks in all five strains as CSV columns. The solving is already done. |


### PR DESCRIPTION
The roadmap's top item after the `score()` work was **"Upper-case the honour cards in output"**. It rested on a false premise twice over.

## dealer3 already prints upper-case honours

`AKQJT`, in every format. Always has.

## And `-u` does nothing in dealer.exe

```c
char lcrep[] = "23456789tjqka";
char ucrep[] = "23456789TJQKA";
#define representation (uppercase ? ucrep : lcrep );
```

`case 'u'` sets `uppercase = 1`, which is read only by that macro — and the macro is **never invoked anywhere** in `dealer.c`. `lcrep` appears exactly twice in the whole file: its own definition and the dead macro. Every output path calls `ucrep` directly.

Confirmed against the binary rather than inferred — output is byte-identical with and without the switch:

```
$ diff <(dealer -p 3 -s 1) <(dealer -u -p 3 -s 1)
(identical apart from the timing line)
```

(Note the stray `;` inside the macro, too. It could never have been used in an expression without breaking — dead on arrival.)

## So the only real gap was the opposite of the row

| | `dealer -u ...` |
|---|---|
| dealer.exe | runs normally, exit 0 |
| dealer3, before | `Error: ... not supported`, exit 1 |
| dealer3, now | runs normally, exit 0 |

Refusing a switch that does nothing broke a command line that works on BBO for no gain. It is now accepted and ignored, with a note under `-v` so nobody thinks it took effect:

```
$ dealer -u -v ...
Note: -u is accepted and ignored; honours are always upper case.
```

Output is byte-identical with and without it here too, matching the original.

## Bookkeeping

- The roadmap row is deleted — there was never any work behind it.
- The switch table moves `-u` out of "Recognised but not supported" into Output. That column derives from clap's `hide` flag, so dropping `hide = true` is what reclassifies it; the existing `rejected_switches_are_not_filed_as_working` test enforces the two stay consistent.
- `docs/DEPRECATED_SWITCHES.md` rewritten for `-u`, with the evidence.

## Also found: two stale lists

`CLAUDE.md` and `docs/command_line_switch_requirements.md` both still listed `-2` and `-3` as deprecated switches that "show helpful errors". They have been implemented as swapping modes since Sprint 3 — I checked, both run. Corrected.

500 tests pass; `cargo fmt` and `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)