### PR TITLE
par(side), printns/printside, and trix() in reports

### DIFF
--- a/dealer-core/src/lib.rs
+++ b/dealer-core/src/lib.rs
@@ -5,6 +5,7 @@ mod hand;
 pub mod rng;
 mod shape;
 mod swap;
+mod vulnerability;
 
 // Re-export core types from bridge-types
 pub use bridge_types::{Card, Direction, Rank, Suit};
@@ -19,3 +20,4 @@ pub use fast_deal::{
 pub use hand::Hand;
 pub use shape::{shape_to_index, ShapeMask};
 pub use swap::SwapMode;
+pub use vulnerability::Vulnerability;

--- a/dealer-core/src/vulnerability.rs
+++ b/dealer-core/src/vulnerability.rs
@@ -1,0 +1,68 @@
+//! Which side is vulnerable, as the run understands it.
+//!
+//! A value rather than two booleans because more than scoring wants it: `par()`
+//! needs the pair of flags, but a script asking *what* the vulnerability is —
+//! to bid differently at unfavourable, say — needs to name it. Keeping the
+//! whole value here means that question can be answered later without moving
+//! anything.
+//!
+//! `dealer-pbn` has a vulnerability of its own for the `[Vulnerable]` tag, and
+//! `dealer-parser` has one for the `vulnerable` statement. Those describe a
+//! written form; this one is what the evaluator is handed.
+
+/// The sides that are vulnerable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Vulnerability {
+    /// Neither side. The default, and what a run that never says otherwise has.
+    #[default]
+    None,
+    NorthSouth,
+    EastWest,
+    Both,
+}
+
+impl Vulnerability {
+    /// Is North-South vulnerable?
+    pub fn ns(self) -> bool {
+        matches!(self, Vulnerability::NorthSouth | Vulnerability::Both)
+    }
+
+    /// Is East-West vulnerable?
+    pub fn ew(self) -> bool {
+        matches!(self, Vulnerability::EastWest | Vulnerability::Both)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn each_value_names_the_sides_it_covers() {
+        assert_eq!(
+            (Vulnerability::None.ns(), Vulnerability::None.ew()),
+            (false, false)
+        );
+        assert_eq!(
+            (
+                Vulnerability::NorthSouth.ns(),
+                Vulnerability::NorthSouth.ew()
+            ),
+            (true, false)
+        );
+        assert_eq!(
+            (Vulnerability::EastWest.ns(), Vulnerability::EastWest.ew()),
+            (false, true)
+        );
+        assert_eq!(
+            (Vulnerability::Both.ns(), Vulnerability::Both.ew()),
+            (true, true)
+        );
+    }
+
+    /// A run that says nothing about vulnerability has none.
+    #[test]
+    fn the_default_is_neither_side() {
+        assert_eq!(Vulnerability::default(), Vulnerability::None);
+    }
+}

--- a/dealer-dds/src/lib.rs
+++ b/dealer-dds/src/lib.rs
@@ -14,7 +14,7 @@
 
 mod memo;
 
-pub use memo::tricks;
+pub use memo::{par_score_ns, table, tricks};
 
 use dealer_core::{Deal, Position, Suit};
 

--- a/dealer-dds/src/memo.rs
+++ b/dealer-dds/src/memo.rs
@@ -132,6 +132,33 @@ pub fn tricks(deal: &Deal, denomination: Denomination, declarer: Position) -> u8
     })
 }
 
+/// The whole 20-entry double-dummy table for a deal.
+///
+/// Every cell goes through [`tricks`], so a table costs only the searches that
+/// have not already been done — a script whose condition asked about one
+/// denomination pays for nineteen more, not twenty — and the answers are shared
+/// with every later caller the same way.
+///
+/// Laid out as `bridge_solver` wants it: seats N, E, S, W and strains C, D, H,
+/// S, NT, which is dealer's own strain numbering too.
+pub fn table(deal: &Deal) -> bridge_solver::DdTricks {
+    let mut tricks = [[0u8; 5]; 4];
+    for (seat, row) in Position::ALL.iter().zip(tricks.iter_mut()) {
+        for (denomination, cell) in Denomination::ALL.iter().zip(row.iter_mut()) {
+            *cell = self::tricks(deal, *denomination, *seat);
+        }
+    }
+    bridge_solver::DdTricks { tricks }
+}
+
+/// The par score, to North-South, at the given vulnerability.
+///
+/// Negative means East-West are the ones who benefit. A passed-out deal — par
+/// zero — is zero, which is what the original returns too.
+pub fn par_score_ns(deal: &Deal, vul_ns: bool, vul_ew: bool) -> i32 {
+    bridge_solver::par(&table(deal), vul_ns, vul_ew).score_ns
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dealer-eval/src/lib.rs
+++ b/dealer-eval/src/lib.rs
@@ -338,6 +338,14 @@ pub struct EvalContext<'a> {
     /// either statement — and it means the hardcoded counts run exactly as they
     /// did before. Only a script that redefines something pays for the table.
     counts: Option<&'a PointCounts>,
+    /// Which side is vulnerable, for `par()`.
+    ///
+    /// `Vulnerability::None` unless a run says otherwise, which is what a
+    /// context built for a bare expression has. Carried as the whole value
+    /// rather than the two flags `par()` needs, so a script asking *what* the
+    /// vulnerability is can be answered from here later without moving
+    /// anything.
+    vulnerability: dealer_core::Vulnerability,
 }
 
 /// Can evaluating `expr` reach a call to `rnd()`?
@@ -425,6 +433,7 @@ impl<'a> EvalContext<'a> {
             cache: RefCell::new(FxHashMap::default()),
             rnd: RefCell::new(None),
             counts: None,
+            vulnerability: dealer_core::Vulnerability::default(),
         }
     }
 
@@ -436,7 +445,23 @@ impl<'a> EvalContext<'a> {
             cache: RefCell::new(FxHashMap::default()),
             rnd: RefCell::new(None),
             counts: None,
+            vulnerability: dealer_core::Vulnerability::default(),
         }
+    }
+
+    /// The same context, told which side is vulnerable.
+    ///
+    /// A builder rather than another constructor: every existing caller wants
+    /// the default, and only a run that has been told a vulnerability has one
+    /// to pass on.
+    pub fn with_vulnerability(mut self, vulnerability: dealer_core::Vulnerability) -> Self {
+        self.vulnerability = vulnerability;
+        self
+    }
+
+    /// Which side is vulnerable.
+    pub fn vulnerability(&self) -> dealer_core::Vulnerability {
+        self.vulnerability
     }
 
     /// The next number below `bound` from this context's `rnd()` stream.
@@ -470,6 +495,7 @@ impl<'a> EvalContext<'a> {
             cache: RefCell::new(FxHashMap::default()),
             rnd: RefCell::new(None),
             counts,
+            vulnerability: dealer_core::Vulnerability::default(),
         }
     }
 }
@@ -1369,6 +1395,32 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
 
             // Convert to IMPs using the standard table
             Ok(score_to_imps(score_diff))
+        }
+
+        Function::Par => {
+            // par(ns) / par(ew), or a compass for the side that seat is on —
+            // `dds_parscore` in DealerV2_4 takes either. The score is worked
+            // out for North-South and negated for East-West, as it is there.
+            let north_south = match &args[0] {
+                Expr::Position(position) => {
+                    matches!(position, Position::North | Position::South)
+                }
+                other => match eval(other, ctx)? {
+                    0 => true,
+                    1 => false,
+                    n => {
+                        return Err(EvalError::InvalidArgument(format!(
+                            "Invalid side: {} (must be ns or ew, or 0 for NS and 1 for EW)",
+                            n
+                        )))
+                    }
+                },
+            };
+
+            let vulnerability = ctx.vulnerability();
+            let score_ns =
+                dealer_dds::par_score_ns(ctx.deal, vulnerability.ns(), vulnerability.ew());
+            Ok(if north_south { score_ns } else { -score_ns })
         }
     }
 }

--- a/dealer-parser/src/ast.rs
+++ b/dealer-parser/src/ast.rs
@@ -400,6 +400,8 @@ pub enum Function {
     Score,
     /// Convert score difference to IMPs
     Imps,
+    /// The par score, to the side named
+    Par,
     /// A random number below the given bound
     ///
     /// The original draws this from the same generator it shuffles with, so
@@ -436,6 +438,7 @@ impl Function {
             "tricks" | "trick" | "dds" => Some(Function::Tricks),
             "score" => Some(Function::Score),
             "imps" | "imp" => Some(Function::Imps),
+            "par" => Some(Function::Par),
             "rnd" => Some(Function::Rnd),
             _ => None,
         }
@@ -471,6 +474,7 @@ impl Function {
             Function::Tricks => "tricks",
             Function::Score => "score",
             Function::Imps => "imps",
+            Function::Par => "par",
             Function::Rnd => "rnd",
         }
     }
@@ -506,6 +510,7 @@ impl Function {
             | Function::Clubs
             | Function::Cccc
             | Function::Imps
+            | Function::Par
             | Function::Rnd => (1, 1),
 
             // A hand and something about it.

--- a/dealer-parser/src/ast.rs
+++ b/dealer-parser/src/ast.rs
@@ -101,6 +101,14 @@ pub enum CsvTerm {
     Side(Side),
     /// All four hands (DEAL keyword)
     Deal,
+    /// `trix(compass)` or `trix(deal)`: double-dummy tricks in all five
+    /// strains, one column each, for every seat listed.
+    ///
+    /// A term rather than a function because it is more than one number: five
+    /// per seat, in the strain order the rest of the language uses (0=C to
+    /// 4=NT). `trix(deal)` lists all four seats in the report's usual N, E, S,
+    /// W order.
+    Trix(Vec<Position>),
 }
 
 /// Side enumeration for CSV output
@@ -152,6 +160,13 @@ impl VulnerabilityType {
 pub enum ActionType {
     PrintAll,
     PrintEW,
+    /// North and South only, the counterpart of `PrintEW`.
+    ///
+    /// `printns` and `printside(ns)` are the same action. DealerV2_4 routes
+    /// `printew`, `printns` and `printside(side)` through one printer; dealer3
+    /// keeps two variants because nothing else needs a payload, and the two
+    /// spellings of each simply resolve here.
+    PrintNS,
     PrintPBN,
     PrintCompact,
     PrintOneLine,
@@ -162,6 +177,7 @@ impl ActionType {
         match s.to_lowercase().as_str() {
             "printall" => Some(ActionType::PrintAll),
             "printew" => Some(ActionType::PrintEW),
+            "printns" => Some(ActionType::PrintNS),
             "printpbn" => Some(ActionType::PrintPBN),
             "printcompact" => Some(ActionType::PrintCompact),
             "printoneline" => Some(ActionType::PrintOneLine),

--- a/dealer-parser/src/grammar.pest
+++ b/dealer-parser/src/grammar.pest
@@ -187,7 +187,8 @@ multiplicative = { unary ~ (mul_op ~ unary)* }
 unary = { "-" ~ unary | not_op ~ unary | primary }
 
 primary = _{
-    score_call     // Before function_call: score's own argument spellings
+    par_call       // Before function_call: `ns` and `ew` are not expressions
+    | score_call     // Before function_call: score's own argument spellings
     | function_call  // Must be first to parse function(args)
     | paren_expr
     | shape_pattern
@@ -217,6 +218,13 @@ function_call = { function_name ~ "(" ~ expr ~ ("," ~ expr)* ~ ")" }
 // not 2" before a card is dealt. Pinning the rule to three instead made
 // `score(nv, x3N)` fall through to `function_call`, where the two words are
 // nothing but undefined names — loud, but about the wrong thing.
+// `par(ns)`, `par(ew)`, and — as `dds_parscore` in DealerV2_4 allows — a
+// compass for the side that seat is on. `ns` and `ew` are not expressions
+// anywhere else, so par needs its own rule to reach them, the same way `score`
+// does for its contract words.
+par_call = { par_name ~ "(" ~ (side | expr) ~ ")" }
+par_name = @{ "par" ~ !(ASCII_ALPHANUMERIC | "_") }
+
 score_call = { score_name ~ "(" ~ score_arg ~ ("," ~ score_arg)* ~ ")" }
 score_name = @{ "score" ~ !(ASCII_ALPHANUMERIC | "_") }
 score_arg = _{ contract_token | vuln_token | expr }
@@ -254,7 +262,7 @@ function_name = @{
     "controls" | "control"
     | "hascard" | "hcps" | "hcp"
     | "losers" | "loser"
-    | "shape" | "quality" | "cccc" | "score"
+    | "shape" | "quality" | "cccc" | "score" | "par"
     | "tens" | "ten"
     | "jacks" | "jack"
     | "queens" | "queen"

--- a/dealer-parser/src/grammar.pest
+++ b/dealer-parser/src/grammar.pest
@@ -41,7 +41,12 @@ frequency_stmt = { &kw_frequency ~ ^"frequency" ~ string_literal? ~ "(" ~ expr ~
 // The parentheses matter: `~` binds tighter than `|`, so without them the
 // guard would cover only the first alternative and `printewFoo` would still
 // be swallowed while `printallQ` was fixed.
-print_stmt = { &kw_print ~ (^"printall" | ^"printew" | ^"printpbn" | ^"printcompact" | ^"printoneline") }
+print_stmt = { &kw_print ~ (printside_spec | simple_action) }
+
+// `printside(ns)` and `printside(ew)`, DealerV2_4's one action for both
+// partnerships. `printns` and `printew` are the same thing already named, and
+// DealerV2_4 routes all three through it.
+printside_spec = { ^"printside" ~ "(" ~ side ~ ")" }
 
 // Action block keywords
 condition_stmt = { &kw_condition ~ ^"condition" ~ expr }
@@ -84,13 +89,23 @@ pointcount_stmt = { &kw_pointcount ~ ^"pointcount" ~ literal+ }
 altcount_stmt = { &kw_altcount ~ ^"altcount" ~ literal ~ literal+ }
 
 // CSV terms for csvrpt
+//
+// `trix` comes first: it is a call, so `expr` would otherwise try to read it as
+// a function and fail on a name the language does not have.
 csv_term = {
+    trix_spec |
     ^"deal" |
     side |
     compass |
     string_literal |
     expr
 }
+
+// `trix(north)` or `trix(deal)`: tricks in all five strains, as columns rather
+// than one value, which is why it is a report term and not a function. Five
+// numbers for a compass, twenty for the deal, in the seat order the report
+// already uses for `deal`.
+trix_spec = { ^"trix" ~ "(" ~ (^"deal" | compass) ~ ")" }
 
 side = @{ ^"ns" | ^"ew" }
 
@@ -111,8 +126,13 @@ printhands_spec = { ^"print" ~ "(" ~ compass ~ ("," ~ compass)* ~ ")" }
 es_term = { string_literal | newline | expr }
 newline = @{ "\\n" }
 
-action_type = @{
-    ^"printall" | ^"printew" | ^"printpbn" | ^"printcompact" | ^"printoneline"
+action_type = { printside_spec | simple_action }
+
+// Longest first, as everywhere: `printns` ahead of nothing it prefixes, but
+// `printoneline` must precede no shorter spelling of itself.
+simple_action = @{
+    ^"printall" | ^"printew" | ^"printns" | ^"printpbn" | ^"printcompact"
+    | ^"printoneline"
 }
 
 // Dealer position (compass)
@@ -344,7 +364,7 @@ kw_altcount   = @{ ^"altcount"   ~ !(ASCII_ALPHANUMERIC | "_") }
 kw_average    = @{ ^"average"    ~ !(ASCII_ALPHANUMERIC | "_") }
 kw_frequency  = @{ ^"frequency"  ~ !(ASCII_ALPHANUMERIC | "_") }
 kw_printes    = @{ ^"printes"    ~ !(ASCII_ALPHANUMERIC | "_") }
-kw_print      = @{ (^"printall" | ^"printew" | ^"printpbn" | ^"printcompact" | ^"printoneline" | ^"print") ~ !(ASCII_ALPHANUMERIC | "_") }
+kw_print      = @{ (^"printall" | ^"printew" | ^"printns" | ^"printside" | ^"printpbn" | ^"printcompact" | ^"printoneline" | ^"print") ~ !(ASCII_ALPHANUMERIC | "_") }
 
 // Words that introduce a statement. Kept out of bare-identifier position: a
 // malformed statement otherwise backtracks into `expr` and parses as bare

--- a/dealer-parser/src/parser.rs
+++ b/dealer-parser/src/parser.rs
@@ -163,6 +163,16 @@ fn build_csv_terms(inner: Pair<Rule>) -> Result<Vec<CsvTerm>, ParseError> {
                 CsvTerm::Deal
             } else if let Some(term_inner) = term_pair.into_inner().next() {
                 match term_inner.as_rule() {
+                    Rule::trix_spec => {
+                        let target = term_inner.into_inner().next();
+                        let seats = match target {
+                            // `trix(deal)`: the keyword is consumed by the rule
+                            // itself, so there is no inner pair to look at.
+                            None => Position::ALL.to_vec(),
+                            Some(compass) => vec![compass_position(compass.as_str())?],
+                        };
+                        CsvTerm::Trix(seats)
+                    }
                     Rule::expr => CsvTerm::Expression(build_ast(term_inner)?),
                     Rule::string_literal => {
                         let s = term_inner.as_str();
@@ -377,14 +387,7 @@ fn build_statement(pair: Pair<Rule>) -> Result<Statement, ParseError> {
                                 }
                             }
                             Rule::action_type => {
-                                let action_type = ActionType::parse(comp_inner.as_str())
-                                    .ok_or_else(|| ParseError {
-                                        message: format!(
-                                            "Invalid action type: {}",
-                                            comp_inner.as_str()
-                                        ),
-                                    })?;
-                                format = Some(action_type);
+                                format = Some(action_type_from(comp_inner)?);
                             }
                             _ => {
                                 return Err(ParseError {
@@ -573,10 +576,8 @@ fn build_statement(pair: Pair<Rule>) -> Result<Statement, ParseError> {
             })
         }
         Rule::print_stmt => {
-            // Standalone print statement: printpbn, printall, etc.
-            let action_type = ActionType::parse(inner.as_str()).ok_or_else(|| ParseError {
-                message: format!("Invalid print statement: {}", inner.as_str()),
-            })?;
+            // Standalone print statement: printpbn, printall, printside(ns), etc.
+            let action_type = action_type_from(inner)?;
             Ok(Statement::Action {
                 averages: Vec::new(),
                 frequencies: Vec::new(),
@@ -663,6 +664,54 @@ fn contract_code(token: &str) -> Result<i32, ParseError> {
     let doubled = chars.filter(|c| *c == 'x').count() as i32;
 
     Ok(40 * doubled + level * 5 + strain)
+}
+
+/// A compass word as a `Position`, in any of the language's spellings.
+fn compass_position(text: &str) -> Result<Position, ParseError> {
+    match text.to_lowercase().as_str() {
+        "north" | "n" => Ok(Position::North),
+        "south" | "s" => Ok(Position::South),
+        "east" | "e" => Ok(Position::East),
+        "west" | "w" => Ok(Position::West),
+        other => Err(ParseError {
+            message: format!("Invalid compass: {}", other),
+        }),
+    }
+}
+
+/// The action a `print...` word names, in either of its spellings.
+///
+/// `printside(ns)` and `printns` are one action, as are `printside(ew)` and
+/// `printew`, so both forms resolve to the same `ActionType` here rather than
+/// being carried separately through the rest of the program.
+fn action_type_from(pair: pest::iterators::Pair<Rule>) -> Result<ActionType, ParseError> {
+    let text = pair.as_str();
+    let inner = match pair.as_rule() {
+        Rule::action_type | Rule::print_stmt => {
+            pair.into_inner().next().ok_or_else(|| ParseError {
+                message: format!("Empty action: {}", text),
+            })?
+        }
+        _ => pair,
+    };
+
+    match inner.as_rule() {
+        Rule::printside_spec => {
+            let side = inner.into_inner().next().ok_or_else(|| ParseError {
+                message: "printside needs a side".to_string(),
+            })?;
+            match side.as_str().to_lowercase().as_str() {
+                "ns" => Ok(ActionType::PrintNS),
+                "ew" => Ok(ActionType::PrintEW),
+                other => Err(ParseError {
+                    message: format!("Unknown side: {}", other),
+                }),
+            }
+        }
+        _ => ActionType::parse(inner.as_str()).ok_or_else(|| ParseError {
+            message: format!("Invalid action type: {}", inner.as_str()),
+        }),
+    }
 }
 
 /// Parse a single card from a string like "AS", "KH", "2C" (rank+suit format for hascard)

--- a/dealer-parser/src/parser.rs
+++ b/dealer-parser/src/parser.rs
@@ -1018,6 +1018,24 @@ fn build_ast(pair: Pair<Rule>) -> Result<Expr, ParseError> {
             })
         }
 
+        Rule::par_call => {
+            // `par_name` then the side. A side word becomes the number the
+            // evaluator reads — 0 for North-South, 1 for East-West — so a
+            // compass or a computed value works in the same slot.
+            let mut args = Vec::new();
+            for arg in pair.into_inner() {
+                match arg.as_rule() {
+                    Rule::par_name => continue,
+                    Rule::side => {
+                        let side = arg.as_str().to_lowercase();
+                        args.push(Expr::Literal(i32::from(side == "ew")));
+                    }
+                    _ => args.push(build_ast(arg)?),
+                }
+            }
+            Ok(Expr::call_multi(Function::Par, args))
+        }
+
         Rule::score_call => {
             // score_name, then the three arguments. The first two may have
             // arrived as tokens, which the rules below have already turned

--- a/dealer-parser/src/vocabulary.rs
+++ b/dealer-parser/src/vocabulary.rs
@@ -28,7 +28,7 @@ pub const FUNCTIONS: &[&str] = &[
     "top3", "top4", "top5", "c13", // Indexed point counts
     "pt0", "pt1", "pt2", "pt3", "pt4", "pt5", "pt6", "pt7", "pt8", "pt9",
     // Double-dummy and scoring
-    "tricks", "trick", "dds", "score", "imps", "imp", "rnd",
+    "tricks", "trick", "dds", "score", "imps", "imp", "par", "rnd",
 ];
 
 /// Statement keywords that introduce a directive.
@@ -636,6 +636,27 @@ pub const FUNCTION_DOCS: &[FunctionDoc] = &[
         example: "imps(score(nv, x4S, 10) - score(nv, x3N, 9)) >= 1",
         alias_of: None,
         note: None,
+    },
+    FunctionDoc {
+        name: "par",
+        group: "Double-dummy and scoring",
+        signature: "par(side)",
+        summary: "The par score to that side: what the deal is worth with both sides bidding \
+                  and defending perfectly. `side` is `ns` or `ew`, or a compass for the side \
+                  that seat is on.",
+        example: "par(ns) >= 400",
+        alias_of: None,
+        note: Some(
+            "Worked out from all twenty double-dummy results, which cost the same searches \
+             `tricks()` does and are remembered per deal — so `par()` beside a `tricks()` \
+             condition is close to free.\n\nThe two sides are opposites: `par(ew)` is \
+             `-par(ns)`, and a passed-out deal is zero. Vulnerability is the run's own — \
+             `--vulnerable`, or the `vulnerable` statement — and neither side is vulnerable \
+             when a script names none. It is deliberately not the rotation `printpbn` applies \
+             to an unnamed vulnerability: par is a property of the cards and the vulnerability \
+             the run was given, not of where a board sits in a set. DealerV2_4 instead has a \
+             `-P` switch of its own for this.",
+        ),
     },
     FunctionDoc {
         name: "rnd",

--- a/dealer-parser/src/vocabulary.rs
+++ b/dealer-parser/src/vocabulary.rs
@@ -56,6 +56,8 @@ pub const STATEMENT_KEYWORDS: &[&str] = &[
 pub const ACTIONS: &[&str] = &[
     "printall",
     "printew",
+    "printns",
+    "printside",
     "printpbn",
     "printcompact",
     "printoneline",
@@ -998,16 +1000,24 @@ pub const STATEMENT_DOCS: &[StatementDoc] = &[
         form: "csvrpt(<term>, <term>, ...)",
         summary: "Writes one comma-separated row per matching deal. A term is an expression, a \
                   quoted string, a compass for that hand, `ns` or `ew` for a partnership's two \
-                  hands, or the word `deal` for all four.",
+                  hands, the word `deal` for all four, or `trix(...)` for double-dummy tricks.",
         example: "csvrpt(deal, hcp(north), \"north\")",
-        note: Some("Command-line only: the browser app has nowhere to write a file."),
+        note: Some(
+            "Command-line only: the browser app has nowhere to write a file.\n\n`trix(compass)` \
+             adds five columns — the tricks that seat takes in clubs, diamonds, hearts, spades \
+             and notrump — and `trix(deal)` adds twenty, four seats in the order `deal` uses. \
+             It is a term rather than a function because it is more than one number. The \
+             solving is the same work `tricks()` does and is remembered per deal, so naming \
+             both costs one search each, not two.",
+        ),
     },
     StatementDoc {
         keyword: Some("printrpt"),
         form: "printrpt(<term>, <term>, ...)",
         summary: "Writes one comma-separated row per matching deal to the screen. The terms are \
                   `csvrpt`'s: an expression, a quoted string, a compass for that hand, `ns` or \
-                  `ew` for a partnership's two hands, or the word `deal` for all four.",
+                  `ew` for a partnership's two hands, the word `deal` for all four, or \
+                  `trix(...)`.",
         example: "printrpt(\"deal \", deal, hcp(south))",
         note: Some(
             "DealerV2_4's screen counterpart of `csvrpt`, and the same row — so the two share \
@@ -1040,6 +1050,11 @@ pub struct ActionDoc {
     pub name: &'static str,
     pub summary: &'static str,
     pub note: Option<&'static str>,
+    /// How the action is written, when the name alone is not a whole action.
+    ///
+    /// `None` means the name is the form, which is true of all but
+    /// `printside`, whose side has to be given.
+    pub form: Option<&'static str>,
 }
 
 /// Every action in [`ACTIONS`], described.
@@ -1049,26 +1064,50 @@ pub const ACTION_DOCS: &[ActionDoc] = &[
         summary: "All four hands, laid out around the compass. This is what happens with no \
                   action given.",
         note: None,
+        form: None,
     },
     ActionDoc {
         name: "printew",
         summary: "East and West only, West on the left.",
-        note: None,
+        note: Some("The same action as `printside(ew)`."),
+        form: None,
+    },
+    ActionDoc {
+        name: "printns",
+        summary: "North and South only, South on the left.",
+        note: Some(
+            "The counterpart of `printew`, and the same action as `printside(ns)`. South \
+             sits left for the reason West does in `printew`: the pair reads as one auction, \
+             and the hand that speaks first goes on the left. From DealerV2_4.",
+        ),
+        form: None,
+    },
+    ActionDoc {
+        name: "printside",
+        summary: "One partnership's two hands: `printside(ns)` or `printside(ew)`.",
+        note: Some(
+            "DealerV2_4's one action for both partnerships. `printside(ns)` and `printns` \
+             are the same thing, as are `printside(ew)` and `printew`.",
+        ),
+        form: Some("printside(ns)"),
     },
     ActionDoc {
         name: "printpbn",
         summary: "PBN, the record format other bridge programs read.",
         note: None,
+        form: None,
     },
     ActionDoc {
         name: "printcompact",
         summary: "Four lines per deal.",
         note: None,
+        form: None,
     },
     ActionDoc {
         name: "printoneline",
         summary: "One line per deal.",
         note: None,
+        form: None,
     },
 ];
 

--- a/dealer-parser/syntaxes/dlr.tmLanguage.json
+++ b/dealer-parser/syntaxes/dlr.tmLanguage.json
@@ -110,7 +110,7 @@
       "patterns": [
         {
           "name": "keyword.control.dlr",
-          "match": "\\b(printcompact|printoneline|pointcount|vulnerable|condition|frequency|altcount|generate|printall|printpbn|printrpt|average|predeal|printes|printew|produce|action|csvrpt|dealer|print|title|seed)\\b"
+          "match": "\\b(printcompact|printoneline|pointcount|vulnerable|condition|frequency|printside|altcount|generate|printall|printpbn|printrpt|average|predeal|printes|printew|printns|produce|action|csvrpt|dealer|print|title|seed)\\b"
         },
         {
           "name": "keyword.other.condition.dlr",

--- a/dealer-parser/syntaxes/dlr.tmLanguage.json
+++ b/dealer-parser/syntaxes/dlr.tmLanguage.json
@@ -118,7 +118,7 @@
         },
         {
           "name": "support.function.dlr",
-          "match": "\\b(controls|diamonds|control|diamond|hascard|quality|hearts|losers|queens|spades|tricks|clubs|heart|jacks|kings|loser|queen|score|shape|spade|trick|aces|cccc|club|hcps|imps|jack|king|tens|top2|top3|top4|top5|ace|c13|dds|hcp|imp|pt0|pt1|pt2|pt3|pt4|pt5|pt6|pt7|pt8|pt9|rnd|ten)\\b"
+          "match": "\\b(controls|diamonds|control|diamond|hascard|quality|hearts|losers|queens|spades|tricks|clubs|heart|jacks|kings|loser|queen|score|shape|spade|trick|aces|cccc|club|hcps|imps|jack|king|tens|top2|top3|top4|top5|ace|c13|dds|hcp|imp|par|pt0|pt1|pt2|pt3|pt4|pt5|pt6|pt7|pt8|pt9|rnd|ten)\\b"
         },
         {
           "name": "constant.language.dlr",

--- a/dealer-parser/tests/vocabulary_docs.rs
+++ b/dealer-parser/tests/vocabulary_docs.rs
@@ -258,8 +258,10 @@ fn statement_examples_parse() {
 #[test]
 fn action_examples_parse() {
     for doc in ACTION_DOCS {
-        if let Err(e) = parses(&format!("action {}\ncondition 1\n", doc.name)) {
-            panic!("`action {}` does not parse\n{}", doc.name, e);
+        // `printside` needs its side; every other action is its own whole form.
+        let form = doc.form.unwrap_or(doc.name);
+        if let Err(e) = parses(&format!("action {}\ncondition 1\n", form)) {
+            panic!("`action {}` does not parse\n{}", form, e);
         }
     }
 }

--- a/dealer-parser/tests/vocabulary_matches_grammar.rs
+++ b/dealer-parser/tests/vocabulary_matches_grammar.rs
@@ -93,18 +93,27 @@ fn functions_match_grammar() {
 
 #[test]
 fn actions_match_grammar() {
-    // `action_type` and the standalone `print_stmt` must list the same actions.
-    let from_action = literals(&rule_body("action_type"));
-    let from_print = literals(&rule_body("print_stmt"));
-    assert_eq!(
-        from_action, from_print,
-        "action_type and print_stmt list different actions"
-    );
-    compare(
-        "ACTIONS",
-        from_action,
-        as_set(dealer_parser::vocabulary::ACTIONS),
-    );
+    // `action_type` and the standalone `print_stmt` used to list the actions
+    // separately, and this test existed because the two lists could drift.
+    // They now both defer to `simple_action` and `printside_spec`, so the
+    // drift is impossible by construction — but only while they really do
+    // defer, which is what is checked first.
+    for rule in ["action_type", "print_stmt"] {
+        let body = rule_body(rule);
+        for referenced in ["simple_action", "printside_spec"] {
+            assert!(
+                body.contains(referenced),
+                "{} no longer goes through {}, so the two spellings of an \
+                 action can drift apart again",
+                rule,
+                referenced
+            );
+        }
+    }
+
+    let mut named = literals(&rule_body("simple_action"));
+    named.extend(literals(&rule_body("printside_spec")));
+    compare("ACTIONS", named, as_set(dealer_parser::vocabulary::ACTIONS));
 }
 
 #[test]

--- a/dealer-pbn/src/formatters.rs
+++ b/dealer-pbn/src/formatters.rs
@@ -84,11 +84,32 @@ pub fn format_printall(deal: &Deal, board_number: usize) -> String {
 /// Q J 6               9 8 7 4 3 2
 /// ```
 pub fn format_printew(deal: &Deal) -> String {
+    format_pair(deal, [Position::West, Position::East])
+}
+
+/// North and South only, laid out exactly as `format_printew` lays out E/W.
+///
+/// South goes on the left, as West does — DealerV2_4's `printside` says
+/// "with S/W on the left", and it is the same reasoning either way: the two
+/// hands read as one auction, and the hand that speaks first sits left.
+///
+/// Example output:
+/// ```text
+/// K T 6               9 8
+/// A Q T 5             9 6 4 2
+/// A 6 4               7
+/// Q J 6               9 8 7 4 3 2
+/// ```
+pub fn format_printns(deal: &Deal) -> String {
+    format_pair(deal, [Position::South, Position::North])
+}
+
+/// The layout both of those use: four suit rows, two hands to a row.
+fn format_pair(deal: &Deal, positions: [Position; 2]) -> String {
     let mut result = String::new();
 
     // Print each suit row (spades, hearts, diamonds, clubs)
     let suits = [Suit::Spades, Suit::Hearts, Suit::Diamonds, Suit::Clubs];
-    let positions = [Position::West, Position::East];
 
     for &suit in &suits {
         let mut cards_count = 10;

--- a/dealer-pbn/src/lib.rs
+++ b/dealer-pbn/src/lib.rs
@@ -4,7 +4,7 @@ mod oneline;
 
 pub use deal::{format_deal_tag, parse_deal_tag, ParseError, PbnDeal};
 pub use formatters::{
-    format_hand_pbn, format_printall, format_printcompact, format_printew, format_printpbn,
-    PbnBoard, PrintFormat, Vulnerability,
+    format_hand_pbn, format_printall, format_printcompact, format_printew, format_printns,
+    format_printpbn, PbnBoard, PrintFormat, Vulnerability,
 };
 pub use oneline::{format_oneline, parse_oneline};

--- a/dealer-run/Cargo.toml
+++ b/dealer-run/Cargo.toml
@@ -8,6 +8,7 @@ license = "Unlicense"
 dealer-core = { path = "../dealer-core" }
 dealer-parser = { path = "../dealer-parser" }
 dealer-eval = { path = "../dealer-eval" }
+dealer-dds = { path = "../dealer-dds" }
 dealer-level = { path = "../dealer-level" }
 dealer-pbn = { path = "../dealer-pbn" }
 

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -117,6 +117,13 @@ pub struct RunOptions {
     /// preprocesses twice — the scenario, then its levelled copy — and a script
     /// half-substituted the second time would not parse.
     pub params: dealer_parser::ScriptParams,
+    /// Which side is vulnerable, for the words that ask — `par()` today.
+    ///
+    /// The run's own setting, not the rotation `printpbn` applies when a script
+    /// names none: a value that changed with a board's position would make
+    /// `par()` answer differently for the same cards, which is not what a
+    /// script asking about par means.
+    pub vulnerability: dealer_core::Vulnerability,
 }
 
 /// What levelling a scenario needs to know.
@@ -349,6 +356,7 @@ pub struct Produced<'a> {
     variables: &'a dealer_eval::Variables<'a>,
     point_counts: Option<&'a dealer_eval::PointCounts>,
     reports: &'a Reports,
+    vulnerability: dealer_core::Vulnerability,
 }
 
 /// What a script asked to be written out per produced deal.
@@ -379,6 +387,7 @@ impl Produced<'_> {
     /// one draws against a `rnd()` in another.
     pub fn context(&self) -> dealer_eval::EvalContext<'_> {
         dealer_eval::EvalContext::with_counts(self.deal, self.variables, self.point_counts)
+            .with_vulnerability(self.vulnerability)
     }
 
     /// What the script's `printes` statements say for this deal.
@@ -700,6 +709,8 @@ struct PassOptions<'a> {
     replay: &'a [Handle],
     /// How far into the stream `replay` accounts for.
     resume: usize,
+    /// Which side is vulnerable, handed to every expression the pass evaluates.
+    vulnerability: dealer_core::Vulnerability,
     /// Whether produced deals go to the host. A characterizing pass's deals
     /// exist to be counted and thrown away.
     emit: bool,
@@ -837,6 +848,7 @@ fn run_pass(
                     variables: &variables,
                     point_counts,
                     reports: &reports,
+                    vulnerability: opts.vulnerability,
                 })
                 .map_err(RunError::Failed)?;
             }
@@ -947,6 +959,7 @@ pub fn run(script: &str, opts: RunOptions, host: &mut dyn RunHost) -> Result<Run
             &mut source,
             host,
             PassOptions {
+                vulnerability: opts.vulnerability,
                 phase: Phase::Dealing,
                 params: &opts.params,
                 threads,
@@ -983,6 +996,7 @@ pub fn run(script: &str, opts: RunOptions, host: &mut dyn RunHost) -> Result<Run
         &mut source,
         host,
         PassOptions {
+            vulnerability: opts.vulnerability,
             phase: Phase::Characterizing,
             params: &opts.params,
             threads,
@@ -1029,6 +1043,7 @@ pub fn run(script: &str, opts: RunOptions, host: &mut dyn RunHost) -> Result<Run
             &mut source,
             host,
             PassOptions {
+                vulnerability: opts.vulnerability,
                 phase: Phase::AdditionalDealing,
                 params: &opts.params,
                 threads,
@@ -1149,6 +1164,7 @@ condition 1
         RunOptions {
             seed: 20260829,
             produce,
+            vulnerability: dealer_core::Vulnerability::None,
             round_robin: false,
             max_generate: 5_000_000,
             deals: Deals::Shuffled {

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -467,6 +467,20 @@ fn report_row(
                     format_hand_pbn(deal.hand(b))
                 ));
             }
+            // Five columns a seat, in strain order C, D, H, S, NT. Pushed as
+            // one part holding its own commas, so it lands in the row as
+            // separate columns without the join needing to know.
+            CsvTerm::Trix(seats) => {
+                for seat in seats {
+                    let columns: Vec<String> = dealer_dds::Denomination::ALL
+                        .iter()
+                        .map(|denomination| {
+                            dealer_dds::tricks(deal, *denomination, *seat).to_string()
+                        })
+                        .collect();
+                    parts.push(columns.join(","));
+                }
+            }
             CsvTerm::Deal => parts.push(format!(
                 "{} {} {} {}",
                 format_hand_pbn(deal.hand(Position::North)),

--- a/dealer-run/tests/threads.rs
+++ b/dealer-run/tests/threads.rs
@@ -29,6 +29,7 @@ fn deal(threads: usize, count: usize) -> (f64, usize) {
     let report = dealer_run::run(
         JACOBY,
         RunOptions {
+            vulnerability: dealer_core::Vulnerability::None,
             seed: 1,
             produce: usize::MAX,
             max_generate: count,

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -366,6 +366,17 @@ enum VulnerabilityArg {
     All,
 }
 
+impl From<VulnerabilityArg> for dealer_core::Vulnerability {
+    fn from(arg: VulnerabilityArg) -> Self {
+        match arg {
+            VulnerabilityArg::None => dealer_core::Vulnerability::None,
+            VulnerabilityArg::NS => dealer_core::Vulnerability::NorthSouth,
+            VulnerabilityArg::EW => dealer_core::Vulnerability::EastWest,
+            VulnerabilityArg::All => dealer_core::Vulnerability::Both,
+        }
+    }
+}
+
 impl std::str::FromStr for VulnerabilityArg {
     type Err = String;
 
@@ -1695,6 +1706,11 @@ fn main() {
             &untrimmed,
             RunOptions {
                 seed,
+                // What `par()` is told. A script that names no vulnerability
+                // gets none, rather than the rotation `printpbn` applies: par
+                // is a property of the cards and the vulnerability the run was
+                // given, not of where a board sits in a set.
+                vulnerability: vulnerability.map(Into::into).unwrap_or_default(),
                 // Nothing to deal from the levelling when only the file was
                 // asked for: `--write-leveled` on its own works the keeps out
                 // and stops there.

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -17,8 +17,8 @@ use dealer_level::{
 };
 use dealer_parser::{ActionType, CsvTerm, Statement, VulnerabilityType};
 use dealer_pbn::{
-    format_oneline, format_printall, format_printcompact, format_printew, format_printpbn,
-    PbnBoard, Vulnerability,
+    format_oneline, format_printall, format_printcompact, format_printew, format_printns,
+    format_printpbn, PbnBoard, Vulnerability,
 };
 use dealer_run::{Phase, Produced, RunHost, RunOptions};
 use std::fs::OpenOptions;
@@ -297,6 +297,7 @@ struct Args {
 enum OutputFormat {
     PrintAll,
     PrintEW,
+    PrintNS,
     PrintPBN,
     PrintCompact,
     PrintOneLine,
@@ -309,11 +310,12 @@ impl std::str::FromStr for OutputFormat {
         match s.to_lowercase().as_str() {
             "printall" | "all" => Ok(OutputFormat::PrintAll),
             "printew" | "ew" => Ok(OutputFormat::PrintEW),
+            "printns" | "ns" => Ok(OutputFormat::PrintNS),
             "printpbn" | "pbn" => Ok(OutputFormat::PrintPBN),
             "printcompact" | "compact" => Ok(OutputFormat::PrintCompact),
             "printoneline" | "oneline" => Ok(OutputFormat::PrintOneLine),
             _ => Err(format!(
-                "Invalid format '{}'. Valid options: printall, printew, printpbn, printcompact, printoneline",
+                "Invalid format '{}'. Valid options: printall, printew, printns, printpbn, printcompact, printoneline",
                 s
             )),
         }
@@ -495,6 +497,7 @@ fn render_board(
     match format {
         OutputFormat::PrintAll => format_printall(deal, board_number),
         OutputFormat::PrintEW => format_printew(deal),
+        OutputFormat::PrintNS => format_printns(deal),
         OutputFormat::PrintPBN => format_printpbn(
             deal,
             &PbnBoard {
@@ -1180,6 +1183,7 @@ fn main() {
                         format_from_input = Some(match action_type {
                             ActionType::PrintAll => OutputFormat::PrintAll,
                             ActionType::PrintEW => OutputFormat::PrintEW,
+                            ActionType::PrintNS => OutputFormat::PrintNS,
                             ActionType::PrintPBN => OutputFormat::PrintPBN,
                             ActionType::PrintCompact => OutputFormat::PrintCompact,
                             ActionType::PrintOneLine => OutputFormat::PrintOneLine,

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -112,22 +112,6 @@ pub const REMAINING: &[WorkItem] = &[
     // DealerV2_4's own words, from reading its lexer and yacc rather than a
     // summary of them, and measured against its 61-script Regression suite.
     WorkItem {
-        what: "`printns` and `printside(side)`",
-        done_when: None,
-        issue: None,
-        effort: Effort::Low,
-        value: Value::Low,
-        note: Some("dealer3 has `printew`; DealerV2_4 routes all three through one action."),
-    },
-    WorkItem {
-        what: "`trix(compass)` and `trix(deal)`",
-        done_when: None,
-        issue: None,
-        effort: Effort::Low,
-        value: Value::Low,
-        note: Some("Tricks in all five strains as CSV columns. The solving is already done."),
-    },
-    WorkItem {
         what: "`par(side)`: the par contract",
         done_when: None,
         issue: None,

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -112,18 +112,6 @@ pub const REMAINING: &[WorkItem] = &[
     // DealerV2_4's own words, from reading its lexer and yacc rather than a
     // summary of them, and measured against its 61-script Regression suite.
     WorkItem {
-        what: "`par(side)`: the par contract",
-        done_when: None,
-        issue: None,
-        effort: Effort::Low,
-        value: Value::Low,
-        note: Some(
-            "Needs all 20 double-dummy results, which bridge-solver already provides for \
-             `tricks()`, `score()` and `imps()`. DealerV2_4 sets its vulnerability with \
-             `-P`, which has a row of its own in the switch table.",
-        ),
-    },
-    WorkItem {
         what: "`ltc(compass)`, `ltc(compass, suit)`: the modern losing trick count",
         done_when: None,
         issue: None,

--- a/dealer/tests/print_report.rs
+++ b/dealer/tests/print_report.rs
@@ -168,3 +168,65 @@ fn trix_of_the_deal_is_four_seats_of_five() {
         assert!(tricks <= 13, "{tricks} is not a possible trick count");
     }
 }
+
+/// `par(side)` is the deal's par score, from that side's point of view. The
+/// two sides are opposites, and a compass names the side its seat is on.
+#[test]
+fn par_is_signed_to_the_side_that_asks() {
+    let out = run(
+        "condition hcp(north) >= 15\nprintrpt(par(ns), par(ew), par(north), par(south), par(east))\n",
+        &["-q", "-p", "3", "-s", "1"],
+    );
+    for row in out.lines().filter(|line| !line.trim().is_empty()) {
+        let values: Vec<i32> = row
+            .trim()
+            .split(',')
+            .map(|v| v.trim().parse().expect("par is a score"))
+            .collect();
+        assert_eq!(values.len(), 5);
+        assert_eq!(values[0], -values[1], "par(ew) is -par(ns)");
+        assert_eq!(values[0], values[2], "north is on the NS side");
+        assert_eq!(values[0], values[3], "so is south");
+        assert_eq!(values[1], values[4], "east is on the EW side");
+    }
+}
+
+/// Par depends on who is vulnerable, so the run's own vulnerability has to
+/// reach it — that is the whole reason `EvalContext` carries one.
+#[test]
+fn par_follows_the_runs_vulnerability() {
+    let script = "condition hcp(north) >= 15\nprintrpt(par(ns))\n";
+    let none = run(
+        script,
+        &["-q", "-p", "5", "-s", "1", "--vulnerable", "None"],
+    );
+    let ns = run(script, &["-q", "-p", "5", "-s", "1", "--vulnerable", "NS"]);
+    let all = run(script, &["-q", "-p", "5", "-s", "1", "--vulnerable", "All"]);
+    let ew = run(script, &["-q", "-p", "5", "-s", "1", "--vulnerable", "EW"]);
+
+    // The same deals throughout — only the scoring changes.
+    assert_ne!(none, ns, "NS vulnerable has to change NS's par");
+    assert_eq!(ns, all, "NS is vulnerable in both");
+    assert_eq!(none, ew, "NS is not vulnerable in either");
+
+    // A script's own `vulnerable` statement reaches it the same way.
+    let by_statement = run(
+        "vulnerable All\ncondition hcp(north) >= 15\nprintrpt(par(ns))\n",
+        &["-q", "-p", "5", "-s", "1"],
+    );
+    assert_eq!(by_statement, all, "the statement and the switch agree");
+}
+
+/// A script that names no vulnerability gets none — deliberately not the
+/// rotation `printpbn` applies, which would make par answer differently for
+/// the same cards depending on where the board sat.
+#[test]
+fn par_without_a_vulnerability_assumes_neither_side() {
+    let script = "condition hcp(north) >= 15\nprintrpt(par(ns))\n";
+    let unset = run(script, &["-q", "-p", "5", "-s", "1"]);
+    let none = run(
+        script,
+        &["-q", "-p", "5", "-s", "1", "--vulnerable", "None"],
+    );
+    assert_eq!(unset, none);
+}

--- a/dealer/tests/print_report.rs
+++ b/dealer/tests/print_report.rs
@@ -108,3 +108,63 @@ fn it_renders_what_csvrpt_renders() {
     assert_eq!(rows(&printed), rows(&written), "the two must agree");
     assert_eq!(rows(&printed).len(), 2);
 }
+
+/// `printns` is `printew`'s counterpart, and `printside(side)` is another
+/// spelling of each. All three come from DealerV2_4, which routes them through
+/// one printer.
+#[test]
+fn printns_and_printside_are_two_spellings_of_one_action() {
+    // No `-q`: quiet mode suppresses the deals these actions print.
+    let args = ["-p", "3", "-s", "1"];
+    let script = "condition hcp(north) >= 15\n";
+    let ns = run(&format!("{script}action printns\n"), &args);
+    let side_ns = run(&format!("{script}action printside(ns)\n"), &args);
+    let ew = run(&format!("{script}action printew\n"), &args);
+    let side_ew = run(&format!("{script}action printside(ew)\n"), &args);
+
+    assert_eq!(ns, side_ns, "printns and printside(ns) are one action");
+    assert_eq!(ew, side_ew, "printew and printside(ew) are one action");
+    assert_ne!(ns, ew, "the two partnerships are different hands");
+    assert!(!ns.trim().is_empty(), "printns should print something");
+}
+
+/// The layout is `printew`'s, so the two are comparable at a glance: four suit
+/// rows, two hands to a row.
+#[test]
+fn printns_lays_out_four_suit_rows() {
+    let out = run(
+        "condition hcp(north) >= 15\naction printns\n",
+        &["-p", "1", "-s", "1"],
+    );
+    let rows: Vec<&str> = out.lines().filter(|line| !line.trim().is_empty()).collect();
+    assert_eq!(rows.len(), 4, "one row a suit, got: {out:?}");
+}
+
+/// `trix(compass)` is five columns, and the numbers are the ones `tricks()`
+/// gives — the same solve, reported differently.
+#[test]
+fn trix_reports_the_same_tricks_the_function_does() {
+    let out = run(
+        "condition hcp(north) >= 15\nprintrpt(trix(north), tricks(north, 0), tricks(north, 4))\n",
+        &["-q", "-p", "1", "-s", "1"],
+    );
+    let columns: Vec<&str> = out.trim().split(',').map(|c| c.trim()).collect();
+    assert_eq!(columns.len(), 7, "five strains plus two checks: {out:?}");
+    // trix runs clubs, diamonds, hearts, spades, notrump.
+    assert_eq!(columns[0], columns[5], "trix's first column is clubs");
+    assert_eq!(columns[4], columns[6], "trix's last column is notrump");
+}
+
+#[test]
+fn trix_of_the_deal_is_four_seats_of_five() {
+    let out = run(
+        "condition hcp(north) >= 15\nprintrpt(trix(deal))\n",
+        &["-q", "-p", "1", "-s", "1"],
+    );
+    let columns: Vec<&str> = out.trim().split(',').collect();
+    assert_eq!(columns.len(), 20, "four seats, five strains: {out:?}");
+    for column in &columns {
+        let tricks: u8 = column.trim().parse().expect("each column is a trick count");
+        assert!(tricks <= 13, "{tricks} is not a possible trick count");
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`printns` and `printside(side)`.** DealerV2_4 routes `printew`, `printns`
+  and `printside` through one printer; dealer3 had only `printew`. `printns`
+  and `printside(ns)` are the same action, as are `printew` and
+  `printside(ew)`. South sits on the left as West does, for DealerV2_4's own
+  reason: the pair reads as one auction and the hand that speaks first goes
+  left.
+- **`trix(compass)` and `trix(deal)` in `csvrpt` and `printrpt`.** Five columns
+  for a seat — clubs, diamonds, hearts, spades, notrump — or twenty for the
+  deal, in the seat order `deal` already uses. A report term rather than a
+  function, because it is more than one number.
+  - The solving is the work `tricks()` already does and is remembered the same
+    way, so a script naming both pays for one search per (deal, denomination,
+    seat), not two. `dealer_dds::table` fills all twenty cells through that
+    same memo.
 - **`score()` now takes dealer.exe's own spellings.** The contract is a word —
   `x3N`, `x4H`, `x7Sxx` — and the vulnerability is `nv` or `vul`, exactly as
   `scan.l:47-48` and `scan.l:101` define them. `z` may replace the leading `x`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`par(side)`: the par score, what the deal is worth with both sides bidding
+  and defending perfectly.** `ns` or `ew`, or a compass for the side that seat
+  is on, as DealerV2_4's `dds_parscore` accepts. `par(ew)` is `-par(ns)`, and a
+  passed-out deal is zero.
+  - Worked out from all twenty double-dummy results through the same memo
+    `tricks()` uses, so `par()` beside a `tricks()` condition is close to free.
+  - **Vulnerability now reaches the evaluator.** `EvalContext` carries a
+    `dealer_core::Vulnerability`, set from `--vulnerable` or the `vulnerable`
+    statement by both front ends, so `par(ns)` means what a reader expects. It
+    is deliberately not `printpbn`'s rotation for an unnamed vulnerability: par
+    is a property of the cards and the vulnerability the run was given, not of
+    where a board sits in a set. A script that names none gets neither side
+    vulnerable. DealerV2_4 instead has a `-P` switch of its own for this.
+  - The value is carried whole rather than as the two flags `par()` needs, so a
+    script asking *what* the vulnerability is can be answered from the same
+    place later.
 - **`printns` and `printside(side)`.** DealerV2_4 routes `printew`, `printns`
   and `printside` through one printer; dealer3 had only `printew`. `printns`
   and `printside(ns)` are the same action, as are `printew` and

--- a/docs/FILTER_LANGUAGE_STATUS.md
+++ b/docs/FILTER_LANGUAGE_STATUS.md
@@ -35,7 +35,7 @@ for the same predealt deal.
 
 <!-- BEGIN GENERATED: functions -->
 
-**25 functions**, under 50 spellings — the extra 25 are alternative names, listed with the function they stand for.
+**26 functions**, under 51 spellings — the extra 25 are alternative names, listed with the function they stand for.
 
 ### Hand evaluation
 
@@ -117,6 +117,8 @@ for the same predealt deal.
 | `score(vulnerable, contract, tricks)` | Declarer's score for a contract played at that vulnerability and making that many tricks. `vulnerable` is the word `nv` or `vul`; `contract` is a word such as `x3N`; `tricks` is 0 to 13. | `score(nv, x3N, 9) == 400` |
 | | A contract is one word: a lowercase `x`, the level, and the strain as an uppercase letter of CDHSN. The `x` is a sigil rather than a meaning — it is what lets the word be told from a number — so doubling is written as a suffix: `x4Hx` is four hearts doubled and `x4Hxx` redoubled. `z` may be used in place of the leading `x`, as in DealerV2_4, and means exactly the same thing. Both the case and the level range are the references' own, so a word that runs here runs on BBO. Either argument may also be written as the number it stands for, which is what a `--param` can supply: 0 or 1 for the vulnerability, and level × 5 + strain for the contract, plus 40 for each level of doubling. Strain numbers match `tricks`: 0 clubs, 1 diamonds, 2 hearts, 3 spades, 4 notrump. So `x3N` is 19, `x4S` is 23, `x4Sx` is 63 and `x4Sxx` is 103. | |
 | `imps(scoredifference)` | Converts a difference between two scores into IMPs, by the standard table. | `imps(score(nv, x4S, 10) - score(nv, x3N, 9)) >= 1` |
+| `par(side)` | The par score to that side: what the deal is worth with both sides bidding and defending perfectly. `side` is `ns` or `ew`, or a compass for the side that seat is on. | `par(ns) >= 400` |
+| | Worked out from all twenty double-dummy results, which cost the same searches `tricks()` does and are remembered per deal — so `par()` beside a `tricks()` condition is close to free. The two sides are opposites: `par(ew)` is `-par(ns)`, and a passed-out deal is zero. Vulnerability is the run's own — `--vulnerable`, or the `vulnerable` statement — and neither side is vulnerable when a script names none. It is deliberately not the rotation `printpbn` applies to an unnamed vulnerability: par is a property of the cards and the vulnerability the run was given, not of where a board sits in a set. DealerV2_4 instead has a `-P` switch of its own for this. | |
 | `rnd(bound)` | A random whole number from zero up to, but not including, the bound. | `rnd(10) == 3` |
 | | Every mention draws again, including through a variable: `r = rnd(4)` used twice is two draws, as in the original. Drawn from a stream of its own, seeded from the deal, so the same seed gives the same answers however many threads are running; the original shares the generator it shuffles with, so calling it there changes the deals. `--rnd-seed` shifts the stream. Beware locally built dealer binaries: `rnd` divides by `RAND_MAX`, which describes `rand()` rather than the generator it actually calls, so a build without `STD_RAND` returns values far outside the bound, or negative ones. BBO's own build is correct. | |
 <!-- END GENERATED: functions -->

--- a/docs/FILTER_LANGUAGE_STATUS.md
+++ b/docs/FILTER_LANGUAGE_STATUS.md
@@ -169,8 +169,8 @@ Tightest binding first. Operators sharing a level are applied left to right.
 | `title "<text>"` | Names the run, filling the `[Event]` tag of PBN output. `-T` wins when both are given. | `title "Weak two openings"` |
 | `seed <number>` | Fixes the random seed, so the run reproduces. `-s` wins when both are given. | `seed 42` |
 | `predeal <compass> <holding>, <holding>, ... [<compass> <holding>, ...]` | Places cards in a hand before shuffling; the rest of the deal is dealt around them. A holding is a suit letter followed by its ranks, using T for the ten. One statement may name several seats: the holdings of a seat are separated by commas and the seats are not. | `predeal north SAKQ,HT98 south SJ32` |
-| `csvrpt(<term>, <term>, ...)` | Writes one comma-separated row per matching deal. A term is an expression, a quoted string, a compass for that hand, `ns` or `ew` for a partnership's two hands, or the word `deal` for all four. | `csvrpt(deal, hcp(north), "north")` |
-| `printrpt(<term>, <term>, ...)` | Writes one comma-separated row per matching deal to the screen. The terms are `csvrpt`'s: an expression, a quoted string, a compass for that hand, `ns` or `ew` for a partnership's two hands, or the word `deal` for all four. | `printrpt("deal ", deal, hcp(south))` |
+| `csvrpt(<term>, <term>, ...)` | Writes one comma-separated row per matching deal. A term is an expression, a quoted string, a compass for that hand, `ns` or `ew` for a partnership's two hands, the word `deal` for all four, or `trix(...)` for double-dummy tricks. | `csvrpt(deal, hcp(north), "north")` |
+| `printrpt(<term>, <term>, ...)` | Writes one comma-separated row per matching deal to the screen. The terms are `csvrpt`'s: an expression, a quoted string, a compass for that hand, `ns` or `ew` for a partnership's two hands, the word `deal` for all four, or `trix(...)`. | `printrpt("deal ", deal, hcp(south))` |
 | `<name> = <expression>` | Names an expression so a long condition can be written in pieces. The name stands for the expression and is worked out afresh for every deal. | `fit = spades(north) + spades(south)` |
 | `<expression>` | An expression on its own is the condition, so the `condition` keyword can be left off. | `hcp(north) >= 20` |
 
@@ -180,6 +180,8 @@ Tightest binding first. Operators sharing a level are applied left to right.
 |---|---|
 | `printall` | All four hands, laid out around the compass. This is what happens with no action given. |
 | `printew` | East and West only, West on the left. |
+| `printns` | North and South only, South on the left. |
+| `printside` | One partnership's two hands: `printside(ns)` or `printside(ew)`. |
 | `printpbn` | PBN, the record format other bridge programs read. |
 | `printcompact` | Four lines per deal. |
 | `printoneline` | One line per deal. |

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -266,8 +266,6 @@ Priority is derived from effort and value rather than written down beside them.
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
 | 🔵 Unlikely | `par(side)`: the par contract | Low | Low |  | Needs all 20 double-dummy results, which bridge-solver already provides for `tricks()`, `score()` and `imps()`. DealerV2_4 sets its vulnerability with `-P`, which has a row of its own in the switch table. |
-| 🔵 Unlikely | `printns` and `printside(side)` | Low | Low |  | dealer3 has `printew`; DealerV2_4 routes all three through one action. |
-| 🔵 Unlikely | `trix(compass)` and `trix(deal)` | Low | Low |  | Tricks in all five strains as CSV columns. The solving is already done. |
 | 🔵 Unlikely | Decimal literals, `6.25` and `.5` | Medium | Low |  | DealerV2_4 reads them as hundredths, which is what lets `altcount` weight a card at 0.75 and `ltc` count in halves. dealer3's numbers are integers. |
 | 🔵 Unlikely | Double-dummy solver mode | Medium | Low |  | DealerV2_4's `-M`, which prints a double-dummy table per deal. The solver behind it is in place; this is the switch and its output format. |
 | 🔵 Unlikely | Export in DL52 format | Medium | Low |  | DealerV2_4 spells it `-l`, which is dealer.exe's library switch — so as with the script parameters, the spelling here would have to differ. |

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -265,7 +265,6 @@ Priority is derived from effort and value rather than written down beside them.
 
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
-| 🔵 Unlikely | `par(side)`: the par contract | Low | Low |  | Needs all 20 double-dummy results, which bridge-solver already provides for `tricks()`, `score()` and `imps()`. DealerV2_4 sets its vulnerability with `-P`, which has a row of its own in the switch table. |
 | 🔵 Unlikely | Decimal literals, `6.25` and `.5` | Medium | Low |  | DealerV2_4 reads them as hundredths, which is what lets `altcount` weight a card at 0.75 and `ltc` count in halves. dealer3's numbers are integers. |
 | 🔵 Unlikely | Double-dummy solver mode | Medium | Low |  | DealerV2_4's `-M`, which prints a double-dummy table per deal. The solver behind it is in place; this is the switch and its output format. |
 | 🔵 Unlikely | Export in DL52 format | Medium | Low |  | DealerV2_4 spells it `-l`, which is dealer.exe's library switch — so as with the script parameters, the spelling here would have to differ. |

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -498,6 +498,14 @@ pub fn generate(
             seed,
             produce,
             max_generate,
+            // What `par()` is told: the `vulnerable` statement if the script
+            // has one, and neither side otherwise. Same rule as the terminal.
+            vulnerability: match output.vulnerability {
+                Some(Vulnerability::NS) => dealer_core::Vulnerability::NorthSouth,
+                Some(Vulnerability::EW) => dealer_core::Vulnerability::EastWest,
+                Some(Vulnerability::All) => dealer_core::Vulnerability::Both,
+                Some(Vulnerability::None) | None => dealer_core::Vulnerability::None,
+            },
             deals: Deals::Shuffled {
                 predeal,
                 swap: dealer_core::SwapMode::None,


### PR DESCRIPTION
The three items at the top of what is left, all DealerV2_4 words riding on solver work already paid for.

## `par(side)`

```
$ printrpt(par(ns), par(ew))
 -100,100
 140,-140
```

`ns` or `ew`, or a compass for the side that seat is on — which is what DealerV2_4's `dds_parscore` accepts. `par(ew)` is `-par(ns)`, a passed-out deal is zero.

The scoring is bridge-solver's own `par()`, which was already there; it is fed by all twenty double-dummy results through the same memo `tricks()` uses, so `par()` beside a `tricks()` condition costs almost nothing extra.

### Vulnerability now reaches the evaluator

Par depends on who is vulnerable, and nothing below the front ends knew. `EvalContext` carries a `dealer_core::Vulnerability`, set from `--vulnerable` or the `vulnerable` statement by the terminal and the browser alike:

```
$ dealer --vulnerable None ...   →  -100
$ dealer --vulnerable NS   ...   →  -110
```

Two decisions worth flagging:

- **Carried as the whole value, not the two flags par needs.** A script asking *what* the vulnerability is wants to name it. That word isn't here yet, but this is where it will read from.
- **Not `printpbn`'s rotation** for an unnamed vulnerability. Par is a property of the cards and the vulnerability the run was given, not of where a board sits in a set — a rotating value would make `par()` answer differently for the same cards. A script naming none gets neither side vulnerable. DealerV2_4 keeps a `-P` switch of its own for this.

## `printns` and `printside(side)`

```
$ dealer -p 1 -s 1 <<< 'condition hcp(north) >= 15
action printns'
Q 9 5               J 7
J 3                 A T 9 7 5
9 6                 A K Q 2
J 9 8 7 6 4         A 3
```

DealerV2_4 routes `printew`, `printns` and `printside` through one printer; dealer3 had only `printew`. `printns` and `printside(ns)` are one action, as are `printew` and `printside(ew)` — asserted by test, not just by construction. South sits left as West does, for DealerV2_4's stated reason: the pair reads as one auction, so the hand that speaks first goes left.

## `trix(compass)` and `trix(deal)`

```
$ printrpt(trix(north), tricks(north, 0), tricks(north, 4))
 8,5,7,4,6,8,6
```

Five columns for a seat (C, D, H, S, NT), twenty for the deal in the seat order `deal` already uses. A report term rather than a function, because it is more than one number. The cross-check above is a test: `trix`'s first and last columns are `tricks(north,0)` and `tricks(north,4)`, so it is the same solve reported differently, through the same memo.

## Structural bits

- `action_type` and `print_stmt` now defer to one `simple_action` rule, so the two lists cannot drift. The test that existed to catch that drift checks the deferral instead of comparing two lists.
- `ActionDoc` gained a `form`, because `printside` is the one action whose name is not a whole action.
- `par` sits in `function_name` as well as its own rule, so `par(a, b)` reaches the arity error from #36 rather than becoming a syntax error — the arrangement #38 settled on for `score`.
- `dealer_dds::table` and `par_score_ns` fill all twenty cells through the existing memo.

509 tests pass (7 new); `cargo fmt` and `clippy -D warnings` clean; the wasm front end builds and is wired for vulnerability too. Three roadmap rows deleted, leaving 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)