### PR TITLE
Solve the double-dummy table denomination-outermost

### DIFF
--- a/dealer-dds/src/memo.rs
+++ b/dealer-dds/src/memo.rs
@@ -143,9 +143,14 @@ pub fn tricks(deal: &Deal, denomination: Denomination, declarer: Position) -> u8
 /// S, NT, which is dealer's own strain numbering too.
 pub fn table(deal: &Deal) -> bridge_solver::DdTricks {
     let mut tricks = [[0u8; 5]; 4];
-    for (seat, row) in Position::ALL.iter().zip(tricks.iter_mut()) {
-        for (denomination, cell) in Denomination::ALL.iter().zip(row.iter_mut()) {
-            *cell = self::tricks(deal, *denomination, *seat);
+    // Denomination outermost, so the four declarers share one pair of solver
+    // caches — `DealAnalysis` keeps them per denomination and throws them away
+    // when the denomination changes. Seat-outermost asks for a different
+    // denomination on every call and so rebuilds the caches twenty times
+    // instead of five, which costs about a third of the run.
+    for denomination in Denomination::ALL {
+        for (seat, row) in Position::ALL.iter().zip(tricks.iter_mut()) {
+            row[denomination as usize] = self::tricks(deal, denomination, *seat);
         }
     }
     bridge_solver::DdTricks { tricks }

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -480,6 +480,14 @@ fn report_row(
             // one part holding its own commas, so it lands in the row as
             // separate columns without the join needing to know.
             CsvTerm::Trix(seats) => {
+                // Solved denomination-outermost, for the cache sharing
+                // described on `dealer_dds::table`, then read back per seat in
+                // the order the report wants.
+                for denomination in dealer_dds::Denomination::ALL {
+                    for seat in seats {
+                        dealer_dds::tricks(deal, denomination, *seat);
+                    }
+                }
                 for seat in seats {
                     let columns: Vec<String> = dealer_dds::Denomination::ALL
                         .iter()

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -223,17 +223,6 @@ pub const REMAINING: &[WorkItem] = &[
         ),
     },
     WorkItem {
-        what: "Double-dummy solver mode",
-        done_when: Some(DoneWhen::Switch("-M")),
-        issue: None,
-        effort: Effort::Medium,
-        value: Value::Low,
-        note: Some(
-            "DealerV2_4's `-M`, which prints a double-dummy table per deal. The solver \
-             behind it is in place; this is the switch and its output format.",
-        ),
-    },
-    WorkItem {
         what: "Exhaust mode",
         done_when: Some(DoneWhen::Switch("-e")),
         issue: None,

--- a/dealer/src/switches.rs
+++ b/dealer/src/switches.rs
@@ -574,10 +574,10 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
         short: "-M",
         long: "",
         group: "Not implemented",
-        what: "Double-dummy solver mode",
+        what: "Double-dummy solver mode — nothing to implement",
         dealer_exe: Origin::Absent,
         dealer_v2: Origin::Same,
-        note: Some("dealer3 has `tricks()` but no mode switch."),
+        note: Some("It prints nothing. DealerV2_4's own docs describe it as \"1 Single result mode; 2 all 20 strain-compass combinations\" (`docs/Handstat_layout.txt`), so it chooses how the DDS library is called, not what comes out — and DealerV2_4 switches to mode 2 by itself whenever `par` or `trix` needs it. dealer3 has no such choice to offer: results are remembered per (deal, denomination, declarer) and shared across threads, so asking once costs one search, asking twenty costs twenty, and asking again costs nothing."),
     },
     SwitchRow {
         short: "-Z",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -146,6 +146,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   divide by, so its bar means something.
 
 ### Fixed
+- **`trix(deal)` and `par()` were about twice as slow as they needed to be.**
+  `dealer_dds::table` filled the twenty cells seat-outermost, asking for a
+  different denomination on every call. `DealAnalysis` keeps the solver's
+  caches per denomination and drops them when the denomination changes, so the
+  caches were rebuilt twenty times instead of five. Filled denomination-
+  outermost now, as `DealAnalysis::table` already did.
+  - Forty deals through `trix(deal)`: 11.7s to 6.2s. Same for `par()`, 11.8s to
+    6.2s. Output byte-identical.
+  - `scripts/dd-bench.sh` gained a stage for the whole table, with a budget the
+    wrong order exceeds — verified by putting the wrong order back and watching
+    it fail.
 - **Unary minus did nothing: `-2` evaluated to `2`, and `-2 == 2` was true.**
   A bare `"-"` inside a non-atomic pest rule produces no pair, so the parser
   saw only the operand and dropped the negation; `not_op` is a named rule,

--- a/docs/command_line_comparison.md
+++ b/docs/command_line_comparison.md
@@ -110,7 +110,7 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 
 | Switch | What it does | dealer3 | dealer.exe | DealerV2_4 | Notes |
 |---|---|---|---|---|---|
-| `-M` | Double-dummy solver mode | ❌ | — | ✅ | dealer3 has `tricks()` but no mode switch. |
+| `-M` | Double-dummy solver mode — nothing to implement | ❌ | — | ✅ | It prints nothing. DealerV2_4's own docs describe it as "1 Single result mode; 2 all 20 strain-compass combinations" (`docs/Handstat_layout.txt`), so it chooses how the DDS library is called, not what comes out — and DealerV2_4 switches to mode 2 by itself whenever `par` or `trix` needs it. dealer3 has no such choice to offer: results are remembered per (deal, denomination, declarer) and shared across threads, so asking once costs one search, asking twenty costs twenty, and asking again costs nothing. |
 | `-Z` | Export in RP zrd format | ❌ | — | ✅ |  |
 | `-U` | DealerServer path | ❌ | — | ✅ |  |
 | `-O` | OPC evaluation for the opener | ❌ | — | ✅ |  |

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -265,7 +265,6 @@ Priority is derived from effort and value rather than written down beside them.
 
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
-| 🔵 Unlikely | Double-dummy solver mode | Medium | Low |  | DealerV2_4's `-M`, which prints a double-dummy table per deal. The solver behind it is in place; this is the switch and its output format. |
 | 🔵 Unlikely | Export in DL52 format | Medium | Low |  | DealerV2_4 spells it `-l`, which is dealer.exe's library switch — so as with the script parameters, the spelling here would have to differ. |
 | 🔵 Unlikely | Export in RP zrd format | Medium | Low |  |  |
 | 🔵 Unlikely | The length-bias form of `predeal`, `spades(north) == 5` | Medium | Low |  | The original's, not DealerV2_4's: `predealarg : SUIT '(' COMPASS ')' CMPEQ NUMBER` in `defs.y` calls `bias_deal`, which biases the shuffle rather than fixing cards. Rejected loudly today; the same thing can be written in the condition, at the cost of dealing and discarding instead of dealing to fit. |

--- a/scripts/dd-bench.sh
+++ b/scripts/dd-bench.sh
@@ -51,6 +51,16 @@ EOF
 cat "$WORK/base.dlr" > "$WORK/none.dlr"
 echo 'action average "North HCP" hcp(north)' >> "$WORK/none.dlr"
 
+# Stage 4: the whole 20-entry table, through `trix(deal)`. This is the stage
+# that catches a table solved in the wrong order. `DealAnalysis` keeps the
+# solver's caches per denomination and drops them when the denomination
+# changes, so a table filled seat-outermost rebuilds them twenty times instead
+# of five and takes about twice as long -- which is exactly what the first cut
+# of `dealer_dds::table` did. The budget is set just above the correct order,
+# so the wrong one fails rather than merely being slower.
+cat "$WORK/base.dlr" > "$WORK/table.dlr"
+echo 'printrpt(trix(deal))' >> "$WORK/table.dlr"
+
 fail=0
 
 run_stage() {
@@ -80,5 +90,6 @@ run_stage "no-dd baseline"       "$WORK/none.dlr"   1000  10
 run_stage "1 solve  x 1  deal"   "$WORK/one.dlr"       1  10
 run_stage "1 solve  x 100 deals" "$WORK/one.dlr"     100  30
 run_stage "2 solves x 1000 deals (the real workload)" "$WORK/two.dlr" 1000 300
+run_stage "20 solves x 40 deals (the whole table)"    "$WORK/table.dlr"  40  10
 
 exit "$fail"


### PR DESCRIPTION
Started as a question — why is "double-dummy solver mode" rated Medium? — and turned up a performance bug I shipped in #41.

## `-M` is not what the roadmap said

The row claimed `-M` "prints a double-dummy table per deal". It prints nothing. DealerV2_4's own `docs/Handstat_layout.txt`:

```
int dds_mode ;   // -M  1 Single result mode; 2 all 20 strain-compass combinations; used for par etc.
```

It selects how the DDS library is *called*, not what comes out — and DealerV2_4 switches to mode 2 by itself whenever `par` or `csv_trix` needs it ("Using Parscore requires TableMode. Setting Mode and continuing.."). Nothing in the source prints a DD table at all.

dealer3 has no such choice to offer. Results are remembered per (deal, denomination, declarer) and shared across threads, so asking once costs one search, asking twenty costs twenty, and asking again costs nothing. There is no mode to pick. Roadmap row deleted; the switch table now says what the switch actually is.

## But the question found a real bug

Measuring to answer it showed twenty solves costing 20.6× one — no cache sharing at all. The cause is in the code #41 added:

```rust
for seat in Position::ALL {          // ← outermost
    for denomination in Denomination::ALL {
        tricks(deal, denomination, seat)
    }
}
```

`DealAnalysis` keeps the solver's cutoff and pattern caches **per denomination** and drops them when the denomination changes. Asking seat-outermost changes denomination on every single call, so the caches were rebuilt twenty times instead of five. `DealAnalysis::table` already loops the right way round and says so in a comment — the memo layer just didn't follow it.

| 40 deals | before | after |
|---|---|---|
| `trix(deal)` | 11.7s | **6.2s** |
| `par(ns)` | 11.8s | **6.2s** |

Output byte-identical, verified by diff.

## Guard

`scripts/dd-bench.sh` — which CLAUDE.md already names as the guard for DDS speed — gains a stage for the whole table, budgeted just above the correct order so the wrong one fails rather than merely being slower. I checked that it works by putting the wrong order back:

```
FAIL  20 solves x 40 deals (the whole table): exceeded 10s budget at -p 40
ok    20 solves x 40 deals (the whole table): -p 40 in 6s (budget 10s)
```

513 tests pass; `cargo fmt` and `clippy -D warnings` clean. One roadmap row deleted, leaving 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)