### PR TITLE
Pin wasm-pack: 'latest' fails open to a 2020 toolchain

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,10 +58,16 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
 
+      # PINNED, not `latest`. This action resolves `latest` by asking the
+      # GitHub API, and when that call fails it does not fail the step — it
+      # silently falls back to its own default, wasm-pack v0.9.1, whose
+      # wasm-opt is too old to parse what wasm-bindgen emits. The build then
+      # dies with "Only 1 table definition allowed in MVP", which names
+      # nothing relevant. pdf-handouts hit exactly that on 2026-09-01.
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: latest
+          version: 'v0.15.0'
 
       - name: Install dependencies
         working-directory: web


### PR DESCRIPTION
`jetli/wasm-pack-action` resolves `version: latest` by asking the GitHub API.
When that call fails it **does not fail the step** — it silently installs its own
hardcoded default, wasm-pack **v0.9.1**, whose bundled `wasm-opt` is too old to
parse what wasm-bindgen now emits. The build then dies with `Only 1 table
definition allowed in MVP`, which names nothing relevant to the cause.

`pdf-handouts` hit exactly this on 2026-09-01 — two runs eleven minutes apart,
no change to the workflow in between:

| Run | wasm-pack | Result |
| --- | --- | --- |
| first | v0.15.0 | ✅ |
| second | v0.9.1 | ❌ |

Pinned to v0.15.0, which is what `latest` resolves to today — so this makes the
current behaviour deterministic rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)