### PR TITLE
Derive the print footer's URL instead of hard-coding it

### DIFF
--- a/web/src/components/PrintView.vue
+++ b/web/src/components/PrintView.vue
@@ -121,7 +121,22 @@ const props = defineProps({
 /** A run of 500 deals is not a document. Enough to show the shape of the set. */
 const MAX_PRINTED_BOARDS = 12
 
-const siteUrl = 'https://dealer.bridge-classroom.org'
+/**
+ * Where this build is actually being served from, for the footer's way back.
+ *
+ * Derived, not hard-coded. The same build answers on its own pages.dev and is
+ * mounted at bridge-craftwork.com/dealer3/, so any fixed address would be
+ * wrong from one of them — and this one ends up on paper, where a wrong URL
+ * cannot be corrected by redeploying.
+ *
+ * The directory, not the full path: `/dealer3/index.html` and `/dealer3/` must
+ * both print `/dealer3/`. Trailing slash kept so the printed link resolves
+ * without a redirect.
+ */
+const siteUrl = computed(() => {
+  const { origin, pathname } = window.location
+  return origin + pathname.replace(/[^/]*$/, '')
+})
 
 const title = computed(() =>
   props.scenario ? props.scenario.replace(/_/g, ' ') : 'Dealer script',


### PR DESCRIPTION
The print footer said `https://dealer.bridge-classroom.org`, baked in at build
time. The same build now answers on its own `pages.dev` **and** is mounted at
`bridge-craftwork.com/dealer3/`, so any fixed address is wrong from one of them.

This one matters more than most: it ends up **on paper**, where a wrong URL
cannot be fixed by redeploying.

```js
const siteUrl = computed(() => {
  const { origin, pathname } = window.location
  return origin + pathname.replace(/[^/]*$/, '')
})
```

The directory rather than the full path, so `/dealer3/index.html` and
`/dealer3/` both print `/dealer3/`. Trailing slash kept so the printed link
resolves without a redirect.

## Verified

Built for real and served under a subpath, then generated deals and read the
rendered footer:

```
Generated with dealer3 — http://127.0.0.1:8795/dealer3/.
```

Path arithmetic checked against every shape it will actually see: the mount,
the mount with `index.html`, with a query string, `pages.dev` root, and dev.
All 129 web tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)