### PR TITLE
An action that only measures prints nothing and samples everything

### DIFF
--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -1196,6 +1196,16 @@ fn main() {
             std::process::exit(1);
         }
 
+        // Whether the script named an `action` at all, and whether anything it
+        // named prints deals. The original settles both questions the same way
+        // — `will_print` in `defs.y`, incremented by `printall`, `printew`,
+        // `print(...)`, `printcompact`, `printoneline`, `printpbn` and
+        // `printes(...)`, and nothing else. `average` and `frequency` do not
+        // print, so an action list holding only those means the script is
+        // measuring rather than dealing out hands. See #49.
+        let mut has_action_statement = false;
+        let mut script_prints = false;
+
         // Extract action block directives from the program
         let mut produce_count_from_input: Option<usize> = None;
         let mut generate_count_from_input: Option<usize> = None;
@@ -1229,6 +1239,17 @@ fn main() {
                     print_reports: report_specs,
                     ..
                 } => {
+                    has_action_statement = true;
+                    // A `printrpt` in the list writes a row per deal, so it
+                    // prints as surely as `printall` does — the original has no
+                    // opinion, since the word is DealerV2_4's.
+                    if action_format.is_some()
+                        || !printes_specs.is_empty()
+                        || !print_hands.is_empty()
+                        || !report_specs.is_empty()
+                    {
+                        script_prints = true;
+                    }
                     print_reports.extend(report_specs.iter().cloned());
                     // Extract format if present
                     if let Some(action_type) = action_format {
@@ -1271,9 +1292,11 @@ fn main() {
                     seed_from_input = Some(*value);
                 }
                 Statement::CsvReport(terms) => {
+                    script_prints = true;
                     csv_reports.push(terms.clone());
                 }
                 Statement::PrintReport(terms) => {
+                    script_prints = true;
                     print_reports.push(terms.clone());
                 }
                 _ => {}
@@ -1293,11 +1316,19 @@ fn main() {
             .generate
             .or(generate_count_from_input)
             .unwrap_or(10_000_000);
+        // A script whose `action` names only statistics is measuring, so it
+        // takes every deal it generates rather than the first forty — and
+        // prints none of them. `dealer.c:1656` settles both with one line:
+        // `maxproduce = ((actionlist == &defaultaction) || will_print) ? 40 :
+        // maxgenerate`. Without this a `frequency` study written on BBO
+        // silently sampled forty deals here. See #49.
+        let measuring_only = has_action_statement && !script_prints;
+
         let produce_count = args
             .produce
             .or(produce_count_from_input)
             .unwrap_or_else(|| {
-                if args.generate.is_some() {
+                if args.generate.is_some() || measuring_only {
                     usize::MAX // No produce limit when only -g is specified
                 } else {
                     40 // dealer.exe default for -p
@@ -1315,6 +1346,11 @@ fn main() {
             .format
             .or(format_from_input)
             .unwrap_or(OutputFormat::PrintAll); // Default format (matches dealer.exe)
+
+        // `printall` is the default *action*, so naming an action list without
+        // a printing one replaces it. `-f` on the command line still asks for
+        // deals explicitly and wins.
+        let print_deals = !measuring_only || args.format.is_some();
 
         let dealer_position = args.dealer.or(dealer_from_input);
 
@@ -1610,6 +1646,9 @@ fn main() {
         struct Terminal<'a> {
             args: &'a Args,
             output_format: OutputFormat,
+            /// Whether produced deals are shown at all. False for a script
+            /// whose `action` names only statistics — see #49.
+            print_deals: bool,
             dealer_position: Option<DealerPosition>,
             vulnerability: Option<VulnerabilityArg>,
             title: Option<String>,
@@ -1688,7 +1727,7 @@ fn main() {
                     if self.args.interleave {
                         self.held
                             .push((hand_type.map(str::to_string), deal.deal.clone()));
-                    } else {
+                    } else if self.print_deals {
                         print!(
                             "{}",
                             render_board(
@@ -1725,6 +1764,7 @@ fn main() {
         let mut terminal = Terminal {
             args: &args,
             output_format,
+            print_deals,
             dealer_position,
             vulnerability,
             title: title.clone(),
@@ -1907,6 +1947,9 @@ fn main() {
                 .into_iter()
                 .enumerate()
             {
+                if !print_deals {
+                    continue;
+                }
                 let (hand_type, deal) = &held[index];
                 print!(
                     "{}",

--- a/dealer/tests/script_statements.rs
+++ b/dealer/tests/script_statements.rs
@@ -462,3 +462,76 @@ fn unary_minus_negates() {
         assert_eq!(out.trim(), expected, "{written}");
     }
 }
+
+/// #49. An `action` list replaces the default action, and `printall` is the
+/// default — so a list naming only statistics prints no deals. The original
+/// settles it with `will_print` in `defs.y`, incremented by every printing
+/// action and by nothing else.
+#[test]
+fn an_action_that_only_measures_prints_no_deals() {
+    let boards = |out: &str| out.lines().filter(|l| l.trim_end().ends_with('.')).count();
+
+    let (measuring, err, status) = run(
+        &["-p", "3", "-s", "1"],
+        "condition 1\naction average \"hcp\" hcp(north)\n",
+    );
+    assert_eq!(status, 0, "stderr was: {err}");
+    assert_eq!(
+        boards(&measuring),
+        0,
+        "no deals were asked for: {measuring:?}"
+    );
+    assert!(measuring.contains("hcp:"), "the average is still reported");
+
+    // The two cases that already agreed with the original must keep agreeing.
+    let (no_action, _, _) = run(&["-p", "3", "-s", "1"], "condition 1\n");
+    assert_eq!(boards(&no_action), 3, "no action at all still prints deals");
+
+    let (explicit, _, _) = run(
+        &["-p", "3", "-s", "1"],
+        "condition 1\naction printall, average \"hcp\" hcp(north)\n",
+    );
+    assert_eq!(
+        boards(&explicit),
+        3,
+        "an explicit format still prints deals"
+    );
+}
+
+/// The silent half: a measuring script takes every deal it generates, rather
+/// than the first forty. `dealer.c:1656` decides both with one expression.
+#[test]
+fn an_action_that_only_measures_takes_every_deal_generated() {
+    let (out, err, status) = run(
+        &["-s", "1", "-v"],
+        "generate 1000\ncondition 1\naction average \"hcp\" hcp(north)\n",
+    );
+    assert_eq!(status, 0, "stderr was: {err}");
+    assert!(
+        out.contains("Produced 1000 hands"),
+        "a measuring run samples everything it generates: {out:?}"
+    );
+
+    // And `-p` still wins when it is given.
+    let (capped, _, _) = run(
+        &["-s", "1", "-v", "-p", "25"],
+        "generate 1000\ncondition 1\naction average \"hcp\" hcp(north)\n",
+    );
+    assert!(capped.contains("Produced 25 hands"), "got: {capped:?}");
+}
+
+/// Asking for a format on the command line is asking for deals, whatever the
+/// script's action list says.
+#[test]
+fn an_explicit_format_shows_deals_even_when_only_measuring() {
+    let (out, _, status) = run(
+        &["-p", "3", "-s", "1", "-f", "printoneline"],
+        "condition 1\naction average \"hcp\" hcp(north)\n",
+    );
+    assert_eq!(status, 0);
+    assert_eq!(
+        out.lines().filter(|l| l.starts_with('n')).count(),
+        3,
+        "got: {out:?}"
+    );
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -168,6 +168,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   divide by, so its bar means something.
 
 ### Fixed
+- **An `action` naming only statistics printed deals, and measured 25x fewer of
+  them.** Both from one rule dealer3 did not have: an `action` list *replaces*
+  the default action, and `printall` is the default, so a list holding only
+  `average` and `frequency` prints nothing — and produces every deal it
+  generates rather than the first forty, because statistics want the whole
+  sample. `dealer.c:1656` settles both in one line, keyed on the `will_print`
+  that every printing action in `defs.y` increments.
+  - `generate 1000` with a statistics-only action produced 1000 deals in the
+    original and 40 here, silently, both averages looking plausible. With
+    `generate` left at its 10,000,000 default the gap is far wider.
+  - `-p` and `-f` still win when given: asking for a count or a format is
+    asking for it.
+  - The browser is unaffected — it takes `produce` and the format as explicit
+    settings from the page rather than defaulting from the script.
+  - Found by `scripts/compare-stats.py` on its first real script. (#49)
 - **`trix(deal)` and `par()` were about twice as slow as they needed to be.**
   `dealer_dds::table` filled the twenty cells seat-outermost, asking for a
   different denomination on every call. `DealAnalysis` keeps the solver's

--- a/scripts/compare-stats.py
+++ b/scripts/compare-stats.py
@@ -63,28 +63,34 @@ PRINT_ACTIONS = r"printall|printew|printpbn|printcompact|printoneline"
 TRAILER = re.compile(r"^(Generated |Produced |Initial random seed|Time needed)")
 
 
-def with_printpbn(script: str) -> str:
-    """The script, emitting PBN as well as whatever it already reports.
+def with_printpbn(script: str) -> tuple:
+    """The script emitting PBN, and whether that had to be added.
 
-    `printpbn` rather than another format because `--input-deals` reads it
-    back exactly, including the seat each hand belongs to.
+    `printpbn` rather than another format because `--input-deals` reads it back
+    exactly, including the seat each hand belongs to.
+
+    The flag matters for the comparison. A script that already printed is
+    compared including its blank lines, because those are part of the layout
+    and a missing one is a real difference. A script that did not print gets
+    PBN injected, and PBN separates its records with blank lines that only one
+    side will have — so those are dropped rather than reported.
     """
     if re.search(rf"\b({PRINT_ACTIONS})\b", script):
-        # It already prints deals; swap the format for PBN so they can be read
-        # back, leaving any averages and frequencies beside it alone.
-        return re.sub(rf"\b({PRINT_ACTIONS})\b", "printpbn", script, count=1)
+        return re.sub(rf"\b({PRINT_ACTIONS})\b", "printpbn", script, count=1), False
     if re.search(r"^\s*action\b", script, re.MULTILINE):
         return re.sub(r"^(\s*action\b)", r"\1 printpbn,", script, count=1,
-                      flags=re.MULTILINE)
-    return script.rstrip("\n") + "\naction printpbn\n"
+                      flags=re.MULTILINE), True
+    return script.rstrip("\n") + "\naction printpbn\n", True
 
 
-def statistics(text: str) -> list:
+def statistics(text: str, drop_blanks: bool) -> list:
     """The lines worth comparing: not deals, not the run trailer."""
     lines = []
     for line in text.splitlines():
         line = line.rstrip("\r")
         if line.startswith("[") or TRAILER.match(line):
+            continue
+        if drop_blanks and not line.strip():
             continue
         lines.append(line)
     # Trailing blank lines carry no information either way.
@@ -114,7 +120,8 @@ def main() -> int:
     handle, remote_script = tempfile.mkstemp(suffix=".dlr", dir=here)
     try:
         with os.fdopen(handle, "w") as f:
-            f.write(with_printpbn(script))
+            reference_script, injected = with_printpbn(script)
+            f.write(reference_script)
         command = (f'dealer -p {args.produce} -s {args.seed} '
                    f'"{mac_to_windows_path(remote_script)}"')
         code, reference, stderr = run_windows_command(command, timeout=300,
@@ -155,8 +162,8 @@ def main() -> int:
         return 2
     mine = run.stdout
 
-    theirs = statistics(reference)
-    ours = statistics(mine)
+    theirs = statistics(reference, injected)
+    ours = statistics(mine, injected)
 
     boards = reference.count("[Deal ")
     print(f"{boards} deals from dealer.exe, seed {args.seed}")


### PR DESCRIPTION
Closes #49. Found by `scripts/compare-stats.py` on the first real script it was pointed at.

## One rule, two symptoms

An `action` list *replaces* the default action, and `printall` is the default. So a list naming only `average` and `frequency` prints no deals — and produces every deal it generates rather than the first forty, because statistics want the whole sample. `dealer.c:1656` settles both:

```c
maxproduce = ((actionlist == &defaultaction) || will_print) ? 40 : maxgenerate;
```

`will_print` is incremented by `printall`, `printew`, `print(...)`, `printcompact`, `printoneline`, `printpbn` and `printes(...)` in `defs.y`, and by nothing else.

dealer3 had neither half.

```
condition 1
action average "hcp" hcp(north)
```

| | deals printed |
|---|---|
| dealer.exe | 0 |
| dealer3, before | all of them |

And the silent half, with `generate 1000`:

| | produced | average |
|---|---|---|
| dealer.exe | 1000 | 9.959 |
| dealer3, before | **40** | 10.075 |

Both plausible, nothing warning. With `generate` at its 10,000,000 default the gap is far wider. Fourth silent-wrong-answer of the session, after #36, #38 and #43.

## What still wins

`-p` and `-f` given on the command line, since asking for a count or a format is asking for one. And the three cases that already agreed still do: no `action` at all prints deals, an explicit format prints deals, an explicit `-p` caps the count. All four are tests.

`printrpt` and `csvrpt` count as printing too. The original has no opinion — they are DealerV2_4's — but they write a row per deal, so treating them as measuring would flood a file at ten million deals.

**The browser needs no change**: it takes `produce` and the format as explicit settings from the page rather than defaulting from the script. Checked rather than assumed.

## Verification

`compare-stats.py` now reports MATCH on the script that found the bug:

```
200 deals from dealer.exe, seed 3
MATCH: 10 lines identical over the same deals
```

The tool gained a fix of its own: when it injects `printpbn` to capture deals, the blank lines separating PBN records exist on only one side, so they are dropped — but only when it injected. A script that prints on its own is still compared including its blank lines, because a missing one is a real layout difference.

518 tests pass (3 new); `cargo fmt --check` and `clippy --workspace --all-targets -D warnings` clean, matching CI's flags exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)