### PR TITLE
Four-way performance harness, and a 1.6x dealing speedup it found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ docs/*.pdf
 # Playwright MCP scratch: snapshots, console logs and screenshots from
 # driving the site in a browser. Never part of the build.
 .playwright-mcp/
+
+# Benchmark scratch (see bench/README.md)
+bench/.staging/
+bench/.verify/
+scripts/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,5 @@ docs/*.pdf
 # Benchmark scratch (see bench/README.md)
 bench/.staging/
 bench/.verify/
+bench/.dds/
 scripts/__pycache__/

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,266 @@
+# Performance comparison: dealer.exe, dealer-c, DealerV2_4, dealer3
+
+A characterization, not a proof. It answers "roughly how much faster is
+dealer3, and where does its threading stop paying?" to within a few percent,
+which is the accuracy the question deserves.
+
+## The five scripts
+
+| Script | What it does | How often to run it |
+|---|---|---|
+| `scripts/bench-corpus.py` | Picks scripts from Practice-Bidding-Scenarios, rewrites them for benchmarking, checks each one runs on all three programs, collapses near-duplicates, and sizes each one's workload | Only when the script selection should change |
+| `scripts/bench-reference.py` | Measures dealer.exe, dealer-c and DealerV2_4 | Only when the corpus changes, or one of those builds does |
+| `scripts/bench-dealer3.py` | Measures dealer3: single-threaded, default, and a thread sweep | Whenever dealer3 changes substantively |
+| `scripts/bench-report.py` | Joins the two result sets into one table | After either |
+| `scripts/bench-verify.py` | Checks dealer3 *agrees* with both references on the same deals | With the corpus, and after language changes |
+
+The split is the point: the reference numbers are the slow half (every
+dealer.exe run is an SSH round trip) and the half that does not change.
+
+```bash
+./dev-build.sh build --release
+
+# once, or when the selection changes
+scripts/bench-corpus.py -n 10 --all-targets
+
+# once per corpus
+export DEALERV2_BIN=../Dealer-Version-2-/macos-build/dealerv2
+scripts/bench-reference.py
+
+# every time dealer3 changes
+scripts/bench-dealer3.py
+scripts/bench-report.py
+
+# iterating on a performance change - one script, same one every time
+scripts/bench-dealer3.py --quick
+
+# semantics, not speed - safe to run any time
+scripts/bench-verify.py
+```
+
+Two of the reference binaries have to be built first:
+
+- **DealerV2_4** — upstream ships a Linux x86-64 binary that will not run on
+  macOS. `scripts/build-dealerv2-macos.sh` builds it, DDS and all, and
+  documents the four glibc-isms that need shimming.
+- **dealer-c** — the original C dealer, built natively.
+  `scripts/build-dealer-c-macos.sh`. Everything it needs is already in
+  `../Dealer-cleanup/`, including `__random.c`, the GNU `random()` port, so it
+  uses the original RNG rather than a substitute.
+
+Either can be absent; `bench-reference.py` says so and measures the rest.
+
+## The four programs, and which comparison means what
+
+| | What it is | Read it as |
+|---|---|---|
+| `dealer.exe` | 32-bit x86, on an ARM64 Windows VM, **under emulation** | What running dealer.exe actually costs you today |
+| `dealer-c` | The same C source, built natively for arm64 — and it deals **identically** to dealer.exe | The honest speed of the original implementation |
+| `dealerv2_4` | DealerV2_4, built natively for arm64 | The honest speed of the modern C fork |
+| `dealer3` | This project, native, `-R 1` and threaded | — |
+
+`dealer-c` deals the same boards as `dealer.exe`, verified byte-for-byte over
+400 deals at seed 1 and 200 each at seeds 42 and 12345 (modulo CRLF). The
+64-bit and 32-bit builds of `__random.c` differ only in bit 31, and dealer
+indexes its card table from bits 15..=30. So the two are the same program doing
+the same work, and the gap between them in the table is purely the cost of x86
+emulation on ARM64.
+
+`dealer-c` exists specifically to take emulation out of the comparison. Without
+it the only C reference on equal silicon would be DealerV2_4, and dealer.exe's
+number would get read as "the C implementation is slow" when much of the gap is
+the emulation layer. With both present, the "vs dealer-c" column is the
+algorithmic comparison and "vs exe" is the operational one.
+
+## Why ten scripts, and which ten
+
+The corpus is vendored into this repo, so every script in it has to earn its
+place. Ten distinct ones characterize the three programs better than thirty
+near-identical ones, and cost far less to carry.
+
+The PBS `.dlr` files are **generated**: a precompiler expands shared fragments
+inline and brackets each with `##### Imported Script: NAME #####`. 155 of the
+347 scripts pull in at least one of ten such fragments, and 46 share the exact
+same set. Separately, whole families differ only in a threshold — there are
+seven `Weak_NT_*` scripts whose conditions are identical once the numbers are
+masked. Picking ten of those would cost ten files and measure one thing.
+
+So candidates are collapsed before selection. Two scripts are the same
+benchmark when they import the same fragments *and* their normalized bodies —
+comments stripped, integers masked — are at least 85% similar. Requiring the
+import set to match too means two scripts are never merged merely because both
+inline the same large shared fragment; what must be alike is the part that is
+theirs. The threshold is not a guess: measured across the real corpus, members
+of a family score **1.000** against each other while genuinely different
+scripts score **0.04–0.22**, so nothing sits near 0.85.
+
+Survivors are then picked along two axes at once — round-robin across distinct
+import sets, taking from each the script that most extends the cost-per-deal
+range covered so far. Different import sets mean different shared machinery is
+exercised; different cost per deal means a change that only helps cheap or only
+helps expensive conditions cannot hide. `corpus.json` records, for each row,
+how many near-duplicates it stands for and which they were.
+
+## Iterating on a change
+
+The whole corpus is a slow loop. `--quick` (or `-1`) runs one script — the
+median cost per deal, chosen deterministically, so two `--quick` runs are
+comparable to each other:
+
+```bash
+scripts/bench-dealer3.py --quick --no-sweep     # fastest signal
+scripts/bench-dealer3.py --quick                # with the thread sweep
+scripts/bench-dealer3.py --scripts Bergen_Raises,Negative_Double
+```
+
+It is on `bench-reference.py` and `bench-verify.py` too. Use the full corpus
+for anything being recorded or compared across revisions.
+
+## What is actually being measured
+
+**Deals evaluated per second, at a fixed deal count.** Not "time to produce 40
+matching hands". The three programs do not deal the same boards — dealer3
+deliberately stopped reproducing dealer.exe's sequence in 0.5.0 — so producing
+40 matches is a different amount of work for each of them, decided by whose
+shuffle happens to hit the condition sooner. `-g N` makes all three evaluate
+exactly N deals against the same condition, and that is comparable. `-p` is
+pinned high enough never to bind, and every sample is checked to confirm the
+run really did generate N deals.
+
+**Condition evaluation, not output.** Each corpus script's `action` block is
+replaced with a cheap `average`, so the number reflects filter throughput
+rather than how fast `printall` writes to a pipe.
+
+Three traps the harness exists to avoid, each of which silently produces a
+plausible wrong number:
+
+- **A script's own `produce`/`generate` beats the command line.** In `dealer.c`
+  `yyparse()` runs after `getopt()`, and the limits are only defaulted if still
+  zero. 120 of the 347 PBS scripts carry such a line. The corpus strips them.
+- **`-v` turns dealer.exe's timing *off*.** Its verbose flag defaults to on and
+  the switch XORs it (`dealer.c:1608`). The VM's build is older than the local
+  source and has no `-X` to force it on either, and `-v` there has a separate
+  known bug tied to whether an odd or even number of PBN rows were written. So
+  that target is passed no verbosity flag at all.
+- **dealer.exe's own clock is broken on Windows.** It prints
+  `Time needed 0.000 sec` however long it ran. That target is therefore
+  wall-clocked, with SSH and startup overhead measured once (~0.28s) and
+  subtracted. dealer3 and DealerV2_4 report honest times and are trusted.
+  Every result records which clock it used.
+
+**dealer.exe is measured under emulation, and that is not a footnote.** The
+Windows VM is ARM64 with 4 cores, while `dealer.exe` is a PE32/i386 binary, so
+it runs through Windows-on-ARM's x86 emulation layer. `bench-reference.py`
+records the VM's architecture in its results and prints a warning when it sees
+ARM64. This is why `dealer-c` and `dealerv2_4` are in the table: they are the
+same lineage on the same silicon, with no emulation in the way.
+
+**Best of N runs.** The fastest run is the least contaminated by whatever else
+the machine was doing. The median and the spread are kept alongside; a spread
+over 15% is flagged, because it means the machine was busy rather than that the
+code changed.
+
+## Separating the shuffle from the filter
+
+dealer3 rewrote the RNG and the shuffle, and the originals were slow, so a
+large part of any headline ratio is deal *generation* rather than condition
+*evaluation*. Those are different pieces of work that improve for different
+reasons, and one deals/sec number cannot tell them apart — on a cheap condition
+the shuffle dominates, on an expensive one it barely registers.
+
+So the corpus carries one synthetic entry, `_shuffle_baseline`, that is not
+from PBS and is not subject to the duplicate or diversity rules. Its condition
+is as close to free as the language allows — a single `hcp()` and a comparison
+— so its throughput is essentially generation alone. `bench-report.py`
+subtracts its cost per deal from each script's to get evaluation cost, and
+reports the two separately along with each program's generation share.
+
+The subtraction is done in **nanoseconds per deal, not in rates** — times
+subtract honestly and rates do not. Where a real script comes out cheaper than
+the baseline the difference is noise, so evaluation cost is floored at zero
+rather than reported as negative.
+
+Its threshold (`hcp(north) >= 24`) is rare but not impossible, so `average`
+always has at least some samples; a condition nothing satisfies would leave
+each program to decide what to print for an empty average, which is not worth
+finding out.
+
+## Reading the thread sweep
+
+`bench-dealer3.py` runs each script at 1, 2, 3 … threads and reports speedup
+against single-threaded.
+
+The distinction that matters is **plateau versus regression**. A curve that
+flattens past the physical core count is ordinary saturation. A curve that
+turns down — more workers, less throughput — is contention, and that is a bug.
+
+**Sweep runs must be long enough or the curve is fiction.** At a few hundred
+milliseconds a run is mostly thread startup and the final merge, and the shape
+that comes out is noise. This is not hypothetical: the first measurement taken
+while building this harness showed throughput *regressing* past 6 threads, and
+it was an artifact of single short runs. Best-of-three at a properly sized
+workload showed clean monotonic scaling on the same script. `bench-dealer3.py`
+now pilots the highest thread count and scales the whole sweep up until even
+the fastest configuration runs past `--min-sweep-seconds`, so the trap is
+closed by default rather than left to the reader.
+
+To check a curve is real, vary the workload and see whether its shape holds:
+
+```bash
+scripts/bench-dealer3.py --sweep-only --scale 0.2   # short
+scripts/bench-dealer3.py --sweep-only --scale 4     # long
+```
+
+If the turnover moves with workload size, the cost is per-run. If it stays put,
+it is contention in the generate loop. `--batch-sizes` adds the work-unit size
+as a second dimension, the obvious suspect for shared state.
+
+One caveat worth keeping in mind: this measures fixed-work runs, which is the
+right way to compare the three programs, but it is *not* what a user feels. A
+typical invocation is `-p 40` — a short run where thread startup is a real
+fraction of the total. Threading will always look better here than it does
+there.
+
+## Correctness, from the same corpus
+
+A throughput number means nothing if the three programs disagree about what a
+script *says*, so `bench-verify.py` reuses the corpus for that too. Per script,
+per reference:
+
+1. The reference runs with `printpbn` added to its action list, emitting both
+   the deals it produced and its statistics.
+2. Those deals go into dealer3 through `--input-deals`, script unchanged.
+3. dealer3 must match **every** deal the reference matched, and must report the
+   same `average` over them.
+
+Both programs are then looking at identical cards, so a disagreement is a real
+difference in what a word means and never an artefact of the shuffle — which is
+what makes this work at all, given the three stopped dealing alike in 0.5.0.
+
+Statistics are compared **by value, not as text**. The three do not agree on
+how to print an average: dealer.exe and dealer3 write `label: 10.66`, while
+DealerV2_4 writes `label: Mean=   10.6600, Std Dev= …, Sample Size=50`. Those
+are the same answer; comparing the strings would fail on every line and bury
+any real difference in cosmetic noise.
+
+This is `scripts/test-filter.py`'s idea — which covers dealer.exe only, and
+acceptance only — widened to both references and to the statistics, and run
+across the whole corpus in one command. The PBN plumbing is imported from
+`scripts/compare-stats.py` rather than copied, so the two cannot drift apart.
+
+## Files
+
+```
+bench/
+  corpus.json          what got selected, what was rejected and why
+  corpus/*.dlr         the normalized scripts, committed so results are comparable
+  results/
+    reference-<rev>.json   dealer.exe + DealerV2_4, keyed to the corpus revision
+    dealer3-<rev>.json     dealer3, keyed to the dealer3 revision
+  .staging/, .verify/      scratch, not committed
+```
+
+Reference results are keyed to the corpus revision they were measured against.
+`bench-report.py` warns if you compare across a corpus change, because the
+per-script deal counts are calibrated and numbers taken against a different
+corpus describe different amounts of work.

--- a/bench/README.md
+++ b/bench/README.md
@@ -57,6 +57,14 @@ Either can be absent; `bench-reference.py` says so and measures the rest.
 | `dealer.exe` | 32-bit x86, on an ARM64 Windows VM, **under emulation** | What running dealer.exe actually costs you today |
 | `dealer-c` | The same C source, built natively for arm64 — and it deals **identically** to dealer.exe | The honest speed of the original implementation |
 | `dealerv2_4` | DealerV2_4, built natively for arm64 | The honest speed of the modern C fork |
+
+DealerV2_4's deal-and-filter loop is single-threaded, and the corpus calls no
+solver function, so the table above measures it single-threaded throughout. Its
+double-dummy solving is a different matter: `-R` sets DDS worker threads and
+table mode (`-M 2`) defaults them if unset. Any comparison involving `dds()` or
+`par()` has to match `-M`, `-R` and `-L` deliberately -- and `-L` with a `.zrd`
+library means no solving at all, because the file already contains the
+twenty results. See the note on the solver-agreement entry below.
 | `dealer3` | This project, native, `-R 1` and threaded | — |
 
 `dealer-c` deals the same boards as `dealer.exe`, verified byte-for-byte over

--- a/bench/README.md
+++ b/bench/README.md
@@ -124,6 +124,38 @@ scripts/bench-dealer3.py --scripts Bergen_Raises,Negative_Double
 It is on `bench-reference.py` and `bench-verify.py` too. Use the full corpus
 for anything being recorded or compared across revisions.
 
+## Reading the two dealer3 numbers
+
+They answer different questions and should not be collapsed into one headline.
+
+**Single-threaded (`-R 1`) is how efficient the main code path is.** It is one
+core doing one deal's work, directly comparable with the reference programs,
+none of which thread their deal loop. It is also the stable number: a
+single-threaded process gets a full core even on a machine that is otherwise
+busy, so repeats land within a percent or two.
+
+**Threaded (`auto`) is how effective we are with the cores available.** It is
+wall-clock throughput, not one core's effort, so it belongs in a different
+column of the mind. It is the number that matters in practice, because a normal
+run is threaded.
+
+As measured here, on an Apple M4 Pro (8P + 4E), against the natively-built
+original C dealer:
+
+| | vs `dealer-c` |
+|---|---|
+| dealer3 `-R 1` | ~11% slower |
+| dealer3 `-R 1` vs DealerV2_4 | ~14% faster |
+| **dealer3 threaded** | **~4.4x faster** |
+
+The threaded figure is the real win, and it is a **floor rather than a
+ceiling**: the machine it was measured on was not idle, and where a
+single-threaded run simply takes one free core, a twelve-thread run contends
+with whatever else is running for the other eleven. That is also why the
+threaded rows are the noisiest in the report — repeats vary by tens of percent
+where single-threaded repeats vary by one or two — so read them to two
+significant figures at most.
+
 ## What is actually being measured
 
 **Deals evaluated per second, at a fixed deal count.** Not "time to produce 40

--- a/bench/corpus.json
+++ b/bench/corpus.json
@@ -1,0 +1,496 @@
+{
+  "built_with": "v0.4.0-196-gd638789",
+  "source": "/Users/rick/Development/GitHub/Practice-Bidding-Scenarios/dlr",
+  "target_seconds": 2.0,
+  "verified_against": [
+    "dealer3",
+    "dealer.exe",
+    "dealerv2_4"
+  ],
+  "considered": 347,
+  "survived": 286,
+  "distinct": 202,
+  "similarity_threshold": 0.85,
+  "scripts": [
+    {
+      "name": "Scrambling_2NT",
+      "file": "Scrambling_2NT.dlr",
+      "source": "Practice-Bidding-Scenarios/dlr/Scrambling_2NT.dlr",
+      "notes": [
+        "stripped block comments",
+        "replaced action block"
+      ],
+      "imports": [],
+      "signature": "dealer west wS = spades(west)>N and spades(west)>=hearts(west) and spades(west)>=diamonds(west) and spades(west)>=clubs(west) wH = hearts(west)>N and hearts(west)>spades(west)  and hearts(west)>=diamonds(west) and hearts(west)>=clubs(west) sNFit = wS and spades(east)==N hNFit = wH and hearts(east)==N ewNFit = (sNFit or hNFit) and hcp(east)>N and hcp(east)<N sNFit = wS and spades(east)==N hNFit = wH and hearts(east)==N ewNFit = (sNFit or hNFit) and hcp(east)>N and hcp(east)<N OBAR = hcp(west)>N and hcp(west)<N and (ewNFit or ewNFit) sShape = wS ? shape(south,N+N+N+N+N) : shape(south,N+N+N+N+N) hcpBoost = shape(south,any N) ? N : N sTOX = sShape and hcp(south)>(N + hcpBoost)  // require an extra hcp for N nMajor    = spades(north)>N or hearts(north)>N   // with a Major, North has option of free-bid or scramble & bid twoSuits  = shape(north,any Nxx + any Nxx) nFreeBid  = (nMajor and hcp(north)>N) or not twoSuits nScramble = ((not nMajor and shape(north,xxN + xxN + xxN)) or (nMajor and hcp(north)<N)) and not nFreeBid OBAR and sTOX and (nFreeBid or nScramble) action average \"bench\" hcp(north)",
+      "produced_at_verify": 5,
+      "hit_rate": 0.00025,
+      "seconds_per_deal_r1": 6.7e-07,
+      "deals": 2900000,
+      "cluster_size": 1,
+      "cluster_members": [
+        "Scrambling_2NT"
+      ]
+    },
+    {
+      "name": "GIB_1N_Basic",
+      "file": "GIB_1N_Basic.dlr",
+      "source": "Practice-Bidding-Scenarios/dlr/GIB_1N_Basic.dlr",
+      "notes": [
+        "stripped block comments",
+        "dropped 1 produce/generate line(s)",
+        "replaced action block"
+      ],
+      "imports": [
+        "GIB 1 Notrump (North)"
+      ],
+      "signature": "dealer north //   Total Points = HCP + Short-Suit Points - Penalty Points //   Short-Suit Points: N for void, N for singleton, N for doubleton //   Penalty Points: N for each honor (K/Q/J) in a short suit (devalues wasted honors like Kx, Qx) nSpadeSSP = spades(north)<N   ? N-spades(north)   : N nHeartSSP = hearts(north)<N   ? N-hearts(north)   : N nDiamSSP  = diamonds(north)<N ? N-diamonds(north) : N nClubSSP  = clubs(north)<N    ? N-clubs(north)    : N nSSP = nSpadeSSP + nHeartSSP + nDiamSSP + nClubSSP nSpadePP = spades(north)<N   and hcp(north,spades)>N   ? N : N nHeartPP = hearts(north)<N   and hcp(north,hearts)>N   ? N : N nDiamPP  = diamonds(north)<N and hcp(north,diamonds)>N ? N : N nClubPP  = clubs(north)<N    and hcp(north,clubs)>N    ? N : N nPP = nSpadePP + nHeartPP + nDiamPP + nClubPP tpNorth = hcp(north) + nSSP - nPP eSpadeSSP = spades(east)<N   ? N-spades(east)   : N eHeartSSP = hearts(east)<N   ? N-hearts(east)   : N eDiamSSP  = diamonds(east)<N ? N-diamonds(east) : N eClubSSP  = clubs(east)<N    ? N-clubs(east)    : N eSSP = eSpadeSSP + eHeartSSP + eDiamSSP + eClubSSP eSpadePP = spades(east)<N   and hcp(east,spades)>N   ? N : N eHeartPP = hearts(east)<N   and hcp(east,hearts)>N   ? N : N eDiamPP  = diamonds(east)<N and hcp(east,diamonds)>N ? N : N eClubPP  = clubs(east)<N    and hcp(east,clubs)>N    ? N : N ePP = eSpadePP + eHeartPP + eDiamPP + eClubPP tpEast = hcp(east) + eSSP - ePP sSpadeSSP = spades(south)<N   ? N-spades(south)   : N sHeartSSP = hearts(south)<N   ? N-hearts(south)   : N sDiamSSP  = diamonds(south)<N ? N-diamonds(south) : N sClubSSP  = clubs(south)<N    ? N-clubs(south)    : N sSSP = sSpadeSSP + sHeartSSP + sDiamSSP + sClubSSP sSpadePP = spades(south)<N   and hcp(south,spades)>N   ? N : N sHeartPP = hearts(south)<N   and hcp(south,hearts)>N   ? N : N sDiamPP  = diamonds(south)<N and hcp(south,diamonds)>N ? N : N sClubPP  = clubs(south)<N    and hcp(south,clubs)>N    ? N : N sPP = sSpadePP + sHeartPP + sDiamPP + sClubPP tpSouth = hcp(south) + sSSP - sPP wSpadeSSP = spades(west)<N   ? N-spades(west)   : N wHeartSSP = hearts(west)<N   ? N-hearts(west)   : N wDiamSSP  = diamonds(west)<N ? N-diamonds(west) : N wClubSSP  = clubs(west)<N    ? N-clubs(west)    : N wSSP = wSpadeSSP + wHeartSSP + wDiamSSP + wClubSSP wSpadePP = spades(west)<N   and hcp(west,spades)>N   ? N : N wHeartPP = hearts(west)<N   and hcp(west,hearts)>N   ? N : N wDiamPP  = diamonds(west)<N and hcp(west,diamonds)>N ? N : N wClubPP  = clubs(west)<N    and hcp(west,clubs)>N    ? N : N wPP = wSpadePP + wHeartPP + wDiamPP + wClubPP tpWest = hcp(west) + wSSP - wPP tpNS = tpNorth + tpSouth tpEW = tpEast + tpWest ntP = hcp(north) + shape(north,Nxxx+xNxx) ntN = shape(north, any N+any N+any N) and hcp(north)>N and ntP<N ntN = shape(north, any N-Nxxx-xNxx-Nxxx) and hcp(north)>N and hcp(north)<N gibNT = ntN or ntN stayman = shape(south,Nxx+Nxx+Nxxx+xNxx) and hcp(south)>N texas   = (spades(south)>N or hearts(south)>N) and tpSouth>N jacoby  = (spades(south)>N or hearts(south)>N) and not (stayman or texas) threeNT = not (stayman or texas or jacoby) and hcp(south)>N twoSuit = shape(south,any Nxx +any Nxx +any Nxx +any Nxx +any Nxx) gibNT and (stayman or jacoby or threeNT) and hcp(south)<N and not twoSuit action average \"bench\" hcp(north)",
+      "produced_at_verify": 460,
+      "hit_rate": 0.023,
+      "seconds_per_deal_r1": 7.000000000000001e-07,
+      "deals": 2800000,
+      "cluster_size": 1,
+      "cluster_members": [
+        "GIB_1N_Basic"
+      ]
+    },
+    {
+      "name": "Slam_After_Major_Fit",
+      "file": "Slam_After_Major_Fit.dlr",
+      "source": "Practice-Bidding-Scenarios/dlr/Slam_After_Major_Fit.dlr",
+      "notes": [
+        "stripped block comments",
+        "replaced action block"
+      ],
+      "imports": [
+        "Define Calm Opponents",
+        "GIB 1 Notrump"
+      ],
+      "signature": "dealer south cce = topN(east,clubs)<N cde = topN(east,diamonds)<N che = topN(east,hearts)<N cse = topN(east,spades)<N noConEast = cce and cde and che and cse ccw = topN(west,clubs)<N cdw = topN(west,diamonds)<N chw = topN(west,hearts)<N csw = topN(west,spades)<N noConWest = ccw and cdw and chw and csw balEast    = shape(east,any N +any N) unbalEast  = shape(east,xxxx -any N -any N -any Nxxx -any Nxxx -any Nxxx-any Nxxx -any Nxx) balWest    = shape(west,any N +any N) unbalWest  = shape(west,xxxx -any N -any N -any Nxxx -any Nxxx -any Nxxx-any Nxxx -any Nxx) calmEast = (unbalEast and noConEast and hcp(east)<N) or (balEast and hcp(east)<N) calmWest = (unbalWest and noConWest and hcp(west)<N) or (balWest and hcp(west)<N) calmOpps = calmEast and calmWest ntP = hcp(south) + shape(south,Nxxx+xNxx) ntN = shape(south, any N+any N+any N) and hcp(south)>N and ntP<N ntN = shape(south, any N-Nxxx-xNxx-Nxxx) and hcp(south)>N and hcp(south)<N gibNT = ntN or ntN heartFit = shape(south,xNxx + xNxx + xNxx -any Nxx -any Nxx) and hearts(north)>N spadeFit = shape(south,Nxxx + Nxxx + Nxxx -any Nxx -any Nxx) and spades(north)>N oneM = (heartFit or spadeFit) and not gibNT oneM and hcp(south)>N and hcp(south)<N and hcp(north)>N and (hcp(north)+hcp(south))>N and calmWest action average \"bench\" hcp(north)",
+      "produced_at_verify": 32,
+      "hit_rate": 0.0016,
+      "seconds_per_deal_r1": 7.3e-07,
+      "deals": 2700000,
+      "cluster_size": 1,
+      "cluster_members": [
+        "Slam_After_Major_Fit"
+      ]
+    },
+    {
+      "name": "After_Partner_Overcalls",
+      "file": "After_Partner_Overcalls.dlr",
+      "source": "Practice-Bidding-Scenarios/dlr/After_Partner_Overcalls.dlr",
+      "notes": [
+        "stripped block comments",
+        "dropped 1 produce/generate line(s)",
+        "replaced action block"
+      ],
+      "imports": [
+        "GIB 1 Notrump"
+      ],
+      "signature": "dealer east ntP = hcp(south) + shape(south,Nxxx+xNxx) ntN = shape(south, any N+any N+any N) and hcp(south)>N and ntP<N ntN = shape(south, any N-Nxxx-xNxx-Nxxx) and hcp(south)>N and hcp(south)<N gibNT = ntN or ntN s = spades(east) h = hearts(east) d = diamonds(east) c = clubs(east) oS = s>N and s>=h and s>=d and s>=c oH = not oS and h>N and h>=d and h>=c oD = not (oS or oH) and ((d>N and d>=c) or c<N) oC = not (oS or oH or oD) openingSuit = (oS or oH or oD or oC) eRS = oS ? N : N eRH = oH ? N : N eRD = oD ? N : N eRC = oC ? N : N eRank = eRS+eRH+eRD+eRC sGoodS = spades(south)>N   and topN(south,spades)==N   and not oS sGoodH = hearts(south)>N   and topN(south,hearts)==N   and not oH sGoodD = diamonds(south)>N and topN(south,diamonds)==N and not oD sGoodC = clubs(south)>N    and topN(south,clubs)==N    and not oC sShape = shape(south,any Nxxx + any Nxxx + any Nxxx + any Nxxx - any Nxx - any Nxx - any Nxx - any Nxx - any Nxx) sRS = sGoodS ? N : N sRH = sGoodH ? N : N sRD = sGoodD ? N : N sRC = sGoodC ? N : N sRank = sRS + sRH + sRD + sRC sSP = oS and hascard(south,AS) ? hcp(south,spades)-N   : hcp(south,spades) sHP = oH and hascard(south,AH) ? hcp(south,hearts)-N   : hcp(south,hearts) sDP = oD and hascard(south,AD) ? hcp(south,diamonds)-N : hcp(south,diamonds) sCP = oC and hascard(south,AC) ? hcp(south,clubs)-N    : hcp(south,clubs) WP = hcp(south) - sSP - sHP - sDP - sCP // only one will be non-zero sSSP = sGoodS ? spades(south)-N   : N sHSP = sGoodH ? hearts(south)-N   : N sDSP = sGoodD ? diamonds(south)-N : N sCSP = sGoodC ? clubs(south)-N    : N sSuitPoints = hcp(south) + sSSP + sHSP + sDSP + sCSP sTP = WP + sSuitPoints sMin = sRank>eRank ? sTP>=N : sTP>=N sMax = sTP<N     // avoid too strong to overcall. sRange = sMin and sMax shortS = oS and spades(south)<N shortH = oH and hearts(south)<N shortD = oD and diamonds(south)<N shortC = oC and clubs(south)<N shortOS = shortS or shortH or shortD or shortC sX = shape(south,any N +any N +any N +any N +any N +any N) and shortOS and hcp(south)>N sJump = shape(south,any Nxxx +any Nxxx +any Nxxx) and hcp(south)>N and hcp(south)<N sTwoSuits = shape(south,any Nxx+any Nxx+any Nxx+any Nxx+any Nxx) eOpens = (oC or oD or oH or oS) and hcp(east)>N and hcp(east)<N sOvercalls = (sGoodS or sGoodH or sGoodD or sGoodC) and sShape and sRange and not (sX or sJump or sTwoSuits or gibNT) wSFit = oS and spades(west)<N wHFit = oH and hearts(west)<N wDFit = oD and diamonds(west)<N wCFit = oC and clubs(west)<N wPasses = (wSFit or wHFit or wDFit or wCFit) and hcp(west)<N and shape(west,any N +any N -Nxxx -xNxx) nFitsS = sGoodS and spades(north)>N nFitsH = sGoodS and hearts(north)>N nFitsD = sGoodD and diamonds(north)>N nFitsC = sGoodC and clubs(north)>N nFit   = (nFitsS or nFitsH or nFitsD or nFitsC) nCS = oC and clubs(north)>N    and topN(north,clubs)>N nDS = oD and diamonds(north)>N and topN(north,diamonds)>N nHS = oH and hearts(north)>N   and topN(north,hearts)>N nSS = oS and spades(north)>N   and topN(north,spades)>N nStop = nCS or nDS or nHS or nSS nRaises  = nFit and hcp(north)>N and hcp(north)<N nCueBids = nFit and hcp(north)>N nNewSuit = shape(north,any Nxxx+any Nxxx) and hcp(north)>N and not nFit nNotrump = not (nRaises or nCueBids or nNewSuit) and nStop and hcp(north)>N nPunts   = not (nRaises or nCueBids or nNewSuit or nNotrump) cN = hascard(west,NC) cN = hascard(east,ND) cN = hascard(west,NC) cN = hascard(east,ND) keepN = cN and cN          // this is used later w/cN & cN expressions keepN = cN or cN           // this is used later w/cN & cN expressions keepN = keepN and cN keepN = keepN and keepN keepN = keepN and not cN keepN = cN and keepN keepN = cN and not keepN keepN = cN and not cN keepN = cN keepN = keepN or cN keepN = cN or (cN and keepN) keepN = keepN or keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keep   = N keepN  = N levelRaise = nRaises  and keepN levelCue   = nCueBids and keep levelSuit  = nNewSuit and keepN levelNT    = nNotrump and keep levelPunts = nPunts   and keepN levelTheDeal = nRaises or nCueBids or nNewSuit or levelNT or levelPunts eOpens and sOvercalls and wPasses and (nRaises or nCueBids or nNewSuit or nNotrump or nPunts) and levelTheDeal action average \"bench\" hcp(north)",
+      "produced_at_verify": 4,
+      "hit_rate": 0.0002,
+      "seconds_per_deal_r1": 1.02e-06,
+      "deals": 1900000,
+      "cluster_size": 1,
+      "cluster_members": [
+        "After_Partner_Overcalls"
+      ]
+    },
+    {
+      "name": "Major_Suit_Fit",
+      "file": "Major_Suit_Fit.dlr",
+      "source": "Practice-Bidding-Scenarios/dlr/Major_Suit_Fit.dlr",
+      "notes": [
+        "stripped block comments",
+        "replaced action block"
+      ],
+      "imports": [
+        "Predict Opening 1-Bid North"
+      ],
+      "signature": "dealer north ntP = hcp(north) + shape(north,Nxxx+xNxx) ntN = shape(north, any N+any N+any N) and hcp(north)>N and ntP<N ntN = shape(north, any N -Nxxx-xNxx-Nxxx) and hcp(north)>N and hcp(north)<N gibNT = ntN or ntN ssp = spades(north)<N and hcp(north,spades)>N     ? N : N shp = hearts(north)<N and hcp(north,hearts)>N     ? N : N sdp = diamonds(north)<N and hcp(north,diamonds)>N ? N : N scp = clubs(north)<N and hcp(north,clubs)>N       ? N : N svN = shape(north, any Nxxx) ? N : N ssN = shape(north, any Nxxx) ? N : N // allow for N singletons ssN = shape(north, any Nxx) ? N : N sdN = shape(north, any Nxxx) ? N : N // allow for N doubletons sdN = shape(north, any Nxx) ? N : N sdN = shape(north, any Nx) ? N : N nTP = hcp(north) + svN+ssN+ssN+sdN+sdN+sdN -ssp-shp-sdp-scp lpN = spades(north)>N ? spades(north)-N : N lpN = hearts(north)>N ? hearts(north)-N : N lpN = diamonds(north)>N ? diamonds(north)-N : N lpN = clubs(north)>N ? clubs(north)-N : N lengthPoints = lpN + lpN + lpN + lpN suitPoints = hcp(north) + lengthPoints TwoNtShape = shape(north, any N +any N +any N +any N) oneNT   = gibNT twoNT   = TwoNtShape and hcp(north)>N and hcp(north)<N gNShape = shape(north,any Nxxx +any Nxxx +any Nxxx -any Nxxx -any Nxxx -any Nxxx) threeNT = (topN(north,clubs)==N and clubs(north)>N) or (topN(north,diamonds)==N and diamonds(north)>N) and hcp(north)<N and gNShape caseN = hcp(north)>N and nTP>N caseN = hcp(north)>N and nTP>N and losers(north)<N and (spades(north)>N or hearts(north)>N) caseN = hcp(north)>N and nTP>N and losers(north)<N and (diamonds(north)>N or clubs(north)>N) gameForceNC = (caseN or caseN or caseN) PN = gameForceNC PN = PN or threeNT or twoNT or oneNT qNofN = (topN(north,spades)>N or topN(north,hearts)>N) and controls(north)>N lgtN  = (spades(north)>N or hearts(north)>N) and shape(north,any Nxxx +any Nxx +any Nxx +any Nxxx+any Nxxx -any Nxxx -any Nxx) and nTP>(hcp(north) +N) s = spades(north) h = hearts(north) d = diamonds(north) c = clubs(north) lS = s>N and s>=h and s>=d and s>=c lH = h>N and h>s and h>=d and h>=c lM = lS or lH hsOKN = lM and hcp(north)>N hsOKN = lM and hcp(north)>N and nTP>N and not hsOKN hsOKN = lM and hcp(north)>N  and lgtN and qNofN and not (hsOKN or hsOKN) hsRange = (hsOKN or hsOKN or hsOKN) and not PN dOKN = hcp(north)>N and (diamonds(north)>N or shape(north, N)) dOKN = hcp(north)>N  and nTP>N and diamonds(north)>N and not dOKN dRange = (dOKN or dOKN) and not PN cOKN = hcp(north)>N and nTP>N and spades(north)==N cOKN = hcp(north)>N  and nTP>N and clubs(north)>N and not cOKN cOKN = hcp(north)>N and clubs(north)>N            and not (cOKN or cOKN) cRange = (cOKN or cOKN or cOKN) and clubs(north)>N and clubs(north)>diamonds(north) and not PN oS = s>N and s>=h and s>=d and s>=c and hsRange oH = not oS and h>N and h>=d and h>=c and hsRange oD = not (oS or oH) and ((d>N and d>=c) or c<N) and dRange oC = not (oS or oH or oD) and cRange openingSuit = (oS or oH or oD or oC) oneSpade   = oS oneHeart   = oH oneDiamond = oD oneClub    = oC //   Total Points = HCP + Short-Suit Points - Penalty Points //   Short-Suit Points: N for void, N for singleton, N for doubleton //   Penalty Points: N for each honor (K/Q/J) in a short suit (devalues wasted honors like Kx, Qx) nSpadeSSP = spades(north)<N   ? N-spades(north)   : N nHeartSSP = hearts(north)<N   ? N-hearts(north)   : N nDiamSSP  = diamonds(north)<N ? N-diamonds(north) : N nClubSSP  = clubs(north)<N    ? N-clubs(north)    : N nSSP = nSpadeSSP + nHeartSSP + nDiamSSP + nClubSSP nSpadePP = spades(north)<N   and hcp(north,spades)>N   ? N : N nHeartPP = hearts(north)<N   and hcp(north,hearts)>N   ? N : N nDiamPP  = diamonds(north)<N and hcp(north,diamonds)>N ? N : N nClubPP  = clubs(north)<N    and hcp(north,clubs)>N    ? N : N nPP = nSpadePP + nHeartPP + nDiamPP + nClubPP tpNorth = hcp(north) + nSSP - nPP eSpadeSSP = spades(east)<N   ? N-spades(east)   : N eHeartSSP = hearts(east)<N   ? N-hearts(east)   : N eDiamSSP  = diamonds(east)<N ? N-diamonds(east) : N eClubSSP  = clubs(east)<N    ? N-clubs(east)    : N eSSP = eSpadeSSP + eHeartSSP + eDiamSSP + eClubSSP eSpadePP = spades(east)<N   and hcp(east,spades)>N   ? N : N eHeartPP = hearts(east)<N   and hcp(east,hearts)>N   ? N : N eDiamPP  = diamonds(east)<N and hcp(east,diamonds)>N ? N : N eClubPP  = clubs(east)<N    and hcp(east,clubs)>N    ? N : N ePP = eSpadePP + eHeartPP + eDiamPP + eClubPP tpEast = hcp(east) + eSSP - ePP sSpadeSSP = spades(south)<N   ? N-spades(south)   : N sHeartSSP = hearts(south)<N   ? N-hearts(south)   : N sDiamSSP  = diamonds(south)<N ? N-diamonds(south) : N sClubSSP  = clubs(south)<N    ? N-clubs(south)    : N sSSP = sSpadeSSP + sHeartSSP + sDiamSSP + sClubSSP sSpadePP = spades(south)<N   and hcp(south,spades)>N   ? N : N sHeartPP = hearts(south)<N   and hcp(south,hearts)>N   ? N : N sDiamPP  = diamonds(south)<N and hcp(south,diamonds)>N ? N : N sClubPP  = clubs(south)<N    and hcp(south,clubs)>N    ? N : N sPP = sSpadePP + sHeartPP + sDiamPP + sClubPP tpSouth = hcp(south) + sSSP - sPP wSpadeSSP = spades(west)<N   ? N-spades(west)   : N wHeartSSP = hearts(west)<N   ? N-hearts(west)   : N wDiamSSP  = diamonds(west)<N ? N-diamonds(west) : N wClubSSP  = clubs(west)<N    ? N-clubs(west)    : N wSSP = wSpadeSSP + wHeartSSP + wDiamSSP + wClubSSP wSpadePP = spades(west)<N   and hcp(west,spades)>N   ? N : N wHeartPP = hearts(west)<N   and hcp(west,hearts)>N   ? N : N wDiamPP  = diamonds(west)<N and hcp(west,diamonds)>N ? N : N wClubPP  = clubs(west)<N    and hcp(west,clubs)>N    ? N : N wPP = wSpadePP + wHeartPP + wDiamPP + wClubPP tpWest = hcp(west) + wSSP - wPP tpNS = tpNorth + tpSouth tpEW = tpEast + tpWest ePreempt  = shape(east,any Nxxx +any Nxxx +any Nxxx +any Nxxx) and hcp(east)>N eNSuits   = shape(east,any Nxx +any Nxx +any Nxx +any Nxx +any Nxx) and hcp(east)>N eOvercall = shape(east,any Nxxx) and hcp(east)>N ePasses   = hcp(east)<N and not(ePreempt or eNSuits or eOvercall) spadeFitN = oS and spades(south)==N spadeFitN = oS and spades(south)==N spadeFitN = oS and spades(south)>N heartFitN = oH and hearts(south)==N heartFitN = oH and hearts(south)==N heartFitN = oH and hearts(south)>N fitN = spadeFitN or heartFitN fitN = spadeFitN or heartFitN fitN = spadeFitN or heartFitN sP = tpSouth + (fitN and shape(south,xxxx-any N)) Splinter = fitN and shape(south,any Nxxx +any Nxxx) and sP>N and sP<N preempt = sP<N            and fitN faulty  = sP>N  and sP<N  and (fitN or fitN) simple  = sP>N  and sP<N and (fitN or fitN) inviteN = sP>N and sP<N and fitN inviteN = sP>N and sP<N and fitN cN = hascard(west,NC) cN = hascard(east,ND) cN = hascard(west,NC) cN = hascard(east,ND) keepN = cN and cN          // this is used later w/cN & cN expressions keepN = cN or cN           // this is used later w/cN & cN expressions keepN = keepN and cN keepN = keepN and keepN keepN = keepN and not cN keepN = cN and keepN keepN = cN and not keepN keepN = cN and not cN keepN = cN keepN = keepN or cN keepN = cN or (cN and keepN) keepN = keepN or keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keep   = N keepN  = N levN = faulty  and keepN levN = simple  and keepN levN = inviteN and keepN levN = inviteN and keepN levN = preempt and keep levelTheDeal = levN or levN or levN or levN or levN nOpens = (oH or oS) and hcp(north)>N and hcp(north)<N sResponds = (preempt or faulty or simple or inviteN or inviteN) and not Splinter nOpens and ePasses and sResponds and levelTheDeal action average \"bench\" hcp(north)",
+      "produced_at_verify": 48,
+      "hit_rate": 0.0024,
+      "seconds_per_deal_r1": 1.1e-06,
+      "deals": 1800000,
+      "cluster_size": 1,
+      "cluster_members": [
+        "Major_Suit_Fit"
+      ]
+    },
+    {
+      "name": "Drury",
+      "file": "Drury.dlr",
+      "source": "Practice-Bidding-Scenarios/dlr/Drury.dlr",
+      "notes": [
+        "stripped block comments",
+        "dropped 1 produce/generate line(s)",
+        "replaced action block"
+      ],
+      "imports": [
+        "Define Calm Opponents"
+      ],
+      "signature": "dealer south cce = topN(east,clubs)<N cde = topN(east,diamonds)<N che = topN(east,hearts)<N cse = topN(east,spades)<N noConEast = cce and cde and che and cse ccw = topN(west,clubs)<N cdw = topN(west,diamonds)<N chw = topN(west,hearts)<N csw = topN(west,spades)<N noConWest = ccw and cdw and chw and csw balEast    = shape(east,any N +any N) unbalEast  = shape(east,xxxx -any N -any N -any Nxxx -any Nxxx -any Nxxx-any Nxxx -any Nxx) balWest    = shape(west,any N +any N) unbalWest  = shape(west,xxxx -any N -any N -any Nxxx -any Nxxx -any Nxxx-any Nxxx -any Nxx) calmEast = (unbalEast and noConEast and hcp(east)<N) or (balEast and hcp(east)<N) calmWest = (unbalWest and noConWest and hcp(west)<N) or (balWest and hcp(west)<N) calmOpps = calmEast and calmWest //   Total Points = HCP + Short-Suit Points - Penalty Points //   Short-Suit Points: N for void, N for singleton, N for doubleton //   Penalty Points: N for each honor (K/Q/J) in a short suit (devalues wasted honors like Kx, Qx) nSpadeSSP = spades(north)<N   ? N-spades(north)   : N nHeartSSP = hearts(north)<N   ? N-hearts(north)   : N nDiamSSP  = diamonds(north)<N ? N-diamonds(north) : N nClubSSP  = clubs(north)<N    ? N-clubs(north)    : N nSSP = nSpadeSSP + nHeartSSP + nDiamSSP + nClubSSP nSpadePP = spades(north)<N   and hcp(north,spades)>N   ? N : N nHeartPP = hearts(north)<N   and hcp(north,hearts)>N   ? N : N nDiamPP  = diamonds(north)<N and hcp(north,diamonds)>N ? N : N nClubPP  = clubs(north)<N    and hcp(north,clubs)>N    ? N : N nPP = nSpadePP + nHeartPP + nDiamPP + nClubPP tpNorth = hcp(north) + nSSP - nPP eSpadeSSP = spades(east)<N   ? N-spades(east)   : N eHeartSSP = hearts(east)<N   ? N-hearts(east)   : N eDiamSSP  = diamonds(east)<N ? N-diamonds(east) : N eClubSSP  = clubs(east)<N    ? N-clubs(east)    : N eSSP = eSpadeSSP + eHeartSSP + eDiamSSP + eClubSSP eSpadePP = spades(east)<N   and hcp(east,spades)>N   ? N : N eHeartPP = hearts(east)<N   and hcp(east,hearts)>N   ? N : N eDiamPP  = diamonds(east)<N and hcp(east,diamonds)>N ? N : N eClubPP  = clubs(east)<N    and hcp(east,clubs)>N    ? N : N ePP = eSpadePP + eHeartPP + eDiamPP + eClubPP tpEast = hcp(east) + eSSP - ePP sSpadeSSP = spades(south)<N   ? N-spades(south)   : N sHeartSSP = hearts(south)<N   ? N-hearts(south)   : N sDiamSSP  = diamonds(south)<N ? N-diamonds(south) : N sClubSSP  = clubs(south)<N    ? N-clubs(south)    : N sSSP = sSpadeSSP + sHeartSSP + sDiamSSP + sClubSSP sSpadePP = spades(south)<N   and hcp(south,spades)>N   ? N : N sHeartPP = hearts(south)<N   and hcp(south,hearts)>N   ? N : N sDiamPP  = diamonds(south)<N and hcp(south,diamonds)>N ? N : N sClubPP  = clubs(south)<N    and hcp(south,clubs)>N    ? N : N sPP = sSpadePP + sHeartPP + sDiamPP + sClubPP tpSouth = hcp(south) + sSSP - sPP wSpadeSSP = spades(west)<N   ? N-spades(west)   : N wHeartSSP = hearts(west)<N   ? N-hearts(west)   : N wDiamSSP  = diamonds(west)<N ? N-diamonds(west) : N wClubSSP  = clubs(west)<N    ? N-clubs(west)    : N wSSP = wSpadeSSP + wHeartSSP + wDiamSSP + wClubSSP wSpadePP = spades(west)<N   and hcp(west,spades)>N   ? N : N wHeartPP = hearts(west)<N   and hcp(west,hearts)>N   ? N : N wDiamPP  = diamonds(west)<N and hcp(west,diamonds)>N ? N : N wClubPP  = clubs(west)<N    and hcp(west,clubs)>N    ? N : N wPP = wSpadePP + wHeartPP + wDiamPP + wClubPP tpWest = hcp(west) + wSSP - wPP tpNS = tpNorth + tpSouth tpEW = tpEast + tpWest sPasses   = tpSouth<N and hcp(south)<N and shape(south,any xxxx -any Nxxx -any Nxxx -any Nxxx -any Nxxx -any Nxx) rebiddableD = diamonds(south)==N and hcp(south,diamonds)>N rebbidableC = clubs(south)==N    and hcp(south,clubs)>N sSJS = (rebiddableD or rebbidableC) and hcp(south)>N and tpSouth>N nBal = shape(north,any N+any N+any N) nNNT = nBal and hcp(north)>N and hcp(north)<N nNNT = nBal and hcp(north)>N and hcp(north)<N nNT = nNNT or nNNT //nMin = tpNorth==N and hcp(north)==N nSpade = spades(north)>N and hearts(north)<N and diamonds(north)<N and clubs(north)<N and spades(south)>N and hearts(south)<N nHeart = hearts(north)>N and spades(north)<N and diamonds(north)<N and clubs(north)<N and hearts(south)>N and spades(south)<N len = hearts(north)>spades(north) ? hearts(north) : spades(north) nMin = len == N ? N : N nRange = hcp(north)>nMin and hcp(north)<N nOpens = (nSpade or nHeart) and nRange and not nNT and diamonds(north)<len and clubs(north)<len sResponds = tpSouth>N and not sSJS cN = hascard(west,NC) cN = hascard(east,ND) cN = hascard(west,NC) cN = hascard(east,ND) keepN = cN and cN          // this is used later w/cN & cN expressions keepN = cN or cN           // this is used later w/cN & cN expressions keepN = keepN and cN keepN = keepN and keepN keepN = keepN and not cN keepN = cN and keepN keepN = cN and not keepN keepN = cN and not cN keepN = cN keepN = keepN or cN keepN = cN or (cN and keepN) keepN = keepN or keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keep   = N keepN  = N nLow  = hcp(north) < N nMid  = hcp(north) > N and hcp(north) < N nHigh = hcp(north) > N levLow  = nLow  and keep levMid  = nMid  and keepN levHigh = nHigh and keepN levelTheDeal = levLow or levMid or levHigh sPasses and nOpens and calmOpps and sResponds and levelTheDeal action average \"bench\" hcp(north)",
+      "produced_at_verify": 1,
+      "hit_rate": 5e-05,
+      "seconds_per_deal_r1": 1.2700000000000001e-06,
+      "deals": 1500000,
+      "cluster_size": 1,
+      "cluster_members": [
+        "Drury"
+      ]
+    },
+    {
+      "name": "Basic_Takeout_Double",
+      "file": "Basic_Takeout_Double.dlr",
+      "source": "Practice-Bidding-Scenarios/dlr/Basic_Takeout_Double.dlr",
+      "notes": [
+        "stripped block comments",
+        "replaced action block"
+      ],
+      "imports": [
+        "Predict Opening 1-Bid East"
+      ],
+      "signature": "dealer east ntP = hcp(east) + shape(east,Nxxx+xNxx) ntN = shape(east, any N+any N+any N) and hcp(east)>N and ntP<N ntN = shape(east, any N -Nxxx-xNxx-Nxxx) and hcp(east)>N and hcp(east)<N gibNT = ntN or ntN ssp = spades(east)<N and hcp(east,spades)>N     ? N : N shp = hearts(east)<N and hcp(east,hearts)>N     ? N : N sdp = diamonds(east)<N and hcp(east,diamonds)>N ? N : N scp = clubs(east)<N and hcp(east,clubs)>N       ? N : N svN = shape(east, any Nxxx) ? N : N ssN = shape(east, any Nxxx) ? N : N // allow for N singletons ssN = shape(east, any Nxx) ? N : N sdN = shape(east, any Nxxx) ? N : N // allow for N doubletons sdN = shape(east, any Nxx) ? N : N sdN = shape(east, any Nx) ? N : N sTP = hcp(east) + svN+ssN+ssN+sdN+sdN+sdN -ssp-shp-sdp-scp lpN = spades(east)>N ? spades(east)-N : N lpN = hearts(east)>N ? hearts(east)-N : N lpN = diamonds(east)>N ? diamonds(east)-N : N lpN = clubs(east)>N ? clubs(east)-N : N lengthPoints = lpN + lpN + lpN + lpN suitPoints = hcp(east) + lengthPoints TwoNtShape = shape(east, any N +any N +any N +any N) oneNT   = gibNT twoNT   = TwoNtShape and hcp(east)>N and hcp(east)<N gNShape = shape(east,any Nxxx +any Nxxx +any Nxxx -any Nxxx -any Nxxx -any Nxxx) gambleN = (topN(east,clubs)==N and clubs(east)>N) or (topN(east,diamonds)==N and diamonds(east)>N) and hcp(east)<N and gNShape caseN = hcp(east)>N and sTP>N caseN = hcp(east)>N and sTP>N and losers(east)<N and (spades(east)>N or hearts(east)>N) caseN = hcp(east)>N and sTP>N and losers(east)<N and (diamonds(east)>N or clubs(east)>N) gameForceNC = (caseN or caseN or caseN) PN = gameForceNC PN = PN or gambleN or twoNT or oneNT qNofN = (topN(east,spades)>N or topN(east,hearts)>N) and controls(east)>N lgtN  = (spades(east)>N or hearts(east)>N) and shape(east,any Nxxx +any Nxx +any Nxx +any Nxxx+any Nxxx -any Nxxx -any Nxx) and sTP>(hcp(east) +N) s = spades(east) h = hearts(east) d = diamonds(east) c = clubs(east) lS = s>N and s>=h and s>=d and s>=c lH = h>N and h>s and h>=d and h>=c lM = lS or lH hsOKN = lM and hcp(east)>N hsOKN = lM and hcp(east)>N and sTP>N and not hsOKN hsOKN = lM and hcp(east)>N  and lgtN and qNofN and not (hsOKN or hsOKN) hsRange = (hsOKN or hsOKN or hsOKN) and not PN dOKN = hcp(east)>N and (diamonds(east)>N or shape(east, N)) dOKN = hcp(east)>N  and sTP>N and diamonds(east)>N and not dOKN dRange = (dOKN or dOKN) and not PN cOKN = hcp(east)>N and sTP>N and spades(east)==N cOKN = hcp(east)>N  and sTP>N and clubs(east)>N and not cOKN cOKN = hcp(east)>N and clubs(east)>N            and not (cOKN or cOKN) cRange = (cOKN or cOKN or cOKN) and clubs(east)>N and clubs(east)>diamonds(east) and not PN oS = s>N and s>=h and s>=d and s>=c and hsRange oH = not oS and h>N and h>=d and h>=c and hsRange oD = not (oS or oH) and ((d>N and d>=c) or c<N) and dRange oC = not (oS or oH or oD) and cRange openingSuit = (oS or oH or oD or oC) oneSpade   = oS oneHeart   = oH oneDiamond = oD oneClub    = oC eNotNT   = not gibNT eastHand = openingSuit and eNotNT sHcp     = hcp(south) > N and hcp(south) < N sShape   = shape(south, any N + any N) sNoLong  = spades(south) < N and hearts(south) < N and diamonds(south) < N and clubs(south) < N sShortInOpener = (oS and spades(south) < N) or (oH and hearts(south) < N) or (oD and diamonds(south) < N) or (oC and clubs(south) < N) southHand = sHcp and sShape and sNoLong and sShortInOpener wHcp = hcp(west) < N eastHand and southHand and wHcp action average \"bench\" hcp(north)",
+      "produced_at_verify": 107,
+      "hit_rate": 0.00535,
+      "seconds_per_deal_r1": 1.7e-06,
+      "deals": 1100000,
+      "cluster_size": 1,
+      "cluster_members": [
+        "Basic_Takeout_Double"
+      ]
+    },
+    {
+      "name": "GIB_1C-P-Resp",
+      "file": "GIB_1C-P-Resp.dlr",
+      "source": "Practice-Bidding-Scenarios/dlr/GIB_1C-P-Resp.dlr",
+      "notes": [
+        "stripped block comments",
+        "replaced action block"
+      ],
+      "imports": [
+        "Define Calm Opponents",
+        "Predict Opening 1-Bid North"
+      ],
+      "signature": "dealer north cce = topN(east,clubs)<N cde = topN(east,diamonds)<N che = topN(east,hearts)<N cse = topN(east,spades)<N noConEast = cce and cde and che and cse ccw = topN(west,clubs)<N cdw = topN(west,diamonds)<N chw = topN(west,hearts)<N csw = topN(west,spades)<N noConWest = ccw and cdw and chw and csw balEast    = shape(east,any N +any N) unbalEast  = shape(east,xxxx -any N -any N -any Nxxx -any Nxxx -any Nxxx-any Nxxx -any Nxx) balWest    = shape(west,any N +any N) unbalWest  = shape(west,xxxx -any N -any N -any Nxxx -any Nxxx -any Nxxx-any Nxxx -any Nxx) calmEast = (unbalEast and noConEast and hcp(east)<N) or (balEast and hcp(east)<N) calmWest = (unbalWest and noConWest and hcp(west)<N) or (balWest and hcp(west)<N) calmOpps = calmEast and calmWest ntP = hcp(north) + shape(north,Nxxx+xNxx) ntN = shape(north, any N+any N+any N) and hcp(north)>N and ntP<N ntN = shape(north, any N -Nxxx-xNxx-Nxxx) and hcp(north)>N and hcp(north)<N gibNT = ntN or ntN ssp = spades(north)<N and hcp(north,spades)>N     ? N : N shp = hearts(north)<N and hcp(north,hearts)>N     ? N : N sdp = diamonds(north)<N and hcp(north,diamonds)>N ? N : N scp = clubs(north)<N and hcp(north,clubs)>N       ? N : N svN = shape(north, any Nxxx) ? N : N ssN = shape(north, any Nxxx) ? N : N // allow for N singletons ssN = shape(north, any Nxx) ? N : N sdN = shape(north, any Nxxx) ? N : N // allow for N doubletons sdN = shape(north, any Nxx) ? N : N sdN = shape(north, any Nx) ? N : N nTP = hcp(north) + svN+ssN+ssN+sdN+sdN+sdN -ssp-shp-sdp-scp lpN = spades(north)>N ? spades(north)-N : N lpN = hearts(north)>N ? hearts(north)-N : N lpN = diamonds(north)>N ? diamonds(north)-N : N lpN = clubs(north)>N ? clubs(north)-N : N lengthPoints = lpN + lpN + lpN + lpN suitPoints = hcp(north) + lengthPoints TwoNtShape = shape(north, any N +any N +any N +any N) oneNT   = gibNT twoNT   = TwoNtShape and hcp(north)>N and hcp(north)<N gNShape = shape(north,any Nxxx +any Nxxx +any Nxxx -any Nxxx -any Nxxx -any Nxxx) threeNT = (topN(north,clubs)==N and clubs(north)>N) or (topN(north,diamonds)==N and diamonds(north)>N) and hcp(north)<N and gNShape caseN = hcp(north)>N and nTP>N caseN = hcp(north)>N and nTP>N and losers(north)<N and (spades(north)>N or hearts(north)>N) caseN = hcp(north)>N and nTP>N and losers(north)<N and (diamonds(north)>N or clubs(north)>N) gameForceNC = (caseN or caseN or caseN) PN = gameForceNC PN = PN or threeNT or twoNT or oneNT qNofN = (topN(north,spades)>N or topN(north,hearts)>N) and controls(north)>N lgtN  = (spades(north)>N or hearts(north)>N) and shape(north,any Nxxx +any Nxx +any Nxx +any Nxxx+any Nxxx -any Nxxx -any Nxx) and nTP>(hcp(north) +N) s = spades(north) h = hearts(north) d = diamonds(north) c = clubs(north) lS = s>N and s>=h and s>=d and s>=c lH = h>N and h>s and h>=d and h>=c lM = lS or lH hsOKN = lM and hcp(north)>N hsOKN = lM and hcp(north)>N and nTP>N and not hsOKN hsOKN = lM and hcp(north)>N  and lgtN and qNofN and not (hsOKN or hsOKN) hsRange = (hsOKN or hsOKN or hsOKN) and not PN dOKN = hcp(north)>N and (diamonds(north)>N or shape(north, N)) dOKN = hcp(north)>N  and nTP>N and diamonds(north)>N and not dOKN dRange = (dOKN or dOKN) and not PN cOKN = hcp(north)>N and nTP>N and spades(north)==N cOKN = hcp(north)>N  and nTP>N and clubs(north)>N and not cOKN cOKN = hcp(north)>N and clubs(north)>N            and not (cOKN or cOKN) cRange = (cOKN or cOKN or cOKN) and clubs(north)>N and clubs(north)>diamonds(north) and not PN oS = s>N and s>=h and s>=d and s>=c and hsRange oH = not oS and h>N and h>=d and h>=c and hsRange oD = not (oS or oH) and ((d>N and d>=c) or c<N) and dRange oC = not (oS or oH or oD) and cRange openingSuit = (oS or oH or oD or oC) oneSpade   = oS oneHeart   = oH oneDiamond = oD oneClub    = oC //   Total Points = HCP + Short-Suit Points - Penalty Points //   Short-Suit Points: N for void, N for singleton, N for doubleton //   Penalty Points: N for each honor (K/Q/J) in a short suit (devalues wasted honors like Kx, Qx) nSpadeSSP = spades(north)<N   ? N-spades(north)   : N nHeartSSP = hearts(north)<N   ? N-hearts(north)   : N nDiamSSP  = diamonds(north)<N ? N-diamonds(north) : N nClubSSP  = clubs(north)<N    ? N-clubs(north)    : N nSSP = nSpadeSSP + nHeartSSP + nDiamSSP + nClubSSP nSpadePP = spades(north)<N   and hcp(north,spades)>N   ? N : N nHeartPP = hearts(north)<N   and hcp(north,hearts)>N   ? N : N nDiamPP  = diamonds(north)<N and hcp(north,diamonds)>N ? N : N nClubPP  = clubs(north)<N    and hcp(north,clubs)>N    ? N : N nPP = nSpadePP + nHeartPP + nDiamPP + nClubPP tpNorth = hcp(north) + nSSP - nPP eSpadeSSP = spades(east)<N   ? N-spades(east)   : N eHeartSSP = hearts(east)<N   ? N-hearts(east)   : N eDiamSSP  = diamonds(east)<N ? N-diamonds(east) : N eClubSSP  = clubs(east)<N    ? N-clubs(east)    : N eSSP = eSpadeSSP + eHeartSSP + eDiamSSP + eClubSSP eSpadePP = spades(east)<N   and hcp(east,spades)>N   ? N : N eHeartPP = hearts(east)<N   and hcp(east,hearts)>N   ? N : N eDiamPP  = diamonds(east)<N and hcp(east,diamonds)>N ? N : N eClubPP  = clubs(east)<N    and hcp(east,clubs)>N    ? N : N ePP = eSpadePP + eHeartPP + eDiamPP + eClubPP tpEast = hcp(east) + eSSP - ePP sSpadeSSP = spades(south)<N   ? N-spades(south)   : N sHeartSSP = hearts(south)<N   ? N-hearts(south)   : N sDiamSSP  = diamonds(south)<N ? N-diamonds(south) : N sClubSSP  = clubs(south)<N    ? N-clubs(south)    : N sSSP = sSpadeSSP + sHeartSSP + sDiamSSP + sClubSSP sSpadePP = spades(south)<N   and hcp(south,spades)>N   ? N : N sHeartPP = hearts(south)<N   and hcp(south,hearts)>N   ? N : N sDiamPP  = diamonds(south)<N and hcp(south,diamonds)>N ? N : N sClubPP  = clubs(south)<N    and hcp(south,clubs)>N    ? N : N sPP = sSpadePP + sHeartPP + sDiamPP + sClubPP tpSouth = hcp(south) + sSSP - sPP wSpadeSSP = spades(west)<N   ? N-spades(west)   : N wHeartSSP = hearts(west)<N   ? N-hearts(west)   : N wDiamSSP  = diamonds(west)<N ? N-diamonds(west) : N wClubSSP  = clubs(west)<N    ? N-clubs(west)    : N wSSP = wSpadeSSP + wHeartSSP + wDiamSSP + wClubSSP wSpadePP = spades(west)<N   and hcp(west,spades)>N   ? N : N wHeartPP = hearts(west)<N   and hcp(west,hearts)>N   ? N : N wDiamPP  = diamonds(west)<N and hcp(west,diamonds)>N ? N : N wClubPP  = clubs(west)<N    and hcp(west,clubs)>N    ? N : N wPP = wSpadePP + wHeartPP + wDiamPP + wClubPP tpWest = hcp(west) + wSSP - wPP tpNS = tpNorth + tpSouth tpEW = tpEast + tpWest eAS = hascard(east,AS) eKS = hascard(east,KS) eQS = hascard(east,QS) eJS = hascard(east,JS) eTS = hascard(east,TS) eNS = hascard(east,NS) eAH = hascard(east,AH) eKH = hascard(east,KH) eQH = hascard(east,QH) eJH = hascard(east,JH) eTH = hascard(east,TH) eNH = hascard(east,NH) eAD = hascard(east,AD) eKD = hascard(east,KD) eQD = hascard(east,QD) eJD = hascard(east,JD) eTD = hascard(east,TD) eND = hascard(east,ND) eSN = ((eAS and eKS) or (eAS and eQS and (eJS or eTS or eNS)) or (eAS and eJS and eTS and eNS) or (eKS and eQS and (eJS or eTS))) and spades(east)==N eHN = ((eAH and eKH) or (eAH and eQH and (eJH or eTH or eNH)) or (eAH and eJH and eTH and eNH) or (eKH and eQH and (eJH or eTH))) and hearts(east)==N eDN = ((eAD and eKD) or (eAD and eQD and (eJD or eTD or eND)) or (eAD and eJD and eTD and eND) or (eKD and eQD and (eJD or eTD))) and diamonds(east)==N ess = (eSN and eHN) or (eSN and eDN) or (eHN or eDN) X = (hcp(east)==N or hcp(east)==N) and spades(east)==hearts(east)==(N or N)  // I'm out of 'shape' statements reverse = shape(north,Nxx+xNx+xxN) and hcp(north)>N eRange = tpEast>=N and tpEast<=N and not X cOC = oneClub    and (eDN or eHN or eSN) and clubs(east)==N dOC = oneDiamond and (eHN or eSN)        and diamonds(east)==N hOC = oneHeart   and eSN                 and hearts(east)==N eOvercalls = (cOC or dOC or hOC) and eRange and shape(east,any N +any N) eTakeOutDouble = (balEast and hcp(east)>N and clubs(east)==N) or (balWest and hcp(west)>N and clubs(west)==N)  // Must know opening suit oppsPass = calmOpps and not (eOvercalls or eTakeOutDouble) sC = clubs(south) sD = diamonds(south) sH = hearts(south) sS = spades(south) sRS = sS>N or (sS==N and topN(south,spades)>N) sRH = sH>N or (sH==N and topN(south,hearts)>N) sRD = sD>N or (sD==N and topN(south,diamonds)>N) sRC = sC>N or (sC==N and topN(south,clubs)>N) sRebiddableSuit = sRS or sRH or sRD or sRC dStop = (hcp(south,diamonds) + sD)>N ? N : N      // Dealer doesn't allow fractions; so N pts for stop hStop = (hcp(south,hearts)   + sH)>N ? N : N sStop = (hcp(south,spades)   + sS)>N ? N : N dHalf = not dStop and ((hcp(south,diamonds)>N) + sD)==N   // and N pt for half-stop: any N-cards or honor doubleton hHalf = not hStop and ((hcp(south,hearts)>N)   + sH)==N sHalf = not sStop and ((hcp(south,spades)>N)   + sS)==N stops = dStop + hStop + sStop + dHalf + hHalf +sHalf sN = sS==N and sH==N  and sD==N sN = sS==N and sH==N  and sD==N sxxN = (sS==N or sS==N) and sD==N and sC==N  // N or N sBal  = (sN or sN or sxxN)  // no N-card major sRange = sRebiddableSuit ? tpSouth>N and tpSouth<N : tpSouth>N   // no upper range without rebiddable suit rSN = sS>N and sS>=sH                   // higher ranking of N+card suits rSN = tpSouth<N and sS==N and sS>sH        // skip longer D w/<N rSN = sS==N and sS>sH and sD<N          // prefer N-card H/S to N-card D rNS = rSN or rSN or rSN rHN = sH>N and sH>sS rHN = tpSouth<N and sH==N and sH>=sS rHN = sH==N and sD<N rNH = (rHN or rHN or rHN) and not rNS rM = rNH or rNS rNx   = sC>N and shape(south,N+N+any Nxxx +any Nxxx) and tpSouth>N and not rM    // splinter rNCN = sN       and hcp(south)>N  and hcp(south)<N and stops<N and not rM rNCN = sxxN       and hcp(south)>N  and hcp(south)<N and stops<N and not rM rNCNN = sN+sxxN and hcp(south)>N and hcp(south)<N             and not rM          // GIB goes through NC w/a bal N-N rNCxN = sC>N        and sD<N and hcp(south)>N                       and not (rM or rNx) rNC = rNCN or rNCN or rNCNN or rNCxN rNC = sC>N and sD<N and hcp(south)<N and tpSouth>N                     and not (rM or rNx) rC  = rNCN or rNCN or rNCNN or rNCxN or rNC or rNx rNN  = hcp(south)>N  and hcp(south)<N and sBal and not rC rNNa = hcp(south)>N and hcp(south)<N and sxxN and stops>N and hcp(south,diamonds)>N and not rC // prefer ND or NC rNNb = hcp(south)>N and hcp(south)<N and sN and stops>N                           and not rC // no alternative rNNc = hcp(south)>N and hcp(south)<N and sN and stops>N                           and not rC // prefer ND rNN = rNNa or rNNb or rNNc rNN = sN and hcp(south)>N and hcp(south)<N  and sBal  and stops>N                 and not rC rN  = rNN or rNN or rNN rND = sD>N and not (rM or rN or rC) // Change the following line to get the responses you want -------- // sResponds = rND or rNH or rNS or rNN or rNC or rNN or rNC or rNx or rNN // // ---------------------------------------------------------------- oneClub and not eOvercalls and sRange and sResponds and oppsPass action average \"bench\" hcp(north)",
+      "produced_at_verify": 111,
+      "hit_rate": 0.00555,
+      "seconds_per_deal_r1": 1.9e-06,
+      "deals": 1000000,
+      "cluster_size": 1,
+      "cluster_members": [
+        "GIB_1C-P-Resp"
+      ]
+    },
+    {
+      "name": "Splinters_By_Opener",
+      "file": "Splinters_By_Opener.dlr",
+      "source": "Practice-Bidding-Scenarios/dlr/Splinters_By_Opener.dlr",
+      "notes": [
+        "stripped block comments",
+        "dropped 1 produce/generate line(s)",
+        "replaced action block"
+      ],
+      "imports": [
+        "Define Calm Opponents",
+        "Predict Opening 1-Bid South"
+      ],
+      "signature": "dealer south cce = topN(east,clubs)<N cde = topN(east,diamonds)<N che = topN(east,hearts)<N cse = topN(east,spades)<N noConEast = cce and cde and che and cse ccw = topN(west,clubs)<N cdw = topN(west,diamonds)<N chw = topN(west,hearts)<N csw = topN(west,spades)<N noConWest = ccw and cdw and chw and csw balEast    = shape(east,any N +any N) unbalEast  = shape(east,xxxx -any N -any N -any Nxxx -any Nxxx -any Nxxx-any Nxxx -any Nxx) balWest    = shape(west,any N +any N) unbalWest  = shape(west,xxxx -any N -any N -any Nxxx -any Nxxx -any Nxxx-any Nxxx -any Nxx) calmEast = (unbalEast and noConEast and hcp(east)<N) or (balEast and hcp(east)<N) calmWest = (unbalWest and noConWest and hcp(west)<N) or (balWest and hcp(west)<N) calmOpps = calmEast and calmWest ntP = hcp(south) + shape(south,Nxxx+xNxx) ntN = shape(south, any N+any N+any N) and hcp(south)>N and ntP<N ntN = shape(south, any N -Nxxx-xNxx-Nxxx) and hcp(south)>N and hcp(south)<N gibNT = ntN or ntN ssp = spades(south)<N and hcp(south,spades)>N     ? N : N shp = hearts(south)<N and hcp(south,hearts)>N     ? N : N sdp = diamonds(south)<N and hcp(south,diamonds)>N ? N : N scp = clubs(south)<N and hcp(south,clubs)>N       ? N : N svN = shape(south, any Nxxx) ? N : N ssN = shape(south, any Nxxx) ? N : N // allow for N singletons ssN = shape(south, any Nxx) ? N : N sdN = shape(south, any Nxxx) ? N : N // allow for N doubletons sdN = shape(south, any Nxx) ? N : N sdN = shape(south, any Nx) ? N : N sTP = hcp(south) + svN+ssN+ssN+sdN+sdN+sdN -ssp-shp-sdp-scp lpN = spades(south)>N ? spades(south)-N : N lpN = hearts(south)>N ? hearts(south)-N : N lpN = diamonds(south)>N ? diamonds(south)-N : N lpN = clubs(south)>N ? clubs(south)-N : N lengthPoints = lpN + lpN + lpN + lpN suitPoints = hcp(south) + lengthPoints TwoNtShape = shape(south, any N +any N +any N +any N) oneNT   = gibNT twoNT   = TwoNtShape and hcp(south)>N and hcp(south)<N gNShape = shape(south,any Nxxx +any Nxxx +any Nxxx -any Nxxx -any Nxxx -any Nxxx) threeNT = (topN(south,clubs)==N and clubs(south)>N) or (topN(south,diamonds)==N and diamonds(south)>N) and hcp(south)<N and gNShape caseN = hcp(south)>N and sTP>N caseN = hcp(south)>N and sTP>N and losers(south)<N and (spades(south)>N or hearts(south)>N) caseN = hcp(south)>N and sTP>N and losers(south)<N and (diamonds(south)>N or clubs(south)>N) gameForceNC = (caseN or caseN or caseN) PN = gameForceNC PN = PN or threeNT or twoNT or oneNT qNofN = (topN(south,spades)>N or topN(south,hearts)>N) and controls(south)>N lgtN  = (spades(south)>N or hearts(south)>N) and shape(south,any Nxxx +any Nxx +any Nxx +any Nxxx+any Nxxx -any Nxxx -any Nxx) and sTP>(hcp(south) +N) s = spades(south) h = hearts(south) d = diamonds(south) c = clubs(south) lS = s>N and s>=h and s>=d and s>=c lH = h>N and h>s and h>=d and h>=c lM = lS or lH hsOKN = lM and hcp(south)>N hsOKN = lM and hcp(south)>N and sTP>N and not hsOKN hsOKN = lM and hcp(south)>N  and lgtN and qNofN and not (hsOKN or hsOKN) hsRange = (hsOKN or hsOKN or hsOKN) and not PN dOKN = hcp(south)>N and (diamonds(south)>N or shape(south, N)) dOKN = hcp(south)>N  and sTP>N and diamonds(south)>N and not dOKN dRange = (dOKN or dOKN) and not PN cOKN = hcp(south)>N and sTP>N and spades(south)==N cOKN = hcp(south)>N  and sTP>N and clubs(south)>N and not cOKN cOKN = hcp(south)>N and clubs(south)>N            and not (cOKN or cOKN) cRange = (cOKN or cOKN or cOKN) and clubs(south)>N and clubs(south)>diamonds(south) and not PN oS = s>N and s>=h and s>=d and s>=c and hsRange oH = not oS and h>N and h>=d and h>=c and hsRange oD = not (oS or oH) and ((d>N and d>=c) or c<N) and dRange oC = not (oS or oH or oD) and cRange openingSuit = (oS or oH or oD or oC) oneSpade   = oS oneHeart   = oH oneDiamond = oD oneClub    = oC sP = hcp(south) nP = hcp(north) sN = spades(north) hN = hearts(north) dN = diamonds(north) cN = clubs(north) nRS  =  nP<N ? sN>N and sN>hN : sN>N and sN>hN and sN>=dN and sN>=cN               // avoid N/N in minor nRH  = (nP<N ? hN>N           : hN>N           and hN>=dN and hN>=cN) and not (nRS) nRD = dN>N           and dN>=cN and not (nRS or nRH) nRC = cN>N           and cN>N   and not (nRS or nRH or nRD) nRN = not (nRS or nRH or nRD or nRC) sRC = clubs(south)>N sRD = diamonds(south)>N sRH = hearts(south)>N sRS = spades(south)>N sRN = shape(south,any N+any N+any N) CD = oC and nRD CH = oC and nRH CS = oC and nRS CN = oC and nRN CC = oC and nRC DH = oD and nRH DS = oD and nRS DN = oD and nRN DD = oD and not (DH or DS or DN) HS = sP<N ? oH and nRS and hN<N : oH and nRS and hN<N     // no Jacoby NN HN = oH and nRN HH = oH and not (HS or HN) Cshort = (shape(south,xxxN) and (topN(south,clubs)   ==N or hascard(south,AC)) or shape(south,xxxN)) Dshort = (shape(south,xxNx) and (topN(south,diamonds)==N or hascard(south,AD)) or shape(south,xxNx)) Hshort = (shape(south,xNxx) and (topN(south,hearts)  ==N or hascard(south,AH)) or shape(south,xNxx)) Sshort = (shape(south,Nxxx) and (topN(south,spades)  ==N or hascard(south,AS)) or shape(south,Nxxx)) CHND = CH and h>N and Dshort  // invite CHNS = CH and h>N and Sshort CSND = CS and s>N and Dshort  // invite CSNH = CS and s>N and Hshort  // invite DHNC = DH and h>N and Cshort DHNS = DH and h>N and Sshort DSNC = DS and s>N and Cshort DSNH = DS and s>N and Hshort  // invite HSNC = HS and s>N and Cshort HSND = HS and s>N and Dshort jReverse   = (CHND or CSND or CSNH or DSNH) and hcp(south)>N and hcp(south)<N jJumpShift = (CHNS or DHNC or DHNS or DSNC or HSNC or HSND) and hcp(south)>N and hcp(south)<N northOK = N sOpens = jReverse or jJumpShift northRange = hcp(north)>N  and hcp(north)<N  // no jump shifts sOpens and northRange and calmOpps action average \"bench\" hcp(north)",
+      "produced_at_verify": 6,
+      "hit_rate": 0.0003,
+      "seconds_per_deal_r1": 2.4e-06,
+      "deals": 830000,
+      "cluster_size": 2,
+      "cluster_members": [
+        "Reversed_Splinters_By_Opener",
+        "Splinters_By_Opener"
+      ]
+    },
+    {
+      "name": "Gerber_By_Responder",
+      "file": "Gerber_By_Responder.dlr",
+      "source": "Practice-Bidding-Scenarios/dlr/Gerber_By_Responder.dlr",
+      "notes": [
+        "stripped block comments",
+        "dropped 1 produce/generate line(s)",
+        "replaced action block"
+      ],
+      "imports": [
+        "Predict Opening 1-Bid South"
+      ],
+      "signature": "dealer south ntP = hcp(south) + shape(south,Nxxx+xNxx) ntN = shape(south, any N+any N+any N) and hcp(south)>N and ntP<N ntN = shape(south, any N -Nxxx-xNxx-Nxxx) and hcp(south)>N and hcp(south)<N gibNT = ntN or ntN ssp = spades(south)<N and hcp(south,spades)>N     ? N : N shp = hearts(south)<N and hcp(south,hearts)>N     ? N : N sdp = diamonds(south)<N and hcp(south,diamonds)>N ? N : N scp = clubs(south)<N and hcp(south,clubs)>N       ? N : N svN = shape(south, any Nxxx) ? N : N ssN = shape(south, any Nxxx) ? N : N // allow for N singletons ssN = shape(south, any Nxx) ? N : N sdN = shape(south, any Nxxx) ? N : N // allow for N doubletons sdN = shape(south, any Nxx) ? N : N sdN = shape(south, any Nx) ? N : N sTP = hcp(south) + svN+ssN+ssN+sdN+sdN+sdN -ssp-shp-sdp-scp lpN = spades(south)>N ? spades(south)-N : N lpN = hearts(south)>N ? hearts(south)-N : N lpN = diamonds(south)>N ? diamonds(south)-N : N lpN = clubs(south)>N ? clubs(south)-N : N lengthPoints = lpN + lpN + lpN + lpN suitPoints = hcp(south) + lengthPoints TwoNtShape = shape(south, any N +any N +any N +any N) oneNT   = gibNT twoNT   = TwoNtShape and hcp(south)>N and hcp(south)<N gNShape = shape(south,any Nxxx +any Nxxx +any Nxxx -any Nxxx -any Nxxx -any Nxxx) threeNT = (topN(south,clubs)==N and clubs(south)>N) or (topN(south,diamonds)==N and diamonds(south)>N) and hcp(south)<N and gNShape caseN = hcp(south)>N and sTP>N caseN = hcp(south)>N and sTP>N and losers(south)<N and (spades(south)>N or hearts(south)>N) caseN = hcp(south)>N and sTP>N and losers(south)<N and (diamonds(south)>N or clubs(south)>N) gameForceNC = (caseN or caseN or caseN) PN = gameForceNC PN = PN or threeNT or twoNT or oneNT qNofN = (topN(south,spades)>N or topN(south,hearts)>N) and controls(south)>N lgtN  = (spades(south)>N or hearts(south)>N) and shape(south,any Nxxx +any Nxx +any Nxx +any Nxxx+any Nxxx -any Nxxx -any Nxx) and sTP>(hcp(south) +N) s = spades(south) h = hearts(south) d = diamonds(south) c = clubs(south) lS = s>N and s>=h and s>=d and s>=c lH = h>N and h>s and h>=d and h>=c lM = lS or lH hsOKN = lM and hcp(south)>N hsOKN = lM and hcp(south)>N and sTP>N and not hsOKN hsOKN = lM and hcp(south)>N  and lgtN and qNofN and not (hsOKN or hsOKN) hsRange = (hsOKN or hsOKN or hsOKN) and not PN dOKN = hcp(south)>N and (diamonds(south)>N or shape(south, N)) dOKN = hcp(south)>N  and sTP>N and diamonds(south)>N and not dOKN dRange = (dOKN or dOKN) and not PN cOKN = hcp(south)>N and sTP>N and spades(south)==N cOKN = hcp(south)>N  and sTP>N and clubs(south)>N and not cOKN cOKN = hcp(south)>N and clubs(south)>N            and not (cOKN or cOKN) cRange = (cOKN or cOKN or cOKN) and clubs(south)>N and clubs(south)>diamonds(south) and not PN oS = s>N and s>=h and s>=d and s>=c and hsRange oH = not oS and h>N and h>=d and h>=c and hsRange oD = not (oS or oH) and ((d>N and d>=c) or c<N) and dRange oC = not (oS or oH or oD) and cRange openingSuit = (oS or oH or oD or oC) oneSpade   = oS oneHeart   = oH oneDiamond = oD oneClub    = oC sP = hcp(south) nP = hcp(north) sN = spades(north) hN = hearts(north) dN = diamonds(north) cN = clubs(north) nS  =  nP<N ? sN>N and sN>hN : sN>N and sN>hN and sN>=dN and sN>=cN nH  = (nP<N ? hN>N           : hN>N           and hN>=dN and hN>=cN) and not (nS) nD = dN>N           and dN>=cN and not (nS or nH) nC = cN>N           and cN>N   and not (nS or nH or nD) nN = not (nS or nH or nD or nC) sRC = clubs(south)>N sRD = diamonds(south)>N sRH = hearts(south)>N sRS = spades(south)>N sRN = shape(south,any N+any N+any N) CD = oC and nD CH = oC and nH CS = oC and nS CN = oC and nN CC = oC and nC DH = oD and nH DS = oD and nS DN = oD and nN DD = oD and not (DH or DS or DN) HS = oH and nS HH = oH and hN>N and not HS HN = oH and not (HS or HH) CDH = CD and sRH CDS = CD and sRS and not (CDH) CDN = CD and sRN and not (CDH or CDS) CDC = CD and c>N and not (CDH or CDS or CDN) CDD = CD and d>N and not (CDH or CDS or CDN or CDC) CHS = CH and sRS CHN = CH and sRN and not (CHS) CHC = CH and c>N and not (CHS or CHN) CHD = CH and sRD and not (CHS or CHN or CHC) CHH = CH and sRH and not (CHS or CHN or CHC or CHD) CSN = CS and sRN CSC = CS and c>N and not (CSN) CSD = CS and sRD and not (CSN or CSC) CSH = CS and sRH and not (CSN or CSC or CSD) CSS = CS and sRS and not (CSN or CSC or CSD or CSH) CNC = CN and c>N CND = CN and sRD and not (CNC) CNH = CN and sRH and not (CNC or CND) CNS = CN and sRS and not (CNC or CND or CNH) CNN = CN and sRN and not (CNC or CND or CNH or CNS) CCD = CC and sRD CCH = CC and sRH and not (CCD) CCS = CC and sRS and not (CCD or CCH) CCN = CC and sRN and not (CCD or CCH or CCS) CCC = CC and c>N and not (CCD or CCH or CCS or CCN) DHS = DH and sRS DHN = DH and sRN and not (DHS) DHC = DH and sRC and not (DHS or DHN) DHD = DH and d>N and not (DHS or DHC or DHN) DHH = DH and sRH and not (DHS or DHC or DHN or DHD) DSN = DS and sRN DSC = DS and sRC and not (DSN) DSD = DS and d>N and not (DSN or DSC) DSH = DS and sRH and not (DSN or DSC or DSD) DSS = DS and sRS and not (DSN or DSC or DSD or DSH) DNC = DN and sRC DND = DN and d>N and not (DNC) DNH = DN and sRH and not (DNC or DND) DNS = DN and sRS and not (DNC or DND or DNH) DNN = DN and sRN and not (DNC or DND or DNH or DNS) HSN = HS and sRN HSC = HS and sRC and not (HSN) HSD = HS and sRD and not (HSN or HSC) HSH = HS and h>N and not (HSN or HSC or HSD) HSS = HS and sRS and not (HSN or HSC or HSD or HSH) HNC = HN and sRC HND = HN and sRD and not (HNC) HNH = HN and h>N and not (HNC or HND) HNS = HN and sRS and not (HNC or HND or HNH) HNN = HN and sRN and not (HNC or HND or HNH or HNS) cdn = CDN chn = CHN and hearts(north)<N csn = CSN and spades(north)<N dhn = DHN and hearts(north)<N dsn = DSN and spades(north)<N hsn = HSN and spades(north)<N xyNT = cdn or chn or csn or dhn or dsn or hsn gfNT = gameForceNC and shape(south, any N+any N+any N+any N) sFit = (spades(south)+spades(north))>N hFit = (hearts(south)+hearts(north))>N noMfit = not (sFit or hFit) northBal = shape(north,Nxx+Nxx+Nxx+Nxx+Nxx+Nxx-any Nxxx-any Nxxx) northNoNM = shape(north,Nxx+Nxx+Nxx+Nxx-any Nxxx-any Nxxx) ntN = xyNT    and hcp(south)>=N and hcp(south)<=N and hcp(north)>=N and northBal ntN = oneNT   and hcp(south)>=N and hcp(south)<=N and hcp(north)>=N and northNoNM ntN = xyNT    and hcp(south)>=N and hcp(south)<=N and hcp(north)>=N and northBal ntN = twoNT   and hcp(south)>=N and hcp(south)<=N and hcp(north)>=N and northNoNM ntN = gfNT    and hcp(south)>=N and hcp(south)<=N and hcp(north)>=N and northNoNM ntN = threeNT and hcp(south)>=N and hcp(south)<=N and hcp(north)>=N  and northNoNM ntN = gfNT    and hcp(south)>=N                    and hcp(north)>=N  and northNoNM anyNT = ntN or ntN or ntN or ntN or ntN or ntN or ntN cN = hascard(west,NC) cN = hascard(east,ND) cN = hascard(west,NC) cN = hascard(east,ND) keepN = cN and cN          // this is used later w/cN & cN expressions keepN = cN or cN           // this is used later w/cN & cN expressions keepN = keepN and cN keepN = keepN and keepN keepN = keepN and not cN keepN = cN and keepN keepN = cN and not keepN keepN = cN and not cN keepN = cN keepN = keepN or cN keepN = cN or (cN and keepN) keepN = keepN or keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keepN = not keepN keep   = N keepN  = N levN = ntN   and keep levN = ntN   and keepN levN = ntN   and keepN levN = ntN   and keepN levN = ntN   and keepN levN = ntN   and keep levN = ntN   and keep tp = hcp(south)+hcp(north) grandSlam = tp>N smallSlam = tp>N and not grandSlam slamTry   = not (grandSlam or smallSlam) levst = slamTry   and keep levss = smallSlam and keep levgs = grandSlam and keep levelTheDeal = (levN or levN or levN or levN or levN or levN or levN) and (levst or levss or levgs) anyNT and noMfit and levelTheDeal action average \"bench\" hcp(north)",
+      "produced_at_verify": 5,
+      "hit_rate": 0.00025,
+      "seconds_per_deal_r1": 3.06e-06,
+      "deals": 650000,
+      "cluster_size": 1,
+      "cluster_members": [
+        "Gerber_By_Responder"
+      ]
+    },
+    {
+      "name": "_shuffle_baseline",
+      "file": "_shuffle_baseline.dlr",
+      "source": "synthetic",
+      "synthetic": true,
+      "notes": [
+        "generation baseline: RNG and shuffle, minimal evaluation"
+      ],
+      "imports": [],
+      "signature": "",
+      "cluster_size": 1,
+      "cluster_members": [],
+      "produced_at_verify": 98,
+      "hit_rate": 0.00098,
+      "seconds_per_deal_r1": 6e-07,
+      "deals": 3300000
+    }
+  ],
+  "rejected": [
+    {
+      "file": "1N_5M_and_6m.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "1m-1N.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "3N_over_LHO_3x.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "After_Partner_Takeout_Double.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "BART.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Balancing.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Basic_Openers_Rebid.dlr",
+      "reason": "dealerv2_4: exit 255 on Basic_Openers_Rebid.dlr: =minOpenerorinvOpener#Responder:6-9,aminimalone-levelresponsesoOPENER'Srebidcarries"
+    },
+    {
+      "file": "Bergen_Thrump_X_after_Preempt.dlr",
+      "reason": "statements follow the action block"
+    },
+    {
+      "file": "Bust_Over_Strong_2C.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "DOPI_ROPI.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Double_by_Advancer.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Double_double.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Equal_Level_Conversion.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Exclusion_After_Sta_Jac.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Fit_Jumps_after_1M_Double.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Fit_Showing_Jumps.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Forcing_Pass.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "GIB_1N-P-2C-BID.dlr",
+      "reason": "dealer.exe: exit 255 on GIB_1N-P-2C-BID.dlr: line 239: redefined variable"
+    },
+    {
+      "file": "Game_Overcalls.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Gerber.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Gerber_By_Opener.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Grand_Slam_Invite.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Impossible_2S.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Jump_Cuebid_Strong.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Jump_Cuebid_Weak.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Last_Train_GT2.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Last_Train_Game_Try.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Lebensohl.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Lebensohl_vs_Opps_W2_Dir.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Maximal_After_Overcall.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Maximal_Double.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "McCabe_after_WJO.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Michaels_Cuebid.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Minor_Suit_Transfer.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Non_Leaping_Michaels_After_3-Bid.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Ogust.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Opp_Redoubles.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Play_Top_Tricks.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Play_Top_Tricks_NT.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Preempt_X_XX.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Rabbis_Rule.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Responsive_Double.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Responsive_Double_after_Overcall.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Reverse_Flannery.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Rule_of_16-17.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Rule_of_16-18.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Six_Key_RKC.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Snapdragon_Double.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Soloway_Jump_Shift_Type-3.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Spear.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "TEST.dlr",
+      "reason": "dealer3: exit 1 on TEST.dlr: Error: names are used but never defined: west2C, west2D, west2H, west2S, west2N."
+    },
+    {
+      "file": "Trap_Pass.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Trap_Pass_Opener.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Two-Way_Game_Try.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Two_Way_Finesse.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "W2_X_XX.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "We_Overcall_1N_then_Gerber.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "We_Overcall_NT_then_Smolen.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "We_X_Opps_Preempt.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "We_X_Opps_Weak_2.dlr",
+      "reason": "no matches in 20000 deals"
+    },
+    {
+      "file": "Weak_Jump_Shift.dlr",
+      "reason": "no matches in 20000 deals"
+    }
+  ]
+}

--- a/bench/corpus.json
+++ b/bench/corpus.json
@@ -245,6 +245,35 @@
       "hit_rate": 0.00098,
       "seconds_per_deal_r1": 5.3e-07,
       "deals": 3700000
+    },
+    {
+      "name": "_solver_agreement",
+      "file": "_solver_agreement.dlr",
+      "source": "synthetic",
+      "synthetic": true,
+      "verify_only": true,
+      "targets": [
+        "dealer3",
+        "dealerv2_4"
+      ],
+      "target_args": {
+        "dealerv2_4": [
+          "-M",
+          "2"
+        ]
+      },
+      "verify_produce": 50,
+      "notes": [
+        "double-dummy agreement between dealer3 and DealerV2_4"
+      ],
+      "imports": [],
+      "signature": "",
+      "cluster_size": 1,
+      "cluster_members": [],
+      "produced_at_verify": 0,
+      "hit_rate": 0.0,
+      "seconds_per_deal_r1": 0.0,
+      "deals": 100000
     }
   ],
   "rejected": [

--- a/bench/corpus.json
+++ b/bench/corpus.json
@@ -1,5 +1,5 @@
 {
-  "built_with": "v0.4.0-196-gd638789",
+  "built_with": "v0.4.0-196-g529a79a",
   "source": "/Users/rick/Development/GitHub/Practice-Bidding-Scenarios/dlr",
   "target_seconds": 2.0,
   "verified_against": [
@@ -243,8 +243,8 @@
       "cluster_members": [],
       "produced_at_verify": 98,
       "hit_rate": 0.00098,
-      "seconds_per_deal_r1": 6e-07,
-      "deals": 3300000
+      "seconds_per_deal_r1": 5.3e-07,
+      "deals": 3700000
     }
   ],
   "rejected": [
@@ -492,5 +492,7 @@
       "file": "Weak_Jump_Shift.dlr",
       "reason": "no matches in 20000 deals"
     }
-  ]
+  ],
+  "corpus_id": "7d7033566ed1",
+  "built_with_note": "informational only -- the revision current when the corpus was built. Results are keyed to corpus_id, which depends on the corpus content rather than on git state."
 }

--- a/bench/corpus/After_Partner_Overcalls.dlr
+++ b/bench/corpus/After_Partner_Overcalls.dlr
@@ -1,0 +1,177 @@
+# alias: AfterPartnerOvercalls
+# button-text: After Partner Overcalls
+# scenario-title: --- After Partner Overcalls
+# gib-works: true
+# bba-works: true
+# auction-filter: Auction.....\n(1C +1[DHS]|1D +(1[HS]|2C)|1H +(1S|2[CD])|1S +2[CDH]) +Pass
+# convention-card-ns: 21GF-DEFAULT
+# convention-card-ew: 21GF-GIB
+
+
+
+# After Partner Overcalls
+
+dealer east
+
+##### Imported Script -- GIB 1 Notrump #####
+
+# GIB opens 1N w/15-17 HCP or 15-16 and a 5-card major
+ntP = hcp(south) + shape(south,5xxx+x5xx)
+nt1 = shape(south, any 5332+any 4432+any 4333) and hcp(south)>14 and ntP<18
+
+# GIB does not open with 5422 and a 5-card major or with 4 spades
+# GIB does not open with 5422 and the strength to reverse
+nt2 = shape(south, any 5422-5xxx-x5xx-4xxx) and hcp(south)>14 and hcp(south)<17
+
+gibNT = nt1 or nt2
+
+### End of GIB 1 Notrump ###
+# Defines gibNT
+
+# Predict East's opening suit -- east will be limited to 12-14 HCP
+s = spades(east)
+h = hearts(east)
+d = diamonds(east)
+c = clubs(east)
+oS = s>4 and s>=h and s>=d and s>=c
+oH = not oS and h>4 and h>=d and h>=c
+oD = not (oS or oH) and ((d>3 and d>=c) or c<3)
+oC = not (oS or oH or oD)
+openingSuit = (oS or oH or oD or oC)
+
+# Calculate East's Rank
+eRS = oS ? 4 : 0
+eRH = oH ? 3 : 0
+eRD = oD ? 2 : 0
+eRC = oC ? 1 : 0
+eRank = eRS+eRH+eRD+eRC
+
+# Define good suits
+sGoodS = spades(south)>4   and top4(south,spades)==3   and not oS
+sGoodH = hearts(south)>4   and top4(south,hearts)==3   and not oH
+sGoodD = diamonds(south)>4 and top4(south,diamonds)==3 and not oD
+sGoodC = clubs(south)>4    and top4(south,clubs)==3    and not oC
+
+sShape = shape(south,any 8xxx + any 7xxx + any 6xxx + any 5xxx - any 85xx - any 76xx - any 75xx - any 65xx - any 55xx)
+
+# Calculate South's Rank
+sRS = sGoodS ? 4 : 0
+sRH = sGoodH ? 3 : 0
+sRD = sGoodD ? 2 : 0
+sRC = sGoodC ? 1 : 0
+sRank = sRS + sRH + sRD + sRC
+
+# Define working points for South: hcp - points for secondary honors in opponents suit
+sSP = oS and hascard(south,AS) ? hcp(south,spades)-4   : hcp(south,spades)
+sHP = oH and hascard(south,AH) ? hcp(south,hearts)-4   : hcp(south,hearts)
+sDP = oD and hascard(south,AD) ? hcp(south,diamonds)-4 : hcp(south,diamonds)
+sCP = oC and hascard(south,AC) ? hcp(south,clubs)-4    : hcp(south,clubs)
+WP = hcp(south) - sSP - sHP - sDP - sCP // only one will be non-zero
+
+# Define suitPoints for South: 1 point for every card over 5
+sSSP = sGoodS ? spades(south)-5   : 0
+sHSP = sGoodH ? hearts(south)-5   : 0
+sDSP = sGoodD ? diamonds(south)-5 : 0
+sCSP = sGoodC ? clubs(south)-5    : 0
+sSuitPoints = hcp(south) + sSSP + sHSP + sDSP + sCSP
+
+sTP = WP + sSuitPoints
+
+# require 12+ WP for lower rank suit and 8+ WP for higher rank. Use WP for lower limit.
+sMin = sRank>eRank ? sTP>=8 : sTP>=13
+sMax = sTP<18     // avoid too strong to overcall.
+sRange = sMin and sMax
+
+# avoid take-out double
+shortS = oS and spades(south)<3
+shortH = oH and hearts(south)<3
+shortD = oD and diamonds(south)<3
+shortC = oC and clubs(south)<3
+shortOS = shortS or shortH or shortD or shortC
+sX = shape(south,any 7330 +any 6430 +any 6331 +any 5431 +any 5440 +any 5332) and shortOS and hcp(south)>10
+
+# avoid weak jump overcalls/preempts
+sJump = shape(south,any 8xxx +any 7xxx +any 6xxx) and hcp(south)>5 and hcp(south)<11
+
+# avoid Michaels & Unusual 2NT
+sTwoSuits = shape(south,any 76xx+any 75xx+any 66xx+any 65xx+any 55xx)
+
+# East opens
+eOpens = (oC or oD or oH or oS) and hcp(east)>11 and hcp(east)<15
+
+sOvercalls = (sGoodS or sGoodH or sGoodD or sGoodC) and sShape and sRange and not (sX or sJump or sTwoSuits or gibNT)
+
+wSFit = oS and spades(west)<3
+wHFit = oH and hearts(west)<3
+wDFit = oD and diamonds(west)<4
+wCFit = oC and clubs(west)<4
+wPasses = (wSFit or wHFit or wDFit or wCFit) and hcp(west)<6 and shape(west,any 4432 +any 5332 -5xxx -x5xx)
+
+nFitsS = sGoodS and spades(north)>2
+nFitsH = sGoodS and hearts(north)>2
+nFitsD = sGoodD and diamonds(north)>3
+nFitsC = sGoodC and clubs(north)>3
+nFit   = (nFitsS or nFitsH or nFitsD or nFitsC)
+
+nCS = oC and clubs(north)>2    and top3(north,clubs)>1
+nDS = oD and diamonds(north)>2 and top3(north,diamonds)>1
+nHS = oH and hearts(north)>2   and top3(north,hearts)>1
+nSS = oS and spades(north)>2   and top3(north,spades)>1
+nStop = nCS or nDS or nHS or nSS
+
+nRaises  = nFit and hcp(north)>6 and hcp(north)<11
+nCueBids = nFit and hcp(north)>10
+nNewSuit = shape(north,any 5xxx+any 6xxx) and hcp(north)>9 and not nFit
+nNotrump = not (nRaises or nCueBids or nNewSuit) and nStop and hcp(north)>9
+nPunts   = not (nRaises or nCueBids or nNewSuit or nNotrump)
+
+### Imported Leveling Code ###
+c1 = hascard(west,2C)
+c2 = hascard(east,2D)
+c3 = hascard(west,3C)
+c4 = hascard(east,3D)
+
+keep06 = c1 and c2          // this is used later w/c3 & c4 expressions
+keep44 = c3 or c4           // this is used later w/c1 & c2 expressions
+
+keep015 = keep06 and c3
+keep03 = keep06 and keep44
+keep045 = keep06 and not c3
+####06 = c1 and c2
+keep11 = c1 and keep44
+keep14 = c1 and not keep44
+keep19 = c1 and not c2
+keep25 = c1
+keep30 = keep06 or c3
+keep33 = c1 or (c2 and keep44)
+####44 = c3 or c4
+keep47 = keep44 or keep06
+
+keep53 = not keep47
+keep56 = not keep44
+keep67 = not keep33
+keep70 = not keep30
+keep75 = not keep25
+keep81 = not keep19
+keep86 = not keep14
+keep89 = not keep11
+keep94 = not keep06
+keep955 = not keep045
+keep97 = not keep03
+keep985 = not keep015
+keep   = 1
+keep0  = 0
+### End of Imported Leveling Code ###
+
+levelRaise = nRaises  and keep67
+levelCue   = nCueBids and keep
+levelSuit  = nNewSuit and keep25
+levelNT    = nNotrump and keep
+levelPunts = nPunts   and keep25
+
+levelTheDeal = nRaises or nCueBids or nNewSuit or levelNT or levelPunts
+
+# Now do it
+eOpens and sOvercalls and wPasses and (nRaises or nCueBids or nNewSuit or nNotrump or nPunts)
+and levelTheDeal
+action average "bench" hcp(north)

--- a/bench/corpus/Basic_Takeout_Double.dlr
+++ b/bench/corpus/Basic_Takeout_Double.dlr
@@ -1,0 +1,143 @@
+# alias: BasicTakeoutDouble
+# button-text: Basic Takeout Double
+# scenario-title: --- Basic Takeout Double (beginner)
+# gib-works: true
+# bba-works: true
+# auction-filter: Auction.....\n1[CDHS] +X
+# curate: kind=bidding
+# convention-card-ns: Basic-Bridge
+# convention-card-ew: Basic-Bridge
+
+
+
+dealer east
+
+##### Imported Script -- Predict Opening 1-Bid East #####
+# 01/19/2026 -- Changed to use TP and separate ranges for C, D, and majors
+# 03/30/2025 -- Changed to use gibNT
+
+# GIB opens 1N w/15-17 HCP or 15-16 and a 5-card major
+ntP = hcp(east) + shape(east,5xxx+x5xx)
+nt1 = shape(east, any 5332+any 4432+any 4333) and hcp(east)>14 and ntP<18
+
+# GIB does not open with 5422 and a 5-card major
+# GIB does not open with 5422 and the strength to reverse
+nt2 = shape(east, any 5422 -5xxx-x5xx-4xxx) and hcp(east)>14 and hcp(east)<17
+
+gibNT = nt1 or nt2
+
+## Calculate TP for East -- NOTE:  This uses different variable names than TP to avoid conflicts when both are used.
+# Calculate East's Short-Suit Penalty Points
+ssp = spades(east)<3 and hcp(east,spades)>0     ? 1 : 0
+shp = hearts(east)<3 and hcp(east,hearts)>0     ? 1 : 0
+sdp = diamonds(east)<3 and hcp(east,diamonds)>0 ? 1 : 0
+scp = clubs(east)<3 and hcp(east,clubs)>0       ? 1 : 0
+
+# Calculate East's Short-Suit Points
+sv01 = shape(east, any 0xxx) ? 3 : 0
+ss01 = shape(east, any 1xxx) ? 2 : 0 // allow for 2 singletons
+ss02 = shape(east, any 11xx) ? 2 : 0
+sd01 = shape(east, any 2xxx) ? 1 : 0 // allow for 3 doubletons
+sd02 = shape(east, any 22xx) ? 1 : 0
+sd03 = shape(east, any 222x) ? 1 : 0
+
+# Calculate East's Total Points
+sTP = hcp(east) + sv01+ss01+ss02+sd01+sd02+sd03 -ssp-shp-sdp-scp
+
+# Calculate length points for East (lengthPoints)
+lp1 = spades(east)>4 ? spades(east)-4 : 0
+lp2 = hearts(east)>4 ? hearts(east)-4 : 0
+lp3 = diamonds(east)>4 ? diamonds(east)-4 : 0
+lp4 = clubs(east)>4 ? clubs(east)-4 : 0
+lengthPoints = lp1 + lp2 + lp3 + lp4
+
+# Define suit points for east (suitPoints)
+suitPoints = hcp(east) + lengthPoints
+
+TwoNtShape = shape(east, any 4333 +any 4432 +any 5332 +any 5422)
+
+# Define ntPoint ranges
+oneNT   = gibNT
+twoNT   = TwoNtShape and hcp(east)>19 and hcp(east)<22
+
+# Define Gambling 3N
+g3Shape = shape(east,any 9xxx +any 8xxx +any 7xxx -any 4xxx -any 5xxx -any 6xxx)
+gamble3 = (top3(east,clubs)==3 and clubs(east)>6) or (top3(east,diamonds)==3 and diamonds(east)>6) and hcp(east)<12 and g3Shape
+
+# Define Game Forcing 2C
+case1 = hcp(east)>18 and sTP>21
+case2 = hcp(east)>18 and sTP>19 and losers(east)<5 and (spades(east)>5 or hearts(east)>5)
+case3 = hcp(east)>18 and sTP>19 and losers(east)<4 and (diamonds(east)>5 or clubs(east)>5)
+gameForce2C = (case1 or case2 or case3)
+
+### Predict East's opening BID
+P1 = gameForce2C
+P2 = P1 or gamble3 or twoNT or oneNT
+
+# Define quality and length lower limits for 10 HCP openers
+
+q2of3 = (top3(east,spades)>1 or top3(east,hearts)>1) and controls(east)>3
+lgt5  = (spades(east)>4 or hearts(east)>4) and shape(east,any 7xxx +any 64xx +any 55xx +any 1xxx+any 0xxx -any 8xxx -any 54xx) and sTP>(hcp(east) +2)
+
+# Predict East's Opening suit
+# What's the longest suit?
+s = spades(east)
+h = hearts(east)
+d = diamonds(east)
+c = clubs(east)
+
+## GIB has different requirements for 1H/S, 1D, and 1C openings
+#Define range for 1 H/S
+lS = s>4 and s>=h and s>=d and s>=c
+lH = h>4 and h>s and h>=d and h>=c
+lM = lS or lH
+
+hsOK1 = lM and hcp(east)>11
+hsOK2 = lM and hcp(east)>10 and sTP>12 and not hsOK1
+hsOK3 = lM and hcp(east)>9  and lgt5 and q2of3 and not (hsOK1 or hsOK2)
+hsRange = (hsOK1 or hsOK2 or hsOK3) and not P2
+
+# Define 1D Range
+dOK1 = hcp(east)>11 and (diamonds(east)>3 or shape(east, 4432))
+dOK2 = hcp(east)>9  and sTP>12 and diamonds(east)>5 and not dOK1
+dRange = (dOK1 or dOK2) and not P2
+
+# Define 1C Range
+cOK1 = hcp(east)>10 and sTP>12 and spades(east)==4
+cOK2 = hcp(east)>9  and sTP>12 and clubs(east)>5 and not cOK1
+cOK3 = hcp(east)>11 and clubs(east)>2            and not (cOK1 or cOK2)
+cRange = (cOK1 or cOK2 or cOK3) and clubs(east)>2 and clubs(east)>diamonds(east) and not P2
+
+oS = s>4 and s>=h and s>=d and s>=c and hsRange
+oH = not oS and h>4 and h>=d and h>=c and hsRange
+oD = not (oS or oH) and ((d>3 and d>=c) or c<3) and dRange
+oC = not (oS or oH or oD) and cRange
+openingSuit = (oS or oH or oD or oC)
+oneSpade   = oS
+oneHeart   = oH
+oneDiamond = oD
+oneClub    = oC
+
+##### End of Imported Script -- Predict Opening 1-Bid-East #####
+# Provides oS, oH, oD, oC indicating which suit East will open.
+
+# Exclude 1NT opener — East must open 1 of a suit
+eNotNT   = not gibNT
+eastHand = openingSuit and eNotNT
+
+# South: 12-18 HCP, takeout shape, NO 5-card suit, AND <3 cards in
+# whichever suit East opens (the defining feature of a takeout double).
+sHcp     = hcp(south) > 11 and hcp(south) < 19
+sShape   = shape(south, any 4432 + any 4441)
+sNoLong  = spades(south) < 5 and hearts(south) < 5 and diamonds(south) < 5 and clubs(south) < 5
+sShortInOpener = (oS and spades(south) < 3)
+              or (oH and hearts(south) < 3)
+              or (oD and diamonds(south) < 3)
+              or (oC and clubs(south) < 3)
+southHand = sHcp and sShape and sNoLong and sShortInOpener
+
+# Quiet West so the auction stays simple
+wHcp = hcp(west) < 11
+
+eastHand and southHand and wHcp
+action average "bench" hcp(north)

--- a/bench/corpus/Drury.dlr
+++ b/bench/corpus/Drury.dlr
@@ -1,0 +1,195 @@
+# alias: Drury
+# button-text: Drury (Lev)
+# scenario-title: --- Drury
+# gib-works: true
+# bba-works: true
+# auction-filter: Note...:Reverse.drury
+# curate: kind=bidding
+# convention-card-ns: 21GF-DEFAULT
+# convention-card-ew: 21GF-GIB
+
+
+
+# Reverse Drury
+
+dealer south
+
+##### Imported Script: Define Calm Opponents #####
+
+# Avoid concentration of values
+cce = top4(east,clubs)<2
+cde = top4(east,diamonds)<2
+che = top4(east,hearts)<2
+cse = top4(east,spades)<2
+noConEast = cce and cde and che and cse
+
+ccw = top4(west,clubs)<2
+cdw = top4(west,diamonds)<2
+chw = top4(west,hearts)<2
+csw = top4(west,spades)<2
+noConWest = ccw and cdw and chw and csw
+
+balEast    = shape(east,any 4432 +any 4333)
+unbalEast  = shape(east,xxxx -any 4432 -any 4333 -any 9xxx -any 8xxx -any 7xxx-any 6xxx -any 55xx)
+
+balWest    = shape(west,any 4432 +any 4333)
+unbalWest  = shape(west,xxxx -any 4432 -any 4333 -any 9xxx -any 8xxx -any 7xxx-any 6xxx -any 55xx)
+
+calmEast = (unbalEast and noConEast and hcp(east)<8) or (balEast and hcp(east)<11)
+calmWest = (unbalWest and noConWest and hcp(west)<8) or (balWest and hcp(west)<11)
+calmOpps = calmEast and calmWest
+
+##### End of Imported Script: Define Calm Opponents #####
+# Defines calmOpps
+### Imported script: TP (Total Points)
+//   Total Points = HCP + Short-Suit Points - Penalty Points
+//   Short-Suit Points: 3 for void, 2 for singleton, 1 for doubleton
+//   Penalty Points: 1 for each honor (K/Q/J) in a short suit (devalues wasted honors like Kx, Qx)
+
+## Calculate TP for North
+# Short-Suit Points: void=3, singleton=2, doubleton=1
+nSpadeSSP = spades(north)<3   ? 3-spades(north)   : 0
+nHeartSSP = hearts(north)<3   ? 3-hearts(north)   : 0
+nDiamSSP  = diamonds(north)<3 ? 3-diamonds(north) : 0
+nClubSSP  = clubs(north)<3    ? 3-clubs(north)    : 0
+nSSP = nSpadeSSP + nHeartSSP + nDiamSSP + nClubSSP
+
+# Penalty Points: deduct 1 for honors in short suits
+nSpadePP = spades(north)<3   and hcp(north,spades)>0   ? 1 : 0
+nHeartPP = hearts(north)<3   and hcp(north,hearts)>0   ? 1 : 0
+nDiamPP  = diamonds(north)<3 and hcp(north,diamonds)>0 ? 1 : 0
+nClubPP  = clubs(north)<3    and hcp(north,clubs)>0    ? 1 : 0
+nPP = nSpadePP + nHeartPP + nDiamPP + nClubPP
+
+tpNorth = hcp(north) + nSSP - nPP
+
+## Calculate TP for East
+eSpadeSSP = spades(east)<3   ? 3-spades(east)   : 0
+eHeartSSP = hearts(east)<3   ? 3-hearts(east)   : 0
+eDiamSSP  = diamonds(east)<3 ? 3-diamonds(east) : 0
+eClubSSP  = clubs(east)<3    ? 3-clubs(east)    : 0
+eSSP = eSpadeSSP + eHeartSSP + eDiamSSP + eClubSSP
+
+eSpadePP = spades(east)<3   and hcp(east,spades)>0   ? 1 : 0
+eHeartPP = hearts(east)<3   and hcp(east,hearts)>0   ? 1 : 0
+eDiamPP  = diamonds(east)<3 and hcp(east,diamonds)>0 ? 1 : 0
+eClubPP  = clubs(east)<3    and hcp(east,clubs)>0    ? 1 : 0
+ePP = eSpadePP + eHeartPP + eDiamPP + eClubPP
+
+tpEast = hcp(east) + eSSP - ePP
+
+## Calculate TP for South
+sSpadeSSP = spades(south)<3   ? 3-spades(south)   : 0
+sHeartSSP = hearts(south)<3   ? 3-hearts(south)   : 0
+sDiamSSP  = diamonds(south)<3 ? 3-diamonds(south) : 0
+sClubSSP  = clubs(south)<3    ? 3-clubs(south)    : 0
+sSSP = sSpadeSSP + sHeartSSP + sDiamSSP + sClubSSP
+
+sSpadePP = spades(south)<3   and hcp(south,spades)>0   ? 1 : 0
+sHeartPP = hearts(south)<3   and hcp(south,hearts)>0   ? 1 : 0
+sDiamPP  = diamonds(south)<3 and hcp(south,diamonds)>0 ? 1 : 0
+sClubPP  = clubs(south)<3    and hcp(south,clubs)>0    ? 1 : 0
+sPP = sSpadePP + sHeartPP + sDiamPP + sClubPP
+
+tpSouth = hcp(south) + sSSP - sPP
+
+## Calculate TP for West
+wSpadeSSP = spades(west)<3   ? 3-spades(west)   : 0
+wHeartSSP = hearts(west)<3   ? 3-hearts(west)   : 0
+wDiamSSP  = diamonds(west)<3 ? 3-diamonds(west) : 0
+wClubSSP  = clubs(west)<3    ? 3-clubs(west)    : 0
+wSSP = wSpadeSSP + wHeartSSP + wDiamSSP + wClubSSP
+
+wSpadePP = spades(west)<3   and hcp(west,spades)>0   ? 1 : 0
+wHeartPP = hearts(west)<3   and hcp(west,hearts)>0   ? 1 : 0
+wDiamPP  = diamonds(west)<3 and hcp(west,diamonds)>0 ? 1 : 0
+wClubPP  = clubs(west)<3    and hcp(west,clubs)>0    ? 1 : 0
+wPP = wSpadePP + wHeartPP + wDiamPP + wClubPP
+
+tpWest = hcp(west) + wSSP - wPP
+
+## Partnership Totals
+tpNS = tpNorth + tpSouth
+tpEW = tpEast + tpWest
+
+### End of Imported Script: TP
+# Defines tpNorth and tpSouth
+
+# South passes
+sPasses   = tpSouth<12 and hcp(south)<11 and shape(south,any xxxx -any 9xxx -any 8xxx -any 7xxx -any 6xxx -any 55xx)
+
+# South Support Jump-Shift
+rebiddableD = diamonds(south)==5 and hcp(south,diamonds)>3
+rebbidableC = clubs(south)==5    and hcp(south,clubs)>3
+sSJS = (rebiddableD or rebbidableC) and hcp(south)>10 and tpSouth>10
+
+# North opens 1H or 1S
+nBal = shape(north,any 4333+any 4432+any 5332)
+n1NT = nBal and hcp(north)>14 and hcp(north)<18
+n2NT = nBal and hcp(north)>19 and hcp(north)<22
+nNT = n1NT or n2NT
+
+//nMin = tpNorth==12 and hcp(north)==11
+nSpade = spades(north)>4 and hearts(north)<5 and diamonds(north)<5 and clubs(north)<5 and spades(south)>2 and hearts(south)<5
+nHeart = hearts(north)>4 and spades(north)<5 and diamonds(north)<5 and clubs(north)<5 and hearts(south)>2 and spades(south)<5
+len = hearts(north)>spades(north) ? hearts(north) : spades(north)
+nMin = len == 5 ? 12 : 11
+
+nRange = hcp(north)>nMin and hcp(north)<22
+nOpens = (nSpade or nHeart) and nRange and not nNT and diamonds(north)<len and clubs(north)<len
+
+sResponds = tpSouth>9 and not sSJS
+
+# Level north's opening to balance partscore/game/slam
+### Imported Leveling Code ###
+c1 = hascard(west,2C)
+c2 = hascard(east,2D)
+c3 = hascard(west,3C)
+c4 = hascard(east,3D)
+
+keep06 = c1 and c2          // this is used later w/c3 & c4 expressions
+keep44 = c3 or c4           // this is used later w/c1 & c2 expressions
+
+keep015 = keep06 and c3
+keep03 = keep06 and keep44
+keep045 = keep06 and not c3
+####06 = c1 and c2
+keep11 = c1 and keep44
+keep14 = c1 and not keep44
+keep19 = c1 and not c2
+keep25 = c1
+keep30 = keep06 or c3
+keep33 = c1 or (c2 and keep44)
+####44 = c3 or c4
+keep47 = keep44 or keep06
+
+keep53 = not keep47
+keep56 = not keep44
+keep67 = not keep33
+keep70 = not keep30
+keep75 = not keep25
+keep81 = not keep19
+keep86 = not keep14
+keep89 = not keep11
+keep94 = not keep06
+keep955 = not keep045
+keep97 = not keep03
+keep985 = not keep015
+keep   = 1
+keep0  = 0
+### End of Imported Leveling Code ###
+
+# Level by north's HCP to balance partscore/game/slam
+nLow  = hcp(north) < 15
+nMid  = hcp(north) > 14 and hcp(north) < 19
+nHigh = hcp(north) > 18
+
+levLow  = nLow  and keep
+levMid  = nMid  and keep03
+levHigh = nHigh and keep25
+levelTheDeal = levLow or levMid or levHigh
+
+# Now do it
+sPasses and nOpens and calmOpps and sResponds
+and levelTheDeal
+action average "bench" hcp(north)

--- a/bench/corpus/GIB_1C-P-Resp.dlr
+++ b/bench/corpus/GIB_1C-P-Resp.dlr
@@ -1,0 +1,350 @@
+# alias: GibRespTo1C
+# button-text: GIB after 1C
+# scenario-title: --- After 1!C (Pass)...
+# gib-works: true
+# bba-works: true
+# auction-filter: Auction.....\n1C +Pass +(1[DHS]|1NT?|2C|2NT?|3[CDHS]|3NT?) +
+# convention-card-ns: 21GF-GIB
+# convention-card-ew: 21GF-GIB
+
+
+
+dealer north
+
+##### Imported Script: Define Calm Opponents #####
+
+# Avoid concentration of values
+cce = top4(east,clubs)<2
+cde = top4(east,diamonds)<2
+che = top4(east,hearts)<2
+cse = top4(east,spades)<2
+noConEast = cce and cde and che and cse
+
+ccw = top4(west,clubs)<2
+cdw = top4(west,diamonds)<2
+chw = top4(west,hearts)<2
+csw = top4(west,spades)<2
+noConWest = ccw and cdw and chw and csw
+
+balEast    = shape(east,any 4432 +any 4333)
+unbalEast  = shape(east,xxxx -any 4432 -any 4333 -any 9xxx -any 8xxx -any 7xxx-any 6xxx -any 55xx)
+
+balWest    = shape(west,any 4432 +any 4333)
+unbalWest  = shape(west,xxxx -any 4432 -any 4333 -any 9xxx -any 8xxx -any 7xxx-any 6xxx -any 55xx)
+
+calmEast = (unbalEast and noConEast and hcp(east)<8) or (balEast and hcp(east)<11)
+calmWest = (unbalWest and noConWest and hcp(west)<8) or (balWest and hcp(west)<11)
+calmOpps = calmEast and calmWest
+
+##### End of Imported Script: Define Calm Opponents #####
+# Defines calmOpps
+##### Imported Script -- Predict Opening 1-Bid North #####
+# 01/19/2026 -- Changed to use TP and separate ranges for C, D, and majors
+# 03/30/2025 -- Changed to use gibNT
+
+# GIB opens 1N w/15-17 HCP or 15-16 and a 5-card major
+ntP = hcp(north) + shape(north,5xxx+x5xx)
+nt1 = shape(north, any 5332+any 4432+any 4333) and hcp(north)>14 and ntP<18
+
+# GIB does not open with 5422 and a 5-card major
+# GIB does not open with 5422 and the strength to reverse
+nt2 = shape(north, any 5422 -5xxx-x5xx-4xxx) and hcp(north)>14 and hcp(north)<17
+
+gibNT = nt1 or nt2
+
+## Calculate TP for North -- NOTE:  This uses different variable names than TP to avoid conflicts when both are used.
+# Calculate North's Short-Suit Penalty Points
+ssp = spades(north)<3 and hcp(north,spades)>0     ? 1 : 0
+shp = hearts(north)<3 and hcp(north,hearts)>0     ? 1 : 0
+sdp = diamonds(north)<3 and hcp(north,diamonds)>0 ? 1 : 0
+scp = clubs(north)<3 and hcp(north,clubs)>0       ? 1 : 0
+
+# Calculate North's Short-Suit Points
+sv01 = shape(north, any 0xxx) ? 3 : 0
+ss01 = shape(north, any 1xxx) ? 2 : 0 // allow for 2 singletons
+ss02 = shape(north, any 11xx) ? 2 : 0
+sd01 = shape(north, any 2xxx) ? 1 : 0 // allow for 3 doubletons
+sd02 = shape(north, any 22xx) ? 1 : 0
+sd03 = shape(north, any 222x) ? 1 : 0
+
+# Calculate North's Total Points
+nTP = hcp(north) + sv01+ss01+ss02+sd01+sd02+sd03 -ssp-shp-sdp-scp
+
+# Calculate length points for North (lengthPoints)
+lp1 = spades(north)>4 ? spades(north)-4 : 0
+lp2 = hearts(north)>4 ? hearts(north)-4 : 0
+lp3 = diamonds(north)>4 ? diamonds(north)-4 : 0
+lp4 = clubs(north)>4 ? clubs(north)-4 : 0
+lengthPoints = lp1 + lp2 + lp3 + lp4
+
+# Define suit points for north (suitPoints)
+suitPoints = hcp(north) + lengthPoints
+
+TwoNtShape = shape(north, any 4333 +any 4432 +any 5332 +any 5422)
+
+# Define ntPoint ranges
+oneNT   = gibNT
+twoNT   = TwoNtShape and hcp(north)>19 and hcp(north)<22
+
+# Define Gambling 3N
+g3Shape = shape(north,any 9xxx +any 8xxx +any 7xxx -any 4xxx -any 5xxx -any 6xxx)
+threeNT = (top3(north,clubs)==3 and clubs(north)>6) or (top3(north,diamonds)==3 and diamonds(north)>6) and hcp(north)<12 and g3Shape
+
+# Define Game Forcing 2C
+case1 = hcp(north)>18 and nTP>21
+case2 = hcp(north)>18 and nTP>19 and losers(north)<5 and (spades(north)>5 or hearts(north)>5)
+case3 = hcp(north)>18 and nTP>19 and losers(north)<4 and (diamonds(north)>5 or clubs(north)>5)
+gameForce2C = (case1 or case2 or case3)
+
+### Predict North's opening BID
+P1 = gameForce2C
+P2 = P1 or threeNT or twoNT or oneNT
+
+# Define quality and length lower limits for 10 HCP openers
+
+q2of3 = (top3(north,spades)>1 or top3(north,hearts)>1) and controls(north)>3
+lgt5  = (spades(north)>4 or hearts(north)>4) and shape(north,any 7xxx +any 64xx +any 55xx +any 1xxx+any 0xxx -any 8xxx -any 54xx) and nTP>(hcp(north) +2)
+
+# Predict North's Opening suit
+# What's the longest suit?
+s = spades(north)
+h = hearts(north)
+d = diamonds(north)
+c = clubs(north)
+
+## GIB has different requirements for 1H/S, 1D, and 1C openings
+#Define range for 1 H/S
+lS = s>4 and s>=h and s>=d and s>=c
+lH = h>4 and h>s and h>=d and h>=c
+lM = lS or lH
+
+hsOK1 = lM and hcp(north)>11
+hsOK2 = lM and hcp(north)>10 and nTP>12 and not hsOK1
+hsOK3 = lM and hcp(north)>9  and lgt5 and q2of3 and not (hsOK1 or hsOK2)
+hsRange = (hsOK1 or hsOK2 or hsOK3) and not P2
+
+# Define 1D Range
+dOK1 = hcp(north)>11 and (diamonds(north)>3 or shape(north, 4432))
+dOK2 = hcp(north)>9  and nTP>12 and diamonds(north)>5 and not dOK1
+dRange = (dOK1 or dOK2) and not P2
+
+# Define 1C Range
+cOK1 = hcp(north)>10 and nTP>12 and spades(north)==4
+cOK2 = hcp(north)>9  and nTP>12 and clubs(north)>5 and not cOK1
+cOK3 = hcp(north)>11 and clubs(north)>2            and not (cOK1 or cOK2)
+cRange = (cOK1 or cOK2 or cOK3) and clubs(north)>2 and clubs(north)>diamonds(north) and not P2
+
+oS = s>4 and s>=h and s>=d and s>=c and hsRange
+oH = not oS and h>4 and h>=d and h>=c and hsRange
+oD = not (oS or oH) and ((d>3 and d>=c) or c<3) and dRange
+oC = not (oS or oH or oD) and cRange
+openingSuit = (oS or oH or oD or oC)
+oneSpade   = oS
+oneHeart   = oH
+oneDiamond = oD
+oneClub    = oC
+
+##### End of Imported Script -- Predict Opening 1-Bid-North #####
+# Defines oneClub
+### Imported script: TP (Total Points)
+//   Total Points = HCP + Short-Suit Points - Penalty Points
+//   Short-Suit Points: 3 for void, 2 for singleton, 1 for doubleton
+//   Penalty Points: 1 for each honor (K/Q/J) in a short suit (devalues wasted honors like Kx, Qx)
+
+## Calculate TP for North
+# Short-Suit Points: void=3, singleton=2, doubleton=1
+nSpadeSSP = spades(north)<3   ? 3-spades(north)   : 0
+nHeartSSP = hearts(north)<3   ? 3-hearts(north)   : 0
+nDiamSSP  = diamonds(north)<3 ? 3-diamonds(north) : 0
+nClubSSP  = clubs(north)<3    ? 3-clubs(north)    : 0
+nSSP = nSpadeSSP + nHeartSSP + nDiamSSP + nClubSSP
+
+# Penalty Points: deduct 1 for honors in short suits
+nSpadePP = spades(north)<3   and hcp(north,spades)>0   ? 1 : 0
+nHeartPP = hearts(north)<3   and hcp(north,hearts)>0   ? 1 : 0
+nDiamPP  = diamonds(north)<3 and hcp(north,diamonds)>0 ? 1 : 0
+nClubPP  = clubs(north)<3    and hcp(north,clubs)>0    ? 1 : 0
+nPP = nSpadePP + nHeartPP + nDiamPP + nClubPP
+
+tpNorth = hcp(north) + nSSP - nPP
+
+## Calculate TP for East
+eSpadeSSP = spades(east)<3   ? 3-spades(east)   : 0
+eHeartSSP = hearts(east)<3   ? 3-hearts(east)   : 0
+eDiamSSP  = diamonds(east)<3 ? 3-diamonds(east) : 0
+eClubSSP  = clubs(east)<3    ? 3-clubs(east)    : 0
+eSSP = eSpadeSSP + eHeartSSP + eDiamSSP + eClubSSP
+
+eSpadePP = spades(east)<3   and hcp(east,spades)>0   ? 1 : 0
+eHeartPP = hearts(east)<3   and hcp(east,hearts)>0   ? 1 : 0
+eDiamPP  = diamonds(east)<3 and hcp(east,diamonds)>0 ? 1 : 0
+eClubPP  = clubs(east)<3    and hcp(east,clubs)>0    ? 1 : 0
+ePP = eSpadePP + eHeartPP + eDiamPP + eClubPP
+
+tpEast = hcp(east) + eSSP - ePP
+
+## Calculate TP for South
+sSpadeSSP = spades(south)<3   ? 3-spades(south)   : 0
+sHeartSSP = hearts(south)<3   ? 3-hearts(south)   : 0
+sDiamSSP  = diamonds(south)<3 ? 3-diamonds(south) : 0
+sClubSSP  = clubs(south)<3    ? 3-clubs(south)    : 0
+sSSP = sSpadeSSP + sHeartSSP + sDiamSSP + sClubSSP
+
+sSpadePP = spades(south)<3   and hcp(south,spades)>0   ? 1 : 0
+sHeartPP = hearts(south)<3   and hcp(south,hearts)>0   ? 1 : 0
+sDiamPP  = diamonds(south)<3 and hcp(south,diamonds)>0 ? 1 : 0
+sClubPP  = clubs(south)<3    and hcp(south,clubs)>0    ? 1 : 0
+sPP = sSpadePP + sHeartPP + sDiamPP + sClubPP
+
+tpSouth = hcp(south) + sSSP - sPP
+
+## Calculate TP for West
+wSpadeSSP = spades(west)<3   ? 3-spades(west)   : 0
+wHeartSSP = hearts(west)<3   ? 3-hearts(west)   : 0
+wDiamSSP  = diamonds(west)<3 ? 3-diamonds(west) : 0
+wClubSSP  = clubs(west)<3    ? 3-clubs(west)    : 0
+wSSP = wSpadeSSP + wHeartSSP + wDiamSSP + wClubSSP
+
+wSpadePP = spades(west)<3   and hcp(west,spades)>0   ? 1 : 0
+wHeartPP = hearts(west)<3   and hcp(west,hearts)>0   ? 1 : 0
+wDiamPP  = diamonds(west)<3 and hcp(west,diamonds)>0 ? 1 : 0
+wClubPP  = clubs(west)<3    and hcp(west,clubs)>0    ? 1 : 0
+wPP = wSpadePP + wHeartPP + wDiamPP + wClubPP
+
+tpWest = hcp(west) + wSSP - wPP
+
+## Partnership Totals
+tpNS = tpNorth + tpSouth
+tpEW = tpEast + tpWest
+
+### End of Imported Script: TP
+# Defines tpEast, tpSouth
+
+# Define suits suitable for 4-card overcall
+eAS = hascard(east,AS)
+eKS = hascard(east,KS)
+eQS = hascard(east,QS)
+eJS = hascard(east,JS)
+eTS = hascard(east,TS)
+e9S = hascard(east,9S)
+
+eAH = hascard(east,AH)
+eKH = hascard(east,KH)
+eQH = hascard(east,QH)
+eJH = hascard(east,JH)
+eTH = hascard(east,TH)
+e9H = hascard(east,9H)
+
+eAD = hascard(east,AD)
+eKD = hascard(east,KD)
+eQD = hascard(east,QD)
+eJD = hascard(east,JD)
+eTD = hascard(east,TD)
+e9D = hascard(east,9D)
+
+# Define East's possible overcall suits: AKxx, AQJx, AQTx, AQ9x, AJT9, KQJx, or KQTx
+eS4 = ((eAS and eKS) or (eAS and eQS and (eJS or eTS or e9S)) or (eAS and eJS and eTS and e9S) or (eKS and eQS and (eJS or eTS))) and spades(east)==4
+eH4 = ((eAH and eKH) or (eAH and eQH and (eJH or eTH or e9H)) or (eAH and eJH and eTH and e9H) or (eKH and eQH and (eJH or eTH))) and hearts(east)==4
+eD4 = ((eAD and eKD) or (eAD and eQD and (eJD or eTD or e9D)) or (eAD and eJD and eTD and e9D) or (eKD and eQD and (eJD or eTD))) and diamonds(east)==4
+ess = (eS4 and eH4) or (eS4 and eD4) or (eH4 or eD4)
+
+# Avoid Takeout Double -- 13/14 HCP and equal length in the majors
+X = (hcp(east)==13 or hcp(east)==14) and spades(east)==hearts(east)==(3 or 4)  // I'm out of 'shape' statements
+reverse = shape(north,45xx+x45x+xx45) and hcp(north)>16
+
+eRange = tpEast>=12 and tpEast<=14 and not X
+
+# Define East's actions
+cOC = oneClub    and (eD4 or eH4 or eS4) and clubs(east)==3
+dOC = oneDiamond and (eH4 or eS4)        and diamonds(east)==3
+hOC = oneHeart   and eS4                 and hearts(east)==3
+eOvercalls = (cOC or dOC or hOC) and eRange and shape(east,any 4432 +any 4333)
+
+eTakeOutDouble = (balEast and hcp(east)>10 and clubs(east)==2) or (balWest and hcp(west)>10 and clubs(west)==2)  // Must know opening suit
+oppsPass = calmOpps and not (eOvercalls or eTakeOutDouble)
+
+## Define things...
+
+# Define South's suit lengths
+sC = clubs(south)
+sD = diamonds(south)
+sH = hearts(south)
+sS = spades(south)
+
+# Define South's rebiddable suit
+sRS = sS>5 or (sS==5 and top5(south,spades)>2)
+sRH = sH>5 or (sH==5 and top5(south,hearts)>2)
+sRD = sD>5 or (sD==5 and top5(south,diamonds)>2)
+sRC = sC>5 or (sC==5 and top5(south,clubs)>2)
+sRebiddableSuit = sRS or sRH or sRD or sRC
+
+# GIB defines partial stop: length+HCP = 4 (Qx or Jxx).  But, it bids differently with 3-cards or honor doubleton
+dStop = (hcp(south,diamonds) + sD)>3 ? 2 : 0      // Dealer doesn't allow fractions; so 2 pts for stop
+hStop = (hcp(south,hearts)   + sH)>3 ? 2 : 0
+sStop = (hcp(south,spades)   + sS)>3 ? 2 : 0
+
+dHalf = not dStop and ((hcp(south,diamonds)>0) + sD)==3   // and 1 pt for half-stop: any 3-cards or honor doubleton
+hHalf = not hStop and ((hcp(south,hearts)>0)   + sH)==3
+sHalf = not sStop and ((hcp(south,spades)>0)   + sS)==3
+
+stops = dStop + hStop + sStop + dHalf + hHalf +sHalf
+
+# I've exceeded the number or 'shape' statements that Dealer allows, I'll use the less efficient version.
+s3334 = sS==3 and sH==3  and sD==3
+s3343 = sS==3 and sH==3  and sD==4
+sxx44 = (sS==3 or sS==2) and sD==4 and sC==4  // 3244 or 2344
+sBal  = (s3334 or s3343 or sxx44)  // no 4-card major
+
+sRange = sRebiddableSuit ? tpSouth>5 and tpSouth<17 : tpSouth>5   // no upper range without rebiddable suit
+
+## 1. Major responses
+
+rS1 = sS>4 and sS>=sH                   // higher ranking of 5+card suits
+rS2 = tpSouth<13 and sS==4 and sS>sH        // skip longer D w/<13
+rS3 = sS==4 and sS>sH and sD<5          // prefer 4-card H/S to 4-card D
+r1S = rS1 or rS2 or rS3
+
+rH1 = sH>4 and sH>sS
+rH2 = tpSouth<13 and sH==4 and sH>=sS
+rH3 = sH==4 and sD<5
+r1H = (rH1 or rH2 or rH3) and not r1S
+
+rM = r1H or r1S
+
+## 2. Club responses
+
+r3x   = sC>4 and shape(south,3316+3307+any 0xxx +any 1xxx) and tpSouth>13 and not rM    // splinter
+r2C34 = s3334       and hcp(south)>9  and hcp(south)<13 and stops<5 and not rM
+r2C44 = sxx44       and hcp(south)>9  and hcp(south)<13 and stops<4 and not rM
+r2C3N = s3334+sxx44 and hcp(south)>12 and hcp(south)<16             and not rM          // GIB goes through 2C w/a bal 13-15
+r2Cx5 = sC>4        and sD<5 and hcp(south)>9                       and not (rM or r3x)
+r2C = r2C34 or r2C44 or r2C3N or r2Cx5
+r3C = sC>4 and sD<5 and hcp(south)<10 and tpSouth>4                     and not (rM or r3x)
+
+rC  = r2C34 or r2C44 or r2C3N or r2Cx5 or r3C or r3x
+
+## 3. Notrump responses
+
+r1N  = hcp(south)>5  and hcp(south)<11 and sBal and not rC
+
+r2Na = hcp(south)>10 and hcp(south)<13 and sxx44 and stops>3 and hcp(south,diamonds)>0 and not rC // prefer 1D or 2C
+r2Nb = hcp(south)>10 and hcp(south)<13 and s3334 and stops>4                           and not rC // no alternative
+r2Nc = hcp(south)>10 and hcp(south)<13 and s3343 and stops>5                           and not rC // prefer 1D
+r2N = r2Na or r2Nb or r2Nc
+
+r3N = s3343 and hcp(south)>12 and hcp(south)<16  and sBal  and stops>5                 and not rC
+
+rN  = r1N or r2N or r3N
+
+## 4. Diamonds
+
+r1D = sD>3 and not (rM or rN or rC)
+
+// Change the following line to get the responses you want --------
+//
+sResponds = r1D or r1H or r1S or r1N or r2C or r2N or r3C or r3x or r3N
+//
+// ----------------------------------------------------------------
+
+oneClub and not eOvercalls and sRange and sResponds and oppsPass
+action average "bench" hcp(north)

--- a/bench/corpus/GIB_1N_Basic.dlr
+++ b/bench/corpus/GIB_1N_Basic.dlr
@@ -1,0 +1,110 @@
+# alias: respToGibNt
+# button-text: Basic NT Resp
+# scenario-title: ---  Basic Notrump Responses
+# gib-works: true
+# bba-works: true
+# auction-filter: Auction.....\n1N +Pass +\d
+# convention-card-ns: 21GF-GIB
+# convention-card-ew: 21GF-GIB
+
+
+
+dealer north
+
+### Imported script: TP (Total Points)
+//   Total Points = HCP + Short-Suit Points - Penalty Points
+//   Short-Suit Points: 3 for void, 2 for singleton, 1 for doubleton
+//   Penalty Points: 1 for each honor (K/Q/J) in a short suit (devalues wasted honors like Kx, Qx)
+
+## Calculate TP for North
+# Short-Suit Points: void=3, singleton=2, doubleton=1
+nSpadeSSP = spades(north)<3   ? 3-spades(north)   : 0
+nHeartSSP = hearts(north)<3   ? 3-hearts(north)   : 0
+nDiamSSP  = diamonds(north)<3 ? 3-diamonds(north) : 0
+nClubSSP  = clubs(north)<3    ? 3-clubs(north)    : 0
+nSSP = nSpadeSSP + nHeartSSP + nDiamSSP + nClubSSP
+
+# Penalty Points: deduct 1 for honors in short suits
+nSpadePP = spades(north)<3   and hcp(north,spades)>0   ? 1 : 0
+nHeartPP = hearts(north)<3   and hcp(north,hearts)>0   ? 1 : 0
+nDiamPP  = diamonds(north)<3 and hcp(north,diamonds)>0 ? 1 : 0
+nClubPP  = clubs(north)<3    and hcp(north,clubs)>0    ? 1 : 0
+nPP = nSpadePP + nHeartPP + nDiamPP + nClubPP
+
+tpNorth = hcp(north) + nSSP - nPP
+
+## Calculate TP for East
+eSpadeSSP = spades(east)<3   ? 3-spades(east)   : 0
+eHeartSSP = hearts(east)<3   ? 3-hearts(east)   : 0
+eDiamSSP  = diamonds(east)<3 ? 3-diamonds(east) : 0
+eClubSSP  = clubs(east)<3    ? 3-clubs(east)    : 0
+eSSP = eSpadeSSP + eHeartSSP + eDiamSSP + eClubSSP
+
+eSpadePP = spades(east)<3   and hcp(east,spades)>0   ? 1 : 0
+eHeartPP = hearts(east)<3   and hcp(east,hearts)>0   ? 1 : 0
+eDiamPP  = diamonds(east)<3 and hcp(east,diamonds)>0 ? 1 : 0
+eClubPP  = clubs(east)<3    and hcp(east,clubs)>0    ? 1 : 0
+ePP = eSpadePP + eHeartPP + eDiamPP + eClubPP
+
+tpEast = hcp(east) + eSSP - ePP
+
+## Calculate TP for South
+sSpadeSSP = spades(south)<3   ? 3-spades(south)   : 0
+sHeartSSP = hearts(south)<3   ? 3-hearts(south)   : 0
+sDiamSSP  = diamonds(south)<3 ? 3-diamonds(south) : 0
+sClubSSP  = clubs(south)<3    ? 3-clubs(south)    : 0
+sSSP = sSpadeSSP + sHeartSSP + sDiamSSP + sClubSSP
+
+sSpadePP = spades(south)<3   and hcp(south,spades)>0   ? 1 : 0
+sHeartPP = hearts(south)<3   and hcp(south,hearts)>0   ? 1 : 0
+sDiamPP  = diamonds(south)<3 and hcp(south,diamonds)>0 ? 1 : 0
+sClubPP  = clubs(south)<3    and hcp(south,clubs)>0    ? 1 : 0
+sPP = sSpadePP + sHeartPP + sDiamPP + sClubPP
+
+tpSouth = hcp(south) + sSSP - sPP
+
+## Calculate TP for West
+wSpadeSSP = spades(west)<3   ? 3-spades(west)   : 0
+wHeartSSP = hearts(west)<3   ? 3-hearts(west)   : 0
+wDiamSSP  = diamonds(west)<3 ? 3-diamonds(west) : 0
+wClubSSP  = clubs(west)<3    ? 3-clubs(west)    : 0
+wSSP = wSpadeSSP + wHeartSSP + wDiamSSP + wClubSSP
+
+wSpadePP = spades(west)<3   and hcp(west,spades)>0   ? 1 : 0
+wHeartPP = hearts(west)<3   and hcp(west,hearts)>0   ? 1 : 0
+wDiamPP  = diamonds(west)<3 and hcp(west,diamonds)>0 ? 1 : 0
+wClubPP  = clubs(west)<3    and hcp(west,clubs)>0    ? 1 : 0
+wPP = wSpadePP + wHeartPP + wDiamPP + wClubPP
+
+tpWest = hcp(west) + wSSP - wPP
+
+## Partnership Totals
+tpNS = tpNorth + tpSouth
+tpEW = tpEast + tpWest
+
+### End of Imported Script: TP
+##### Imported Script -- GIB 1 Notrump (North) #####
+
+# GIB opens 1N w/15-17 HCP or 15-16 and a 5-card major
+ntP = hcp(north) + shape(north,5xxx+x5xx)
+nt1 = shape(north, any 5332+any 4432+any 4333) and hcp(north)>14 and ntP<18
+
+# GIB does not open with 5422 and a 5-card major or with 4 spades
+# GIB does not open with 5422 and the strength to reverse
+nt2 = shape(north, any 5422-5xxx-x5xx-4xxx) and hcp(north)>14 and hcp(north)<17
+
+gibNT = nt1 or nt2
+
+### End of GIB 1 Notrump (North) ###
+# defines gibNT
+
+# Basic Notrump responses
+stayman = shape(south,54xx+45xx+4xxx+x4xx) and hcp(south)>8
+texas   = (spades(south)>5 or hearts(south)>5) and tpSouth>9
+jacoby  = (spades(south)>4 or hearts(south)>4) and not (stayman or texas)
+threeNT = not (stayman or texas or jacoby) and hcp(south)>9
+
+twoSuit = shape(south,any 76xx +any 75xx +any 66xx +any 65xx +any 55xx)
+
+gibNT and (stayman or jacoby or threeNT) and hcp(south)<16 and not twoSuit
+action average "bench" hcp(north)

--- a/bench/corpus/Gerber_By_Responder.dlr
+++ b/bench/corpus/Gerber_By_Responder.dlr
@@ -1,0 +1,345 @@
+# alias: GerberByResponder
+# button-text: Gerber by Responder (Lev)
+# scenario-title: --- Gerber by Responder (Leveled)
+# gib-works: true
+# bba-works: true
+# auction-filter: Note....A=
+# convention-card-ns: 21GF-GIB
+# convention-card-ew: 21GF-GIB
+
+
+
+dealer south
+
+# These are sequences where 4C-Gerber might be bid by Responder
+# Gerber by Responder
+#
+# 1x - 1y - 1N - ?
+# 1x - 1y - 2N - ?
+# 1m - 2N - ?
+# 1N - ?
+# 2N - ?
+# 3N - ?
+# 2C 2D 2N - ?
+# 2C 2D 3N - ?
+
+##### Imported Script -- Predict Opening 1-Bid South #####
+# 01/19/2026 -- Changed to use TP and separate ranges for C, D, and majors
+# 03/30/2025 -- Changed to use gibNT
+
+# GIB opens 1N w/15-17 HCP or 15-16 and a 5-card major
+ntP = hcp(south) + shape(south,5xxx+x5xx)
+nt1 = shape(south, any 5332+any 4432+any 4333) and hcp(south)>14 and ntP<18
+
+# GIB does not open with 5422 and a 5-card major
+# GIB does not open with 5422 and the strength to reverse
+nt2 = shape(south, any 5422 -5xxx-x5xx-4xxx) and hcp(south)>14 and hcp(south)<17
+
+gibNT = nt1 or nt2
+
+## Calculate TP for South -- NOTE:  This uses different variable names than TP to avoid conflicts when both are used.
+# Calculate South's Short-Suit Penalty Points
+ssp = spades(south)<3 and hcp(south,spades)>0     ? 1 : 0
+shp = hearts(south)<3 and hcp(south,hearts)>0     ? 1 : 0
+sdp = diamonds(south)<3 and hcp(south,diamonds)>0 ? 1 : 0
+scp = clubs(south)<3 and hcp(south,clubs)>0       ? 1 : 0
+
+# Calculate South's Short-Suit Points
+sv01 = shape(south, any 0xxx) ? 3 : 0
+ss01 = shape(south, any 1xxx) ? 2 : 0 // allow for 2 singletons
+ss02 = shape(south, any 11xx) ? 2 : 0
+sd01 = shape(south, any 2xxx) ? 1 : 0 // allow for 3 doubletons
+sd02 = shape(south, any 22xx) ? 1 : 0
+sd03 = shape(south, any 222x) ? 1 : 0
+
+# Calculate South's Total Points
+sTP = hcp(south) + sv01+ss01+ss02+sd01+sd02+sd03 -ssp-shp-sdp-scp
+
+# Calculate length points for South (lengthPoints)
+lp1 = spades(south)>4 ? spades(south)-4 : 0
+lp2 = hearts(south)>4 ? hearts(south)-4 : 0
+lp3 = diamonds(south)>4 ? diamonds(south)-4 : 0
+lp4 = clubs(south)>4 ? clubs(south)-4 : 0
+lengthPoints = lp1 + lp2 + lp3 + lp4
+
+# Define suit points for south (suitPoints)
+suitPoints = hcp(south) + lengthPoints
+
+TwoNtShape = shape(south, any 4333 +any 4432 +any 5332 +any 5422)
+
+# Define ntPoint ranges
+oneNT   = gibNT
+twoNT   = TwoNtShape and hcp(south)>19 and hcp(south)<22
+
+# Define Gambling 3N
+g3Shape = shape(south,any 9xxx +any 8xxx +any 7xxx -any 4xxx -any 5xxx -any 6xxx)
+threeNT = (top3(south,clubs)==3 and clubs(south)>6) or (top3(south,diamonds)==3 and diamonds(south)>6) and hcp(south)<12 and g3Shape
+
+# Define Game Forcing 2C
+case1 = hcp(south)>18 and sTP>21
+case2 = hcp(south)>18 and sTP>19 and losers(south)<5 and (spades(south)>5 or hearts(south)>5)
+case3 = hcp(south)>18 and sTP>19 and losers(south)<4 and (diamonds(south)>5 or clubs(south)>5)
+gameForce2C = (case1 or case2 or case3)
+
+### Predict South's opening BID
+P1 = gameForce2C
+P2 = P1 or threeNT or twoNT or oneNT
+
+# Define quality and length lower limits for 10 HCP openers
+
+q2of3 = (top3(south,spades)>1 or top3(south,hearts)>1) and controls(south)>3
+lgt5  = (spades(south)>4 or hearts(south)>4) and shape(south,any 7xxx +any 64xx +any 55xx +any 1xxx+any 0xxx -any 8xxx -any 54xx) and sTP>(hcp(south) +2)
+
+# Predict South's Opening suit
+# What's the longest suit?
+s = spades(south)
+h = hearts(south)
+d = diamonds(south)
+c = clubs(south)
+
+## GIB has different requirements for 1H/S, 1D, and 1C openings 
+#Define range for 1 H/S
+lS = s>4 and s>=h and s>=d and s>=c
+lH = h>4 and h>s and h>=d and h>=c
+lM = lS or lH
+
+hsOK1 = lM and hcp(south)>11
+hsOK2 = lM and hcp(south)>10 and sTP>12 and not hsOK1
+hsOK3 = lM and hcp(south)>9  and lgt5 and q2of3 and not (hsOK1 or hsOK2)
+hsRange = (hsOK1 or hsOK2 or hsOK3) and not P2
+
+# Define 1D Range
+dOK1 = hcp(south)>11 and (diamonds(south)>3 or shape(south, 4432))
+dOK2 = hcp(south)>9  and sTP>12 and diamonds(south)>5 and not dOK1
+dRange = (dOK1 or dOK2) and not P2
+
+# Define 1C Range
+cOK1 = hcp(south)>10 and sTP>12 and spades(south)==4
+cOK2 = hcp(south)>9  and sTP>12 and clubs(south)>5 and not cOK1
+cOK3 = hcp(south)>11 and clubs(south)>2            and not (cOK1 or cOK2)
+cRange = (cOK1 or cOK2 or cOK3) and clubs(south)>2 and clubs(south)>diamonds(south) and not P2
+
+oS = s>4 and s>=h and s>=d and s>=c and hsRange
+oH = not oS and h>4 and h>=d and h>=c and hsRange
+oD = not (oS or oH) and ((d>3 and d>=c) or c<3) and dRange
+oC = not (oS or oH or oD) and cRange
+openingSuit = (oS or oH or oD or oC)
+oneSpade   = oS
+oneHeart   = oH
+oneDiamond = oD
+oneClub    = oC
+
+##### End of Imported Script -- Predict Opening 1-Bid #####
+# Defines oneNT, twoNT, gameForce2C, threeNT
+##### Predict Response to 1-Bid ##### 
+
+# These variables are defined in the imported scripts above
+# The number of cards South has in each suit: s, h, d, c
+# South's predicted opening suit: oC, oD, oH, oS 
+
+sP = hcp(south)
+nP = hcp(north)
+
+# Predict North's 1-level response
+sN = spades(north)
+hN = hearts(north)
+dN = diamonds(north)
+cN = clubs(north)
+
+# North responds in D, H, or S (Walsh style), or raises C.
+######
+# If less than 13, Walsh Style; otherwise, longest suit.
+nS  =  nP<13 ? sN>3 and sN>hN : sN>3 and sN>hN and sN>=dN and sN>=cN
+nH  = (nP<13 ? hN>3           : hN>3           and hN>=dN and hN>=cN) and not (nS)
+nD = dN>3           and dN>=cN and not (nS or nH)
+nC = cN>4           and cN>4   and not (nS or nH or nD)
+nN = not (nS or nH or nD or nC)
+
+# Define South's possible new-suit/NT rebids
+sRC = clubs(south)>3
+sRD = diamonds(south)>3
+sRH = hearts(south)>3
+sRS = spades(south)>3
+sRN = shape(south,any 4333+any 4432+any 5332)
+
+
+# Defining South's opening (not NT) & North's non-GF response
+CD = oC and nD
+CH = oC and nH
+CS = oC and nS
+CN = oC and nN
+CC = oC and nC
+
+DH = oD and nH
+DS = oD and nS
+DN = oD and nN
+DD = oD and not (DH or DS or DN)
+
+HS = oH and nS
+HH = oH and hN>2 and not HS
+HN = oH and not (HS or HH)
+
+##### End of Predict Response to 1-Bid #####
+
+##### Predict Opener's Rebid #####
+CDH = CD and sRH
+CDS = CD and sRS and not (CDH)
+CDN = CD and sRN and not (CDH or CDS)
+CDC = CD and c>5 and not (CDH or CDS or CDN)
+CDD = CD and d>3 and not (CDH or CDS or CDN or CDC)
+
+CHS = CH and sRS
+CHN = CH and sRN and not (CHS)
+CHC = CH and c>5 and not (CHS or CHN)
+CHD = CH and sRD and not (CHS or CHN or CHC)
+CHH = CH and sRH and not (CHS or CHN or CHC or CHD)
+
+CSN = CS and sRN
+CSC = CS and c>5 and not (CSN)
+CSD = CS and sRD and not (CSN or CSC)
+CSH = CS and sRH and not (CSN or CSC or CSD)
+CSS = CS and sRS and not (CSN or CSC or CSD or CSH)
+
+CNC = CN and c>5
+CND = CN and sRD and not (CNC)
+CNH = CN and sRH and not (CNC or CND)
+CNS = CN and sRS and not (CNC or CND or CNH)
+CNN = CN and sRN and not (CNC or CND or CNH or CNS)
+
+CCD = CC and sRD
+CCH = CC and sRH and not (CCD)
+CCS = CC and sRS and not (CCD or CCH)
+CCN = CC and sRN and not (CCD or CCH or CCS)
+CCC = CC and c>5 and not (CCD or CCH or CCS or CCN)
+
+DHS = DH and sRS
+DHN = DH and sRN and not (DHS)
+DHC = DH and sRC and not (DHS or DHN)
+DHD = DH and d>5 and not (DHS or DHC or DHN)
+DHH = DH and sRH and not (DHS or DHC or DHN or DHD)
+
+DSN = DS and sRN
+DSC = DS and sRC and not (DSN)
+DSD = DS and d>5 and not (DSN or DSC)
+DSH = DS and sRH and not (DSN or DSC or DSD)
+DSS = DS and sRS and not (DSN or DSC or DSD or DSH)
+
+DNC = DN and sRC
+DND = DN and d>5 and not (DNC)
+DNH = DN and sRH and not (DNC or DND)
+DNS = DN and sRS and not (DNC or DND or DNH)
+DNN = DN and sRN and not (DNC or DND or DNH or DNS)
+
+
+HSN = HS and sRN
+HSC = HS and sRC and not (HSN)
+HSD = HS and sRD and not (HSN or HSC)
+HSH = HS and h>5 and not (HSN or HSC or HSD)
+HSS = HS and sRS and not (HSN or HSC or HSD or HSH)
+
+HNC = HN and sRC
+HND = HN and sRD and not (HNC)
+HNH = HN and h>5 and not (HNC or HND)
+HNS = HN and sRS and not (HNC or HND or HNH)
+HNN = HN and sRN and not (HNC or HND or HNH or HNS)
+##### End of Predict Opener's Rebid #####
+# Defines CDN, CHN, CSN, DHN, DSN, HSN
+
+# Create hands where the only question is "How may keycards does partner have?"
+#predeal south SA,HA,DAK,CA
+#predeal north S,H,DQJT9876,CK5
+
+# avoid New Minor Forcing
+cdn = CDN
+chn = CHN and hearts(north)<5
+csn = CSN and spades(north)<5
+dhn = DHN and hearts(north)<5
+dsn = DSN and spades(north)<5
+hsn = HSN and spades(north)<5
+xyNT = cdn or chn or csn or dhn or dsn or hsn
+
+gfNT = gameForce2C and shape(south, any 5422+any 5332+any 4432+any 4333)
+
+# Avoid major suit fit
+sFit = (spades(south)+spades(north))>7
+hFit = (hearts(south)+hearts(north))>7
+noMfit = not (sFit or hFit)
+
+# North is balanced with no 4-card major.  May have a long minor.
+northBal = shape(north,43xx+34xx+33xx+32xx+23xx+22xx-any 0xxx-any 1xxx)
+northNo4M = shape(north,33xx+32xx+23xx+22xx-any 0xxx-any 1xxx)
+
+# North is anywhere within their range and the pair has at least 32
+nt12 = xyNT    and hcp(south)>=12 and hcp(south)<=14 and hcp(north)>=20 and northBal
+nt15 = oneNT   and hcp(south)>=15 and hcp(south)<=17 and hcp(north)>=17 and northNo4M
+nt18 = xyNT    and hcp(south)>=18 and hcp(south)<=19 and hcp(north)>=14 and northBal
+nt20 = twoNT   and hcp(south)>=20 and hcp(south)<=21 and hcp(north)>=12 and northNo4M
+nt22 = gfNT    and hcp(south)>=22 and hcp(south)<=24 and hcp(north)>=10 and northNo4M
+nt25 = threeNT and hcp(south)>=25 and hcp(south)<=27 and hcp(north)>=7  and northNo4M
+nt28 = gfNT    and hcp(south)>=28                    and hcp(north)>=4  and northNo4M
+anyNT = nt12 or nt15 or nt18 or nt20 or nt22 or nt25 or nt28
+
+### Imported Leveling Code ###
+c1 = hascard(west,2C)
+c2 = hascard(east,2D)
+c3 = hascard(west,3C)
+c4 = hascard(east,3D)
+
+keep06 = c1 and c2          // this is used later w/c3 & c4 expressions
+keep44 = c3 or c4           // this is used later w/c1 & c2 expressions
+
+keep015 = keep06 and c3
+keep03 = keep06 and keep44
+keep045 = keep06 and not c3
+####06 = c1 and c2
+keep11 = c1 and keep44
+keep14 = c1 and not keep44
+keep19 = c1 and not c2
+keep25 = c1
+keep30 = keep06 or c3
+keep33 = c1 or (c2 and keep44)
+####44 = c3 or c4
+keep47 = keep44 or keep06
+
+keep53 = not keep47
+keep56 = not keep44
+keep67 = not keep33
+keep70 = not keep30
+keep75 = not keep25
+keep81 = not keep19
+keep86 = not keep14
+keep89 = not keep11
+keep94 = not keep06
+keep955 = not keep045
+keep97 = not keep03
+keep985 = not keep015
+keep   = 1
+keep0  = 0
+### End of Imported Leveling Code ###
+
+# Level the deal
+lev12 = nt12   and keep
+lev15 = nt15   and keep25
+lev18 = nt18   and keep81
+lev20 = nt20   and keep44
+lev22 = nt22   and keep75
+lev25 = nt25   and keep
+lev28 = nt28   and keep
+
+# Define tp = combined hcp
+tp = hcp(south)+hcp(north)
+
+# Keep at least one of these
+grandSlam = tp>36
+smallSlam = tp>32 and not grandSlam
+slamTry   = not (grandSlam or smallSlam)
+
+levst = slamTry   and keep
+levss = smallSlam and keep
+levgs = grandSlam and keep
+levelTheDeal = (lev12 or lev15 or lev18 or lev20 or lev22 or lev25 or lev28) and (levst or levss or levgs)
+
+# Now do it
+anyNT and noMfit
+and levelTheDeal
+action average "bench" hcp(north)

--- a/bench/corpus/Major_Suit_Fit.dlr
+++ b/bench/corpus/Major_Suit_Fit.dlr
@@ -1,0 +1,278 @@
+# alias: MajorSuitFit
+# button-text: Major Suit Fit (Lev)
+# scenario-title: --- Major Suit Fit
+# gib-works: true
+# bba-works: true
+# auction-filter: Auction.....\n((1H +Pass +[2-7]H)|(1S +Pass +[2-7]S))
+# curate: kind=bidding
+# convention-card-ns: 21GF-DEFAULT
+# convention-card-ew: 21GF-GIB
+
+
+
+# Major_Suit_Fit
+dealer north
+
+##### Imported Script -- Predict Opening 1-Bid North #####
+# 01/19/2026 -- Changed to use TP and separate ranges for C, D, and majors
+# 03/30/2025 -- Changed to use gibNT
+
+# GIB opens 1N w/15-17 HCP or 15-16 and a 5-card major
+ntP = hcp(north) + shape(north,5xxx+x5xx)
+nt1 = shape(north, any 5332+any 4432+any 4333) and hcp(north)>14 and ntP<18
+
+# GIB does not open with 5422 and a 5-card major
+# GIB does not open with 5422 and the strength to reverse
+nt2 = shape(north, any 5422 -5xxx-x5xx-4xxx) and hcp(north)>14 and hcp(north)<17
+
+gibNT = nt1 or nt2
+
+## Calculate TP for North -- NOTE:  This uses different variable names than TP to avoid conflicts when both are used.
+# Calculate North's Short-Suit Penalty Points
+ssp = spades(north)<3 and hcp(north,spades)>0     ? 1 : 0
+shp = hearts(north)<3 and hcp(north,hearts)>0     ? 1 : 0
+sdp = diamonds(north)<3 and hcp(north,diamonds)>0 ? 1 : 0
+scp = clubs(north)<3 and hcp(north,clubs)>0       ? 1 : 0
+
+# Calculate North's Short-Suit Points
+sv01 = shape(north, any 0xxx) ? 3 : 0
+ss01 = shape(north, any 1xxx) ? 2 : 0 // allow for 2 singletons
+ss02 = shape(north, any 11xx) ? 2 : 0
+sd01 = shape(north, any 2xxx) ? 1 : 0 // allow for 3 doubletons
+sd02 = shape(north, any 22xx) ? 1 : 0
+sd03 = shape(north, any 222x) ? 1 : 0
+
+# Calculate North's Total Points
+nTP = hcp(north) + sv01+ss01+ss02+sd01+sd02+sd03 -ssp-shp-sdp-scp
+
+# Calculate length points for North (lengthPoints)
+lp1 = spades(north)>4 ? spades(north)-4 : 0
+lp2 = hearts(north)>4 ? hearts(north)-4 : 0
+lp3 = diamonds(north)>4 ? diamonds(north)-4 : 0
+lp4 = clubs(north)>4 ? clubs(north)-4 : 0
+lengthPoints = lp1 + lp2 + lp3 + lp4
+
+# Define suit points for north (suitPoints)
+suitPoints = hcp(north) + lengthPoints
+
+TwoNtShape = shape(north, any 4333 +any 4432 +any 5332 +any 5422)
+
+# Define ntPoint ranges
+oneNT   = gibNT
+twoNT   = TwoNtShape and hcp(north)>19 and hcp(north)<22
+
+# Define Gambling 3N
+g3Shape = shape(north,any 9xxx +any 8xxx +any 7xxx -any 4xxx -any 5xxx -any 6xxx)
+threeNT = (top3(north,clubs)==3 and clubs(north)>6) or (top3(north,diamonds)==3 and diamonds(north)>6) and hcp(north)<12 and g3Shape
+
+# Define Game Forcing 2C
+case1 = hcp(north)>18 and nTP>21
+case2 = hcp(north)>18 and nTP>19 and losers(north)<5 and (spades(north)>5 or hearts(north)>5)
+case3 = hcp(north)>18 and nTP>19 and losers(north)<4 and (diamonds(north)>5 or clubs(north)>5)
+gameForce2C = (case1 or case2 or case3)
+
+### Predict North's opening BID
+P1 = gameForce2C
+P2 = P1 or threeNT or twoNT or oneNT
+
+# Define quality and length lower limits for 10 HCP openers
+
+q2of3 = (top3(north,spades)>1 or top3(north,hearts)>1) and controls(north)>3
+lgt5  = (spades(north)>4 or hearts(north)>4) and shape(north,any 7xxx +any 64xx +any 55xx +any 1xxx+any 0xxx -any 8xxx -any 54xx) and nTP>(hcp(north) +2)
+
+# Predict North's Opening suit
+# What's the longest suit?
+s = spades(north)
+h = hearts(north)
+d = diamonds(north)
+c = clubs(north)
+
+## GIB has different requirements for 1H/S, 1D, and 1C openings
+#Define range for 1 H/S
+lS = s>4 and s>=h and s>=d and s>=c
+lH = h>4 and h>s and h>=d and h>=c
+lM = lS or lH
+
+hsOK1 = lM and hcp(north)>11
+hsOK2 = lM and hcp(north)>10 and nTP>12 and not hsOK1
+hsOK3 = lM and hcp(north)>9  and lgt5 and q2of3 and not (hsOK1 or hsOK2)
+hsRange = (hsOK1 or hsOK2 or hsOK3) and not P2
+
+# Define 1D Range
+dOK1 = hcp(north)>11 and (diamonds(north)>3 or shape(north, 4432))
+dOK2 = hcp(north)>9  and nTP>12 and diamonds(north)>5 and not dOK1
+dRange = (dOK1 or dOK2) and not P2
+
+# Define 1C Range
+cOK1 = hcp(north)>10 and nTP>12 and spades(north)==4
+cOK2 = hcp(north)>9  and nTP>12 and clubs(north)>5 and not cOK1
+cOK3 = hcp(north)>11 and clubs(north)>2            and not (cOK1 or cOK2)
+cRange = (cOK1 or cOK2 or cOK3) and clubs(north)>2 and clubs(north)>diamonds(north) and not P2
+
+oS = s>4 and s>=h and s>=d and s>=c and hsRange
+oH = not oS and h>4 and h>=d and h>=c and hsRange
+oD = not (oS or oH) and ((d>3 and d>=c) or c<3) and dRange
+oC = not (oS or oH or oD) and cRange
+openingSuit = (oS or oH or oD or oC)
+oneSpade   = oS
+oneHeart   = oH
+oneDiamond = oD
+oneClub    = oC
+
+##### End of Imported Script -- Predict Opening 1-Bid-North #####
+# Returns oS & oH
+
+### Imported script: TP (Total Points)
+//   Total Points = HCP + Short-Suit Points - Penalty Points
+//   Short-Suit Points: 3 for void, 2 for singleton, 1 for doubleton
+//   Penalty Points: 1 for each honor (K/Q/J) in a short suit (devalues wasted honors like Kx, Qx)
+
+## Calculate TP for North
+# Short-Suit Points: void=3, singleton=2, doubleton=1
+nSpadeSSP = spades(north)<3   ? 3-spades(north)   : 0
+nHeartSSP = hearts(north)<3   ? 3-hearts(north)   : 0
+nDiamSSP  = diamonds(north)<3 ? 3-diamonds(north) : 0
+nClubSSP  = clubs(north)<3    ? 3-clubs(north)    : 0
+nSSP = nSpadeSSP + nHeartSSP + nDiamSSP + nClubSSP
+
+# Penalty Points: deduct 1 for honors in short suits
+nSpadePP = spades(north)<3   and hcp(north,spades)>0   ? 1 : 0
+nHeartPP = hearts(north)<3   and hcp(north,hearts)>0   ? 1 : 0
+nDiamPP  = diamonds(north)<3 and hcp(north,diamonds)>0 ? 1 : 0
+nClubPP  = clubs(north)<3    and hcp(north,clubs)>0    ? 1 : 0
+nPP = nSpadePP + nHeartPP + nDiamPP + nClubPP
+
+tpNorth = hcp(north) + nSSP - nPP
+
+## Calculate TP for East
+eSpadeSSP = spades(east)<3   ? 3-spades(east)   : 0
+eHeartSSP = hearts(east)<3   ? 3-hearts(east)   : 0
+eDiamSSP  = diamonds(east)<3 ? 3-diamonds(east) : 0
+eClubSSP  = clubs(east)<3    ? 3-clubs(east)    : 0
+eSSP = eSpadeSSP + eHeartSSP + eDiamSSP + eClubSSP
+
+eSpadePP = spades(east)<3   and hcp(east,spades)>0   ? 1 : 0
+eHeartPP = hearts(east)<3   and hcp(east,hearts)>0   ? 1 : 0
+eDiamPP  = diamonds(east)<3 and hcp(east,diamonds)>0 ? 1 : 0
+eClubPP  = clubs(east)<3    and hcp(east,clubs)>0    ? 1 : 0
+ePP = eSpadePP + eHeartPP + eDiamPP + eClubPP
+
+tpEast = hcp(east) + eSSP - ePP
+
+## Calculate TP for South
+sSpadeSSP = spades(south)<3   ? 3-spades(south)   : 0
+sHeartSSP = hearts(south)<3   ? 3-hearts(south)   : 0
+sDiamSSP  = diamonds(south)<3 ? 3-diamonds(south) : 0
+sClubSSP  = clubs(south)<3    ? 3-clubs(south)    : 0
+sSSP = sSpadeSSP + sHeartSSP + sDiamSSP + sClubSSP
+
+sSpadePP = spades(south)<3   and hcp(south,spades)>0   ? 1 : 0
+sHeartPP = hearts(south)<3   and hcp(south,hearts)>0   ? 1 : 0
+sDiamPP  = diamonds(south)<3 and hcp(south,diamonds)>0 ? 1 : 0
+sClubPP  = clubs(south)<3    and hcp(south,clubs)>0    ? 1 : 0
+sPP = sSpadePP + sHeartPP + sDiamPP + sClubPP
+
+tpSouth = hcp(south) + sSSP - sPP
+
+## Calculate TP for West
+wSpadeSSP = spades(west)<3   ? 3-spades(west)   : 0
+wHeartSSP = hearts(west)<3   ? 3-hearts(west)   : 0
+wDiamSSP  = diamonds(west)<3 ? 3-diamonds(west) : 0
+wClubSSP  = clubs(west)<3    ? 3-clubs(west)    : 0
+wSSP = wSpadeSSP + wHeartSSP + wDiamSSP + wClubSSP
+
+wSpadePP = spades(west)<3   and hcp(west,spades)>0   ? 1 : 0
+wHeartPP = hearts(west)<3   and hcp(west,hearts)>0   ? 1 : 0
+wDiamPP  = diamonds(west)<3 and hcp(west,diamonds)>0 ? 1 : 0
+wClubPP  = clubs(west)<3    and hcp(west,clubs)>0    ? 1 : 0
+wPP = wSpadePP + wHeartPP + wDiamPP + wClubPP
+
+tpWest = hcp(west) + wSSP - wPP
+
+## Partnership Totals
+tpNS = tpNorth + tpSouth
+tpEW = tpEast + tpWest
+
+### End of Imported Script: TP
+# Returns tpSouth
+
+# Avoid preempts, weak 2, Michaels, and Unusual NT
+ePreempt  = shape(east,any 9xxx +any 8xxx +any 7xxx +any 6xxx) and hcp(east)>3
+e2Suits   = shape(east,any 76xx +any 75xx +any 66xx +any 65xx +any 55xx) and hcp(east)>3
+eOvercall = shape(east,any 5xxx) and hcp(east)>7
+ePasses   = hcp(east)<11 and not(ePreempt or e2Suits or eOvercall)
+
+# Define South's 3- 4+ and 5+ card fits
+spadeFit3 = oS and spades(south)==3
+spadeFit4 = oS and spades(south)==4
+spadeFit5 = oS and spades(south)>4
+heartFit3 = oH and hearts(south)==3
+heartFit4 = oH and hearts(south)==4
+heartFit5 = oH and hearts(south)>4
+fit3 = spadeFit3 or heartFit3
+fit4 = spadeFit4 or heartFit4
+fit5 = spadeFit5 or heartFit5
+
+# Calculate South's Total Points: tpSouth +1 for 4+ support unless 4333
+sP = tpSouth + (fit4 and shape(south,xxxx-any 4333))
+
+# Avoid Splinter
+Splinter = fit4 and shape(south,any 0xxx +any 1xxx) and sP>10 and sP<16
+
+preempt = sP<8            and fit5
+faulty  = sP>3  and sP<8  and (fit3 or fit4)
+simple  = sP>7  and sP<11 and (fit3 or fit4)
+invite3 = sP>10 and sP<13 and fit3
+invite4 = sP>10 and sP<13 and fit4
+
+### Imported Leveling Code ###
+c1 = hascard(west,2C)
+c2 = hascard(east,2D)
+c3 = hascard(west,3C)
+c4 = hascard(east,3D)
+
+keep06 = c1 and c2          // this is used later w/c3 & c4 expressions
+keep44 = c3 or c4           // this is used later w/c1 & c2 expressions
+
+keep015 = keep06 and c3
+keep03 = keep06 and keep44
+keep045 = keep06 and not c3
+####06 = c1 and c2
+keep11 = c1 and keep44
+keep14 = c1 and not keep44
+keep19 = c1 and not c2
+keep25 = c1
+keep30 = keep06 or c3
+keep33 = c1 or (c2 and keep44)
+####44 = c3 or c4
+keep47 = keep44 or keep06
+
+keep53 = not keep47
+keep56 = not keep44
+keep67 = not keep33
+keep70 = not keep30
+keep75 = not keep25
+keep81 = not keep19
+keep86 = not keep14
+keep89 = not keep11
+keep94 = not keep06
+keep955 = not keep045
+keep97 = not keep03
+keep985 = not keep015
+keep   = 1
+keep0  = 0
+### End of Imported Leveling Code ###
+
+lev1 = faulty  and keep25
+lev2 = simple  and keep11
+lev3 = invite3 and keep25
+lev4 = invite4 and keep89
+lev5 = preempt and keep
+levelTheDeal = lev1 or lev2 or lev3 or lev4 or lev5
+
+nOpens = (oH or oS) and hcp(north)>11 and hcp(north)<19
+sResponds = (preempt or faulty or simple or invite3 or invite4) and not Splinter
+
+nOpens and ePasses and sResponds
+and levelTheDeal
+action average "bench" hcp(north)

--- a/bench/corpus/Scrambling_2NT.dlr
+++ b/bench/corpus/Scrambling_2NT.dlr
@@ -1,0 +1,42 @@
+# alias: Scrambling
+# button-text: Scrambling 2NT
+# scenario-title: --- Scrambling 2NT.  In a competitive auction, when your'e forced to bid, 2NT is Scrambling.
+# gib-works: true
+# bba-works: true
+# auction-filter: Auction.....\n(1H +Pass +2H|1S +Pass +2S) +X\nPass.
+# convention-card-ns: 21GF-DEFAULT
+# convention-card-ew: 21GF-GIB
+
+
+
+# Scrambling 2NT
+dealer west
+
+# West has 1 Major suit
+wS = spades(west)>4 and spades(west)>=hearts(west) and spades(west)>=diamonds(west) and spades(west)>=clubs(west)
+wH = hearts(west)>4 and hearts(west)>spades(west)  and hearts(west)>=diamonds(west) and hearts(west)>=clubs(west)
+
+# West has a fit w/3 and 8-9 HCP or w/4 and 6-7 HCP
+s3Fit = wS and spades(east)==3
+h3Fit = wH and hearts(east)==3
+ew3Fit = (s3Fit or h3Fit) and hcp(east)>7 and hcp(east)<10
+
+s4Fit = wS and spades(east)==4
+h4Fit = wH and hearts(east)==4
+ew4Fit = (s4Fit or h4Fit) and hcp(east)>5 and hcp(east)<8
+
+OBAR = hcp(west)>11 and hcp(west)<15 and (ew3Fit or ew4Fit)
+
+# South makes a take-out double
+sShape = wS ? shape(south,2434+2443+1444+0454+0445) : shape(south,4234+4243+4144+4054+4045)
+hcpBoost = shape(south,any 4432) ? 1 : 0
+sTOX = sShape and hcp(south)>(12 + hcpBoost)  // require an extra hcp for 4432
+
+# North has a flatish hand with 2-suits
+nMajor    = spades(north)>3 or hearts(north)>3   // with a Major, North has option of free-bid or scramble & bid
+twoSuits  = shape(north,any 54xx + any 44xx)
+nFreeBid  = (nMajor and hcp(north)>9) or not twoSuits
+nScramble = ((not nMajor and shape(north,xx45 + xx54 + xx44)) or (nMajor and hcp(north)<10)) and not nFreeBid
+
+OBAR and sTOX and (nFreeBid or nScramble)
+action average "bench" hcp(north)

--- a/bench/corpus/Slam_After_Major_Fit.dlr
+++ b/bench/corpus/Slam_After_Major_Fit.dlr
@@ -1,0 +1,65 @@
+# alias: SlamAfterMajor
+# button-text: Major Suit Slam
+# scenario-title: --- Slam w/Major Suit Fit -- N/S have 29+ HCP
+# gib-works: true
+# bba-works: true
+# auction-filter: Auction.....\n1[HS]
+# convention-card-ns: 21GF-DEFAULT
+# convention-card-ew: 21GF-GIB
+
+
+
+# Major_Suit_Fit
+dealer south
+
+##### Imported Script: Define Calm Opponents #####
+
+# Avoid concentration of values
+cce = top4(east,clubs)<2
+cde = top4(east,diamonds)<2
+che = top4(east,hearts)<2
+cse = top4(east,spades)<2
+noConEast = cce and cde and che and cse
+
+ccw = top4(west,clubs)<2
+cdw = top4(west,diamonds)<2
+chw = top4(west,hearts)<2
+csw = top4(west,spades)<2
+noConWest = ccw and cdw and chw and csw
+
+balEast    = shape(east,any 4432 +any 4333)
+unbalEast  = shape(east,xxxx -any 4432 -any 4333 -any 9xxx -any 8xxx -any 7xxx-any 6xxx -any 55xx)
+
+balWest    = shape(west,any 4432 +any 4333)
+unbalWest  = shape(west,xxxx -any 4432 -any 4333 -any 9xxx -any 8xxx -any 7xxx-any 6xxx -any 55xx)
+
+calmEast = (unbalEast and noConEast and hcp(east)<8) or (balEast and hcp(east)<11)
+calmWest = (unbalWest and noConWest and hcp(west)<8) or (balWest and hcp(west)<11)
+calmOpps = calmEast and calmWest
+
+##### End of Imported Script: Define Calm Opponents #####
+# Returns calmWest
+
+##### Imported Script -- GIB 1 Notrump #####
+
+# GIB opens 1N w/15-17 HCP or 15-16 and a 5-card major
+ntP = hcp(south) + shape(south,5xxx+x5xx)
+nt1 = shape(south, any 5332+any 4432+any 4333) and hcp(south)>14 and ntP<18
+
+# GIB does not open with 5422 and a 5-card major or with 4 spades
+# GIB does not open with 5422 and the strength to reverse
+nt2 = shape(south, any 5422-5xxx-x5xx-4xxx) and hcp(south)>14 and hcp(south)<17
+
+gibNT = nt1 or nt2
+
+### End of GIB 1 Notrump ###
+# Returns gibNT
+
+heartFit = shape(south,x7xx + x6xx + x5xx -any 65xx -any 55xx) and hearts(north)>2
+spadeFit = shape(south,7xxx + 6xxx + 5xxx -any 65xx -any 55xx) and spades(north)>2
+
+# North opens 1 Major and South has a fit
+oneM = (heartFit or spadeFit) and not gibNT
+
+oneM and hcp(south)>11 and hcp(south)<20 and hcp(north)>5 and (hcp(north)+hcp(south))>28 and calmWest
+action average "bench" hcp(north)

--- a/bench/corpus/Splinters_By_Opener.dlr
+++ b/bench/corpus/Splinters_By_Opener.dlr
@@ -1,0 +1,229 @@
+# alias: SplinterByOpener
+# button-text: Splinter by Opener
+# scenario-title: --- Splinter by Opener
+# gib-works: true
+# bba-works: true
+# auction-filter: (1[CDH] +Pass +1S +Pass\n4[CDH])|(1[CD] +Pass +1H +Pass\n(3S|4[CD]))
+# convention-card-ns: 21GF-DEFAULT
+# convention-card-ew: 21GF-GIB
+
+
+
+dealer south
+
+# Splinters by Opener
+
+##### Imported Script: Define Calm Opponents #####
+
+# Avoid concentration of values
+cce = top4(east,clubs)<2
+cde = top4(east,diamonds)<2
+che = top4(east,hearts)<2
+cse = top4(east,spades)<2
+noConEast = cce and cde and che and cse
+
+ccw = top4(west,clubs)<2
+cdw = top4(west,diamonds)<2
+chw = top4(west,hearts)<2
+csw = top4(west,spades)<2
+noConWest = ccw and cdw and chw and csw
+
+balEast    = shape(east,any 4432 +any 4333)
+unbalEast  = shape(east,xxxx -any 4432 -any 4333 -any 9xxx -any 8xxx -any 7xxx-any 6xxx -any 55xx)
+
+balWest    = shape(west,any 4432 +any 4333)
+unbalWest  = shape(west,xxxx -any 4432 -any 4333 -any 9xxx -any 8xxx -any 7xxx-any 6xxx -any 55xx)
+
+calmEast = (unbalEast and noConEast and hcp(east)<8) or (balEast and hcp(east)<11)
+calmWest = (unbalWest and noConWest and hcp(west)<8) or (balWest and hcp(west)<11)
+calmOpps = calmEast and calmWest
+
+##### End of Imported Script: Define Calm Opponents #####
+##### Imported Script -- Predict Opening 1-Bid South #####
+# 01/19/2026 -- Changed to use TP and separate ranges for C, D, and majors
+# 03/30/2025 -- Changed to use gibNT
+
+# GIB opens 1N w/15-17 HCP or 15-16 and a 5-card major
+ntP = hcp(south) + shape(south,5xxx+x5xx)
+nt1 = shape(south, any 5332+any 4432+any 4333) and hcp(south)>14 and ntP<18
+
+# GIB does not open with 5422 and a 5-card major
+# GIB does not open with 5422 and the strength to reverse
+nt2 = shape(south, any 5422 -5xxx-x5xx-4xxx) and hcp(south)>14 and hcp(south)<17
+
+gibNT = nt1 or nt2
+
+## Calculate TP for South -- NOTE:  This uses different variable names than TP to avoid conflicts when both are used.
+# Calculate South's Short-Suit Penalty Points
+ssp = spades(south)<3 and hcp(south,spades)>0     ? 1 : 0
+shp = hearts(south)<3 and hcp(south,hearts)>0     ? 1 : 0
+sdp = diamonds(south)<3 and hcp(south,diamonds)>0 ? 1 : 0
+scp = clubs(south)<3 and hcp(south,clubs)>0       ? 1 : 0
+
+# Calculate South's Short-Suit Points
+sv01 = shape(south, any 0xxx) ? 3 : 0
+ss01 = shape(south, any 1xxx) ? 2 : 0 // allow for 2 singletons
+ss02 = shape(south, any 11xx) ? 2 : 0
+sd01 = shape(south, any 2xxx) ? 1 : 0 // allow for 3 doubletons
+sd02 = shape(south, any 22xx) ? 1 : 0
+sd03 = shape(south, any 222x) ? 1 : 0
+
+# Calculate South's Total Points
+sTP = hcp(south) + sv01+ss01+ss02+sd01+sd02+sd03 -ssp-shp-sdp-scp
+
+# Calculate length points for South (lengthPoints)
+lp1 = spades(south)>4 ? spades(south)-4 : 0
+lp2 = hearts(south)>4 ? hearts(south)-4 : 0
+lp3 = diamonds(south)>4 ? diamonds(south)-4 : 0
+lp4 = clubs(south)>4 ? clubs(south)-4 : 0
+lengthPoints = lp1 + lp2 + lp3 + lp4
+
+# Define suit points for south (suitPoints)
+suitPoints = hcp(south) + lengthPoints
+
+TwoNtShape = shape(south, any 4333 +any 4432 +any 5332 +any 5422)
+
+# Define ntPoint ranges
+oneNT   = gibNT
+twoNT   = TwoNtShape and hcp(south)>19 and hcp(south)<22
+
+# Define Gambling 3N
+g3Shape = shape(south,any 9xxx +any 8xxx +any 7xxx -any 4xxx -any 5xxx -any 6xxx)
+threeNT = (top3(south,clubs)==3 and clubs(south)>6) or (top3(south,diamonds)==3 and diamonds(south)>6) and hcp(south)<12 and g3Shape
+
+# Define Game Forcing 2C
+case1 = hcp(south)>18 and sTP>21
+case2 = hcp(south)>18 and sTP>19 and losers(south)<5 and (spades(south)>5 or hearts(south)>5)
+case3 = hcp(south)>18 and sTP>19 and losers(south)<4 and (diamonds(south)>5 or clubs(south)>5)
+gameForce2C = (case1 or case2 or case3)
+
+### Predict South's opening BID
+P1 = gameForce2C
+P2 = P1 or threeNT or twoNT or oneNT
+
+# Define quality and length lower limits for 10 HCP openers
+
+q2of3 = (top3(south,spades)>1 or top3(south,hearts)>1) and controls(south)>3
+lgt5  = (spades(south)>4 or hearts(south)>4) and shape(south,any 7xxx +any 64xx +any 55xx +any 1xxx+any 0xxx -any 8xxx -any 54xx) and sTP>(hcp(south) +2)
+
+# Predict South's Opening suit
+# What's the longest suit?
+s = spades(south)
+h = hearts(south)
+d = diamonds(south)
+c = clubs(south)
+
+## GIB has different requirements for 1H/S, 1D, and 1C openings 
+#Define range for 1 H/S
+lS = s>4 and s>=h and s>=d and s>=c
+lH = h>4 and h>s and h>=d and h>=c
+lM = lS or lH
+
+hsOK1 = lM and hcp(south)>11
+hsOK2 = lM and hcp(south)>10 and sTP>12 and not hsOK1
+hsOK3 = lM and hcp(south)>9  and lgt5 and q2of3 and not (hsOK1 or hsOK2)
+hsRange = (hsOK1 or hsOK2 or hsOK3) and not P2
+
+# Define 1D Range
+dOK1 = hcp(south)>11 and (diamonds(south)>3 or shape(south, 4432))
+dOK2 = hcp(south)>9  and sTP>12 and diamonds(south)>5 and not dOK1
+dRange = (dOK1 or dOK2) and not P2
+
+# Define 1C Range
+cOK1 = hcp(south)>10 and sTP>12 and spades(south)==4
+cOK2 = hcp(south)>9  and sTP>12 and clubs(south)>5 and not cOK1
+cOK3 = hcp(south)>11 and clubs(south)>2            and not (cOK1 or cOK2)
+cRange = (cOK1 or cOK2 or cOK3) and clubs(south)>2 and clubs(south)>diamonds(south) and not P2
+
+oS = s>4 and s>=h and s>=d and s>=c and hsRange
+oH = not oS and h>4 and h>=d and h>=c and hsRange
+oD = not (oS or oH) and ((d>3 and d>=c) or c<3) and dRange
+oC = not (oS or oH or oD) and cRange
+openingSuit = (oS or oH or oD or oC)
+oneSpade   = oS
+oneHeart   = oH
+oneDiamond = oD
+oneClub    = oC
+
+##### End of Imported Script -- Predict Opening 1-Bid #####
+
+###### Define Bidding Sequences #####
+# These variables are defined in the imported script
+# The number of cards South has in each suit: s, h, d, c
+# South's predicted opening suit: oC, oD, oH, oS 
+
+sP = hcp(south)
+nP = hcp(north)
+
+# Predict North's 1-level response
+sN = spades(north)
+hN = hearts(north)
+dN = diamonds(north)
+cN = clubs(north)
+
+# North responds in D, H, or S (Walsh style), or raises C.  longer than C to avoid 2/1
+
+# Predict North's responding suit
+nRS  =  nP<11 ? sN>3 and sN>hN : sN>3 and sN>hN and sN>=dN and sN>=cN               // avoid 2/1 in minor
+nRH  = (nP<11 ? hN>3           : hN>3           and hN>=dN and hN>=cN) and not (nRS)
+nRD = dN>3           and dN>=cN and not (nRS or nRH)
+nRC = cN>4           and cN>4   and not (nRS or nRH or nRD)
+nRN = not (nRS or nRH or nRD or nRC)
+
+# Define South's possible rebids
+sRC = clubs(south)>3
+sRD = diamonds(south)>3
+sRH = hearts(south)>3
+sRS = spades(south)>3
+sRN = shape(south,any 4333+any 4432+any 5332)
+
+# Defining South's opening (not NT) & North's non-GF response
+CD = oC and nRD
+CH = oC and nRH
+CS = oC and nRS
+CN = oC and nRN
+CC = oC and nRC
+
+DH = oD and nRH
+DS = oD and nRS
+DN = oD and nRN
+DD = oD and not (DH or DS or DN)
+
+HS = sP<11 ? oH and nRS and hN<3 : oH and nRS and hN<4     // no Jacoby 2N
+HN = oH and nRN
+HH = oH and not (HS or HN)
+##### End of Define Bidding Sequences #####
+
+# Don't include a singleton K, Q, or J
+Cshort = (shape(south,xxx1) and (top4(south,clubs)   ==0 or hascard(south,AC)) or shape(south,xxx0))
+Dshort = (shape(south,xx1x) and (top4(south,diamonds)==0 or hascard(south,AD)) or shape(south,xx0x))
+Hshort = (shape(south,x1xx) and (top4(south,hearts)  ==0 or hascard(south,AH)) or shape(south,x0xx))
+Sshort = (shape(south,1xxx) and (top4(south,spades)  ==0 or hascard(south,AS)) or shape(south,0xxx))
+
+# Responder does NOT have direct support for Opener's suit
+##   I may need to add this   ##
+
+# Define splinter sequences
+CH3D = CH and h>3 and Dshort  // invite
+CH3S = CH and h>3 and Sshort
+CS3D = CS and s>3 and Dshort  // invite
+CS3H = CS and s>3 and Hshort  // invite
+DH4C = DH and h>3 and Cshort
+DH3S = DH and h>3 and Sshort
+DS4C = DS and s>3 and Cshort
+DS3H = DS and s>3 and Hshort  // invite
+HS4C = HS and s>3 and Cshort
+HS4D = HS and s>3 and Dshort
+jReverse   = (CH3D or CS3D or CS3H or DS3H) and hcp(south)>12 and hcp(south)<22
+jJumpShift = (CH3S or DH4C or DH3S or DS4C or HS4C or HS4D) and hcp(south)>15 and hcp(south)<19
+
+# North does not have direct support for south
+northOK = 1
+
+sOpens = jReverse or jJumpShift
+
+northRange = hcp(north)>5  and hcp(north)<17  // no jump shifts
+
+# Now do it
+sOpens and northRange and calmOpps
+action average "bench" hcp(north)

--- a/bench/corpus/_shuffle_baseline.dlr
+++ b/bench/corpus/_shuffle_baseline.dlr
@@ -1,0 +1,7 @@
+# Synthetic. Not from Practice-Bidding-Scenarios.
+#
+# Measures deal generation -- RNG plus shuffle -- with as little condition
+# evaluation as the language permits, so the generation half of the comparison
+# can be read on its own. See BASELINE_NAME in scripts/benchlib.py.
+hcp(north) >= 24
+action average "bench" hcp(north)

--- a/bench/corpus/_solver_agreement.dlr
+++ b/bench/corpus/_solver_agreement.dlr
@@ -1,0 +1,12 @@
+# Synthetic. Not from Practice-Bidding-Scenarios.
+#
+# Checks that dealer3 and DealerV2_4 return the same double-dummy results for
+# the same cards. dealer.exe and dealer-c have no solver and are excluded.
+#
+# Spellings are the intersection of the two languages: `north` lowercase,
+# `NS` uppercase. See SOLVER_NAME in scripts/benchlib.py.
+condition hcp(north) + hcp(south) >= 26
+action
+    average "dds north notrump" dds(north, notrump),
+    average "dds south spades" dds(south, spades),
+    average "par NS" par(NS)

--- a/bench/results/BASELINE.md
+++ b/bench/results/BASELINE.md
@@ -1,0 +1,67 @@
+# Baseline: dealer3 source `92f902fd12e4`, corpus `7d7033566ed1`
+
+Measured 2026-09-01 on an Apple M4 Pro (12 logical, 8P+4E), best of 3 runs.
+This is the "before" for the deal-generation work: dealer3 as it stands,
+with `sort_all_hands()` still running on every generated deal.
+
+```
+dealer3 results : dealer3-92f902fd12e4.json
+                  source 92f902fd12e4, repo v0.4.0-197-g93bc1ec-dirty
+reference       : reference-7d7033566ed1.json
+machine         : Apple M4 Pro  12 logical (8P+4E)
+
+script                           exe*  dealer-c     V2_4   d3 -R1  d3 auto    vs C   vs V2
+                                  M/s       M/s      M/s      M/s      M/s   (-R1)   (-R1)
+----------------------------------------------------------------------------------------------
+Scrambling_2NT                  0.231     2.754    1.319    1.519    7.592    0.6x    1.2x
+GIB_1N_Basic                    0.226     2.806    1.307    1.468    7.865    0.5x    1.1x
+Slam_After_Major_Fit            0.224     2.786    1.309    1.476    8.036    0.5x    1.1x
+After_Partner_Overcalls         0.205     2.081    1.150    1.004    5.121    0.5x    0.9x
+Major_Suit_Fit                  0.193     1.736    1.052    0.970    5.202    0.6x    0.9x
+Drury                           0.209     2.226    1.184    0.820    4.373    0.4x    0.7x
+Basic_Takeout_Double            0.169     1.193    0.874    0.596    3.235    0.5x    0.7x
+GIB_1C-P-Resp                   0.175     1.299    0.910    0.537    3.175    0.4x    0.6x
+Splinters_By_Opener             0.097     0.424    0.428    0.425    2.219    1.0x    1.0x
+Gerber_By_Responder             0.098     0.331    0.386    0.330    2.038    1.0x    0.9x
+----------------------------------------------------------------------------------------------
+* dealer.exe runs x86-emulated on an ARM64 VM; dealer-c is the same
+  source built natively, and is the fair comparison for its lineage.
+
+dealer3 -R1 is 0.6x the original C dealer, built natively (geometric mean).
+dealer3 -R1 is 4.6x dealer.exe as run on the VM (emulated -- not a like-for-like figure).
+dealer3 -R1 is 0.9x DealerV2_4 across the corpus (geometric mean).
+Threading (auto) buys 5.42x over single-threaded.
+
+Where the time goes, per deal (ns)
+               generate   evaluate      total   gen share
+----------------------------------------------------------
+dealer.exe         1485       4532       6017        25%
+dealer-c            176        781        957        18%
+DealerV2_4          269        943       1212        22%
+dealer3 -R1         534        884       1418        38%
+----------------------------------------------------------
+Mean over the corpus. 'generate' is the _shuffle_baseline entry:
+RNG and shuffle with a near-free condition.
+
+Against the original C dealer: dealer3 is 3.0x SLOWER at generating and is 1.1x SLOWER at evaluating.
+
+Against DealerV2_4: dealer3 is 2.0x SLOWER at generating and is 1.1x faster at evaluating.
+
+Against dealer.exe (emulated): dealer3 is 2.8x faster at generating and is 5.1x faster at evaluating.
+
+Thread scaling (corpus mean)
+threads   speedup  efficiency                          
+--------------------------------------------------------
+      1     1.00x       100%  ####
+      2     1.70x        85%  ######
+      3     2.19x        73%  ########
+      4     3.08x        77%  ############
+      5     3.54x        71%  ##############
+      6     4.06x        68%  ################
+      7     4.53x        65%  ##################
+      8     4.79x        60%  ###################
+     10     5.13x        51%  ####################
+     12     5.30x        44%  #####################
+--------------------------------------------------------
+Peak 5.30x at 12 threads.
+```

--- a/bench/results/CURRENT.md
+++ b/bench/results/CURRENT.md
@@ -1,0 +1,91 @@
+# Current: dealer3 source `28d0c086459a`, corpus `7d7033566ed1`
+
+Measured 2026-09-01 on an Apple M4 Pro (12 logical, 8P+4E), best of 3 runs.
+This is the "after" for removing the per-deal hand sort (`93cf0c2`).
+The "before" is [BASELINE.md](BASELINE.md), source `92f902fd12e4`.
+
+Reference numbers are unchanged and shared between the two: the three
+reference programs did not move, and `corpus_id` is the same, so
+`reference-7d7033566ed1.json` is valid for both.
+
+```
+dealer3 results : dealer3-28d0c086459a.json
+                  source 28d0c086459a, repo v0.4.0-201-g93cf0c2
+reference       : reference-7d7033566ed1.json
+machine         : Apple M4 Pro  12 logical (8P+4E)
+
+script                           exe*  dealer-c     V2_4   d3 -R1  d3 auto    vs C   vs V2
+                                  M/s       M/s      M/s      M/s      M/s   (-R1)   (-R1)
+----------------------------------------------------------------------------------------------
+Scrambling_2NT                  0.231     2.754    1.319    3.190   10.211    1.2x    2.4x
+GIB_1N_Basic                    0.226     2.806    1.307    2.995   10.332    1.1x    2.3x
+Slam_After_Major_Fit            0.224     2.786    1.309    3.103    7.357    1.1x    2.4x
+After_Partner_Overcalls         0.205     2.081    1.150    1.547    7.063    0.7x    1.3x
+Major_Suit_Fit                  0.193     1.736    1.052    1.481    6.667    0.9x    1.4x
+Drury                           0.209     2.226    1.184    1.144    5.190    0.5x    1.0x
+Basic_Takeout_Double            0.169     1.193    0.874    0.762    4.000    0.6x    0.9x
+GIB_1C-P-Resp                   0.175     1.299    0.910    0.668    3.497    0.5x    0.7x
+Splinters_By_Opener             0.097     0.424    0.428    0.501    2.635    1.2x    1.2x
+Gerber_By_Responder             0.098     0.331    0.386    0.378    2.241    1.1x    1.0x
+----------------------------------------------------------------------------------------------
+* dealer.exe runs x86-emulated on an ARM64 VM; dealer-c is the same
+  source built natively, and is the fair comparison for its lineage.
+
+dealer3 -R1 is 0.9x the original C dealer, built natively (geometric mean).
+dealer3 -R1 is 7.0x dealer.exe as run on the VM (emulated -- not a like-for-like figure).
+dealer3 -R1 is 1.3x DealerV2_4 across the corpus (geometric mean).
+Threading (auto) buys 4.29x over single-threaded.
+
+Where the time goes, per deal (ns)
+               generate   evaluate      total   gen share
+----------------------------------------------------------
+dealer.exe         1485       4532       6017        25%
+dealer-c            176        781        957        18%
+DealerV2_4          269        943       1212        22%
+dealer3 -R1         188        874       1062        18%
+----------------------------------------------------------
+Mean over the corpus. 'generate' is the _shuffle_baseline entry:
+RNG and shuffle with a near-free condition.
+
+Against the original C dealer: dealer3 is 1.1x SLOWER at generating and is 1.1x SLOWER at evaluating.
+
+Against DealerV2_4: dealer3 is 1.4x faster at generating and is 1.1x faster at evaluating.
+
+Against dealer.exe (emulated): dealer3 is 7.9x faster at generating and is 5.2x faster at evaluating.
+
+Change against dealer3-92f902fd12e4.json
+  source 92f902fd12e4 -> 28d0c086459a
+script                           before      after     change
+--------------------------------------------------------------
+Scrambling_2NT                   1.519     3.190     2.10x faster
+GIB_1N_Basic                     1.468     2.995     2.04x faster
+Slam_After_Major_Fit             1.476     3.103     2.10x faster
+After_Partner_Overcalls          1.004     1.547     1.54x faster
+Major_Suit_Fit                   0.970     1.481     1.53x faster
+Drury                            0.820     1.144     1.40x faster
+Basic_Takeout_Double             0.596     0.762     1.28x faster
+GIB_1C-P-Resp                    0.537     0.668     1.24x faster
+Splinters_By_Opener              0.425     0.501     1.18x faster
+Gerber_By_Responder              0.330     0.378     1.14x faster
+_shuffle_baseline                1.872     5.324     2.84x faster
+--------------------------------------------------------------
+M deals/s, single-threaded (-R 1).
+
+Overall: 1.60x faster across 11 scripts (geometric mean).
+
+Thread scaling (corpus mean)
+threads   speedup  efficiency                          
+--------------------------------------------------------
+      1     1.00x       100%  ####
+      2     1.57x        78%  ######
+      3     2.10x        70%  ########
+      4     2.81x        70%  ###########
+      5     3.18x        64%  ############
+      6     3.54x        59%  ##############
+      7     3.89x        56%  ###############
+      8     3.85x        48%  ###############
+     10     4.21x        42%  ################
+     12     4.30x        36%  #################
+--------------------------------------------------------
+Peak 4.30x at 12 threads.
+```

--- a/bench/results/dealer3-28d0c086459a.json
+++ b/bench/results/dealer3-28d0c086459a.json
@@ -1,0 +1,2230 @@
+{
+  "tool": "bench-dealer3",
+  "revision": "v0.4.0-201-g93cf0c2",
+  "source_id": "28d0c086459a",
+  "corpus_id": "7d7033566ed1",
+  "repeats": 3,
+  "scale": 1.0,
+  "scripts": {
+    "Scrambling_2NT": {
+      "deals": 2900000,
+      "hit_rate": 0.00025,
+      "single": {
+        "seconds_best": 0.909,
+        "seconds_median": 0.911,
+        "seconds_all": [
+          0.909,
+          0.911,
+          0.916
+        ],
+        "spread_pct": 0.7700770077007707,
+        "deals": 2900000,
+        "deals_per_sec": 3190319.03190319,
+        "produced": 280,
+        "wall_best": 0.9144699997268617,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.284,
+        "seconds_median": 0.301,
+        "seconds_all": [
+          0.284,
+          0.301,
+          0.336
+        ],
+        "spread_pct": 18.309859154929594,
+        "deals": 2900000,
+        "deals_per_sec": 10211267.605633805,
+        "produced": 280,
+        "wall_best": 0.28931849962100387,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 7676470,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 2.376,
+            "seconds_median": 2.407,
+            "seconds_all": [
+              2.376,
+              2.407,
+              2.411
+            ],
+            "spread_pct": 1.4730639730639792,
+            "deals": 7676470,
+            "deals_per_sec": 3230837.5420875424,
+            "produced": 722,
+            "wall_best": 2.381219749804586,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 1.663,
+            "seconds_median": 1.667,
+            "seconds_all": [
+              1.663,
+              1.667,
+              1.754
+            ],
+            "spread_pct": 5.472038484666264,
+            "deals": 7676470,
+            "deals_per_sec": 4616037.282020445,
+            "produced": 722,
+            "wall_best": 1.6681763748638332,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 1.146,
+            "seconds_median": 1.153,
+            "seconds_all": [
+              1.146,
+              1.153,
+              1.177
+            ],
+            "spread_pct": 2.705061082024445,
+            "deals": 7676470,
+            "deals_per_sec": 6698490.401396161,
+            "produced": 722,
+            "wall_best": 1.1514843753539026,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 0.921,
+            "seconds_median": 0.952,
+            "seconds_all": [
+              0.921,
+              0.952,
+              0.954
+            ],
+            "spread_pct": 3.5830618892508057,
+            "deals": 7676470,
+            "deals_per_sec": 8334929.424538544,
+            "produced": 722,
+            "wall_best": 0.9254720001481473,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 0.845,
+            "seconds_median": 0.846,
+            "seconds_all": [
+              0.845,
+              0.846,
+              0.933
+            ],
+            "spread_pct": 10.414201183431961,
+            "deals": 7676470,
+            "deals_per_sec": 9084579.881656805,
+            "produced": 722,
+            "wall_best": 0.8503527496941388,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 0.754,
+            "seconds_median": 0.812,
+            "seconds_all": [
+              0.754,
+              0.812,
+              0.853
+            ],
+            "spread_pct": 13.129973474801057,
+            "deals": 7676470,
+            "deals_per_sec": 10180994.694960212,
+            "produced": 722,
+            "wall_best": 0.7591238748282194,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.815,
+            "seconds_median": 0.868,
+            "seconds_all": [
+              0.815,
+              0.868,
+              0.885
+            ],
+            "spread_pct": 8.588957055214733,
+            "deals": 7676470,
+            "deals_per_sec": 9418981.595092025,
+            "produced": 722,
+            "wall_best": 0.8202146249823272,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.806,
+            "seconds_median": 0.818,
+            "seconds_all": [
+              0.806,
+              0.818,
+              0.879
+            ],
+            "spread_pct": 9.05707196029776,
+            "deals": 7676470,
+            "deals_per_sec": 9524156.327543424,
+            "produced": 722,
+            "wall_best": 0.81038016686216,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.801,
+            "seconds_median": 0.811,
+            "seconds_all": [
+              0.801,
+              0.811,
+              0.819
+            ],
+            "spread_pct": 2.2471910112359432,
+            "deals": 7676470,
+            "deals_per_sec": 9583607.990012484,
+            "produced": 722,
+            "wall_best": 0.806273709051311,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.789,
+            "seconds_median": 0.814,
+            "seconds_all": [
+              0.789,
+              0.814,
+              0.824
+            ],
+            "spread_pct": 4.435994930291498,
+            "deals": 7676470,
+            "deals_per_sec": 9729366.286438528,
+            "produced": 722,
+            "wall_best": 0.7943227495998144,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "GIB_1N_Basic": {
+      "deals": 2800000,
+      "hit_rate": 0.023,
+      "single": {
+        "seconds_best": 0.935,
+        "seconds_median": 0.936,
+        "seconds_all": [
+          0.935,
+          0.936,
+          0.937
+        ],
+        "spread_pct": 0.2139037433155082,
+        "deals": 2800000,
+        "deals_per_sec": 2994652.4064171123,
+        "produced": 67798,
+        "wall_best": 0.9402840421535075,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.271,
+        "seconds_median": 0.275,
+        "seconds_all": [
+          0.271,
+          0.275,
+          0.299
+        ],
+        "spread_pct": 10.332103321033198,
+        "deals": 2800000,
+        "deals_per_sec": 10332103.32103321,
+        "produced": 67798,
+        "wall_best": 0.2753593339584768,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 7777777,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 2.601,
+            "seconds_median": 2.608,
+            "seconds_all": [
+              2.601,
+              2.608,
+              2.618
+            ],
+            "spread_pct": 0.6535947712418264,
+            "deals": 7777777,
+            "deals_per_sec": 2990302.5759323337,
+            "produced": 189559,
+            "wall_best": 2.6056909589096904,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 1.746,
+            "seconds_median": 1.746,
+            "seconds_all": [
+              1.746,
+              1.746,
+              1.757
+            ],
+            "spread_pct": 0.630011454753717,
+            "deals": 7777777,
+            "deals_per_sec": 4454626.002290951,
+            "produced": 189559,
+            "wall_best": 1.7506337920203805,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 1.155,
+            "seconds_median": 1.183,
+            "seconds_all": [
+              1.155,
+              1.183,
+              1.208
+            ],
+            "spread_pct": 4.588744588744583,
+            "deals": 7777777,
+            "deals_per_sec": 6734006.060606061,
+            "produced": 189559,
+            "wall_best": 1.1592705408111215,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 0.896,
+            "seconds_median": 0.934,
+            "seconds_all": [
+              0.896,
+              0.934,
+              0.936
+            ],
+            "spread_pct": 4.464285714285718,
+            "deals": 7777777,
+            "deals_per_sec": 8680554.6875,
+            "produced": 189559,
+            "wall_best": 0.902648541610688,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 0.852,
+            "seconds_median": 0.872,
+            "seconds_all": [
+              0.852,
+              0.872,
+              0.962
+            ],
+            "spread_pct": 12.910798122065724,
+            "deals": 7777777,
+            "deals_per_sec": 9128846.244131455,
+            "produced": 189559,
+            "wall_best": 0.8572177919559181,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 0.782,
+            "seconds_median": 0.83,
+            "seconds_all": [
+              0.782,
+              0.83,
+              0.893
+            ],
+            "spread_pct": 14.194373401534524,
+            "deals": 7777777,
+            "deals_per_sec": 9946006.393861892,
+            "produced": 189559,
+            "wall_best": 0.787128834053874,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.713,
+            "seconds_median": 0.885,
+            "seconds_all": [
+              0.713,
+              0.885,
+              0.897
+            ],
+            "spread_pct": 25.806451612903235,
+            "deals": 7777777,
+            "deals_per_sec": 10908523.14165498,
+            "produced": 189559,
+            "wall_best": 0.7184609579853714,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.858,
+            "seconds_median": 0.861,
+            "seconds_all": [
+              0.858,
+              0.861,
+              0.876
+            ],
+            "spread_pct": 2.0979020979020997,
+            "deals": 7777777,
+            "deals_per_sec": 9065008.15850816,
+            "produced": 189559,
+            "wall_best": 0.8627638332545757,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.76,
+            "seconds_median": 0.785,
+            "seconds_all": [
+              0.76,
+              0.785,
+              0.844
+            ],
+            "spread_pct": 11.052631578947365,
+            "deals": 7777777,
+            "deals_per_sec": 10233917.105263159,
+            "produced": 189559,
+            "wall_best": 0.7642539162188768,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.758,
+            "seconds_median": 0.817,
+            "seconds_all": [
+              0.758,
+              0.817,
+              0.83
+            ],
+            "spread_pct": 9.498680738786273,
+            "deals": 7777777,
+            "deals_per_sec": 10260919.525065962,
+            "produced": 189559,
+            "wall_best": 0.7627638331614435,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Slam_After_Major_Fit": {
+      "deals": 2700000,
+      "hit_rate": 0.0016,
+      "single": {
+        "seconds_best": 0.87,
+        "seconds_median": 0.879,
+        "seconds_all": [
+          0.87,
+          0.879,
+          1.132
+        ],
+        "spread_pct": 30.11494252873562,
+        "deals": 2700000,
+        "deals_per_sec": 3103448.275862069,
+        "produced": 4588,
+        "wall_best": 0.8756592497229576,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.367,
+        "seconds_median": 0.411,
+        "seconds_all": [
+          0.367,
+          0.411,
+          0.518
+        ],
+        "spread_pct": 41.14441416893734,
+        "deals": 2700000,
+        "deals_per_sec": 7356948.228882834,
+        "produced": 4588,
+        "wall_best": 0.3725591669790447,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 6806722,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 2.189,
+            "seconds_median": 2.24,
+            "seconds_all": [
+              2.189,
+              2.24,
+              2.661
+            ],
+            "spread_pct": 21.5623572407492,
+            "deals": 6806722,
+            "deals_per_sec": 3109512.1059844675,
+            "produced": 11521,
+            "wall_best": 2.1953322920016944,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 1.531,
+            "seconds_median": 1.538,
+            "seconds_all": [
+              1.531,
+              1.538,
+              1.544
+            ],
+            "spread_pct": 0.8491182233834176,
+            "deals": 6806722,
+            "deals_per_sec": 4445932.07054213,
+            "produced": 11521,
+            "wall_best": 1.5365641247481108,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 1.008,
+            "seconds_median": 1.028,
+            "seconds_all": [
+              1.008,
+              1.028,
+              1.047
+            ],
+            "spread_pct": 3.8690476190476115,
+            "deals": 6806722,
+            "deals_per_sec": 6752700.396825396,
+            "produced": 11521,
+            "wall_best": 1.0132046672515571,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 0.775,
+            "seconds_median": 0.786,
+            "seconds_all": [
+              0.775,
+              0.786,
+              0.788
+            ],
+            "spread_pct": 1.677419354838711,
+            "deals": 6806722,
+            "deals_per_sec": 8782867.096774193,
+            "produced": 11521,
+            "wall_best": 0.7804100839421153,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 0.735,
+            "seconds_median": 0.757,
+            "seconds_all": [
+              0.735,
+              0.757,
+              0.774
+            ],
+            "spread_pct": 5.306122448979597,
+            "deals": 6806722,
+            "deals_per_sec": 9260846.258503402,
+            "produced": 11521,
+            "wall_best": 0.7400703332386911,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 0.667,
+            "seconds_median": 0.714,
+            "seconds_all": [
+              0.667,
+              0.714,
+              0.744
+            ],
+            "spread_pct": 11.544227886056964,
+            "deals": 6806722,
+            "deals_per_sec": 10204980.509745127,
+            "produced": 11521,
+            "wall_best": 0.6720415418967605,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.684,
+            "seconds_median": 0.7,
+            "seconds_all": [
+              0.684,
+              0.7,
+              0.705
+            ],
+            "spread_pct": 3.0701754385964777,
+            "deals": 6806722,
+            "deals_per_sec": 9951347.953216374,
+            "produced": 11521,
+            "wall_best": 0.6892888750880957,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.704,
+            "seconds_median": 0.729,
+            "seconds_all": [
+              0.704,
+              0.729,
+              0.733
+            ],
+            "spread_pct": 4.119318181818186,
+            "deals": 6806722,
+            "deals_per_sec": 9668639.204545455,
+            "produced": 11521,
+            "wall_best": 0.7092224173247814,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.599,
+            "seconds_median": 0.611,
+            "seconds_all": [
+              0.599,
+              0.611,
+              0.632
+            ],
+            "spread_pct": 5.509181969949921,
+            "deals": 6806722,
+            "deals_per_sec": 11363475.792988315,
+            "produced": 11521,
+            "wall_best": 0.6039729998447001,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.594,
+            "seconds_median": 0.636,
+            "seconds_all": [
+              0.594,
+              0.636,
+              0.71
+            ],
+            "spread_pct": 19.52861952861953,
+            "deals": 6806722,
+            "deals_per_sec": 11459127.946127947,
+            "produced": 11521,
+            "wall_best": 0.5990696246735752,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "After_Partner_Overcalls": {
+      "deals": 1900000,
+      "hit_rate": 0.0002,
+      "single": {
+        "seconds_best": 1.228,
+        "seconds_median": 1.229,
+        "seconds_all": [
+          1.228,
+          1.229,
+          1.243
+        ],
+        "spread_pct": 1.221498371335515,
+        "deals": 1900000,
+        "deals_per_sec": 1547231.2703583061,
+        "produced": 367,
+        "wall_best": 1.2331525827758014,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.269,
+        "seconds_median": 0.319,
+        "seconds_all": [
+          0.269,
+          0.319,
+          0.329
+        ],
+        "spread_pct": 22.304832713754642,
+        "deals": 1900000,
+        "deals_per_sec": 7063197.026022305,
+        "produced": 367,
+        "wall_best": 0.27419095765799284,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 5816326,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 3.759,
+            "seconds_median": 3.759,
+            "seconds_all": [
+              3.759,
+              3.759,
+              3.781
+            ],
+            "spread_pct": 0.5852620377760107,
+            "deals": 5816326,
+            "deals_per_sec": 1547306.7305134344,
+            "produced": 1080,
+            "wall_best": 3.7636167081072927,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.578,
+            "seconds_median": 2.599,
+            "seconds_all": [
+              2.578,
+              2.599,
+              2.605
+            ],
+            "spread_pct": 1.0473235065942645,
+            "deals": 5816326,
+            "deals_per_sec": 2256138.8673390225,
+            "produced": 1080,
+            "wall_best": 2.582686625421047,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.025,
+            "seconds_median": 2.042,
+            "seconds_all": [
+              2.025,
+              2.042,
+              2.065
+            ],
+            "spread_pct": 1.9753086419753103,
+            "deals": 5816326,
+            "deals_per_sec": 2872259.75308642,
+            "produced": 1080,
+            "wall_best": 2.0296784159727395,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.403,
+            "seconds_median": 1.546,
+            "seconds_all": [
+              1.403,
+              1.546,
+              1.667
+            ],
+            "spread_pct": 18.8168210976479,
+            "deals": 5816326,
+            "deals_per_sec": 4145635.0677120457,
+            "produced": 1080,
+            "wall_best": 1.4076410830020905,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.102,
+            "seconds_median": 1.332,
+            "seconds_all": [
+              1.102,
+              1.332,
+              1.339
+            ],
+            "spread_pct": 21.506352087114326,
+            "deals": 5816326,
+            "deals_per_sec": 5277972.77676951,
+            "produced": 1080,
+            "wall_best": 1.1068893750198185,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.143,
+            "seconds_median": 1.18,
+            "seconds_all": [
+              1.143,
+              1.18,
+              1.18
+            ],
+            "spread_pct": 3.237095363079608,
+            "deals": 5816326,
+            "deals_per_sec": 5088649.168853893,
+            "produced": 1080,
+            "wall_best": 1.1473230407573283,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.98,
+            "seconds_median": 1.069,
+            "seconds_all": [
+              0.98,
+              1.069,
+              1.112
+            ],
+            "spread_pct": 13.469387755102053,
+            "deals": 5816326,
+            "deals_per_sec": 5935026.530612245,
+            "produced": 1080,
+            "wall_best": 0.984910124912858,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.977,
+            "seconds_median": 1.069,
+            "seconds_all": [
+              0.977,
+              1.069,
+              1.1
+            ],
+            "spread_pct": 12.589559877175038,
+            "deals": 5816326,
+            "deals_per_sec": 5953250.76765609,
+            "produced": 1080,
+            "wall_best": 0.9831115417182446,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.923,
+            "seconds_median": 1.004,
+            "seconds_all": [
+              0.923,
+              1.004,
+              1.016
+            ],
+            "spread_pct": 10.075839653304438,
+            "deals": 5816326,
+            "deals_per_sec": 6301544.962080173,
+            "produced": 1080,
+            "wall_best": 0.928720457945019,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.851,
+            "seconds_median": 0.964,
+            "seconds_all": [
+              0.851,
+              0.964,
+              0.995
+            ],
+            "spread_pct": 16.92126909518214,
+            "deals": 5816326,
+            "deals_per_sec": 6834695.652173913,
+            "produced": 1080,
+            "wall_best": 0.855879541952163,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Major_Suit_Fit": {
+      "deals": 1800000,
+      "hit_rate": 0.0024,
+      "single": {
+        "seconds_best": 1.215,
+        "seconds_median": 1.223,
+        "seconds_all": [
+          1.215,
+          1.223,
+          1.242
+        ],
+        "spread_pct": 2.222222222222215,
+        "deals": 1800000,
+        "deals_per_sec": 1481481.4814814813,
+        "produced": 5400,
+        "wall_best": 1.2197721246629953,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.27,
+        "seconds_median": 0.297,
+        "seconds_all": [
+          0.27,
+          0.297,
+          0.297
+        ],
+        "spread_pct": 9.999999999999988,
+        "deals": 1800000,
+        "deals_per_sec": 6666666.666666666,
+        "produced": 5400,
+        "wall_best": 0.27439066721126437,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 5912408,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 3.971,
+            "seconds_median": 3.992,
+            "seconds_all": [
+              3.971,
+              3.992,
+              4.025
+            ],
+            "spread_pct": 1.3598589775875163,
+            "deals": 5912408,
+            "deals_per_sec": 1488896.4996222614,
+            "produced": 17808,
+            "wall_best": 3.975928916130215,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.608,
+            "seconds_median": 2.622,
+            "seconds_all": [
+              2.608,
+              2.622,
+              2.646
+            ],
+            "spread_pct": 1.457055214723919,
+            "deals": 5912408,
+            "deals_per_sec": 2267027.607361963,
+            "produced": 17808,
+            "wall_best": 2.6131436247378588,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.035,
+            "seconds_median": 2.039,
+            "seconds_all": [
+              2.035,
+              2.039,
+              2.056
+            ],
+            "spread_pct": 1.0319410319410274,
+            "deals": 5912408,
+            "deals_per_sec": 2905360.1965601966,
+            "produced": 17808,
+            "wall_best": 2.0400047921575606,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.329,
+            "seconds_median": 1.434,
+            "seconds_all": [
+              1.329,
+              1.434,
+              1.592
+            ],
+            "spread_pct": 19.7893152746426,
+            "deals": 5912408,
+            "deals_per_sec": 4448764.484574868,
+            "produced": 17808,
+            "wall_best": 1.3337139580398798,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.305,
+            "seconds_median": 1.355,
+            "seconds_all": [
+              1.305,
+              1.355,
+              1.445
+            ],
+            "spread_pct": 10.727969348659014,
+            "deals": 5912408,
+            "deals_per_sec": 4530580.842911878,
+            "produced": 17808,
+            "wall_best": 1.3096265411004424,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.083,
+            "seconds_median": 1.132,
+            "seconds_all": [
+              1.083,
+              1.132,
+              1.155
+            ],
+            "spread_pct": 6.648199445983385,
+            "deals": 5912408,
+            "deals_per_sec": 5459287.165281625,
+            "produced": 17808,
+            "wall_best": 1.0872752079740167,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.962,
+            "seconds_median": 1.008,
+            "seconds_all": [
+              0.962,
+              1.008,
+              1.013
+            ],
+            "spread_pct": 5.301455301455295,
+            "deals": 5912408,
+            "deals_per_sec": 6145954.261954262,
+            "produced": 17808,
+            "wall_best": 0.9666065000928938,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.991,
+            "seconds_median": 1.015,
+            "seconds_all": [
+              0.991,
+              1.015,
+              1.017
+            ],
+            "spread_pct": 2.623612512613513,
+            "deals": 5912408,
+            "deals_per_sec": 5966102.9263370335,
+            "produced": 17808,
+            "wall_best": 0.9957019160501659,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.904,
+            "seconds_median": 0.926,
+            "seconds_all": [
+              0.904,
+              0.926,
+              0.964
+            ],
+            "spread_pct": 6.637168141592914,
+            "deals": 5912408,
+            "deals_per_sec": 6540274.3362831855,
+            "produced": 17808,
+            "wall_best": 0.9087081253528595,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.827,
+            "seconds_median": 0.876,
+            "seconds_all": [
+              0.827,
+              0.876,
+              0.95
+            ],
+            "spread_pct": 14.873035066505441,
+            "deals": 5912408,
+            "deals_per_sec": 7149223.700120919,
+            "produced": 17808,
+            "wall_best": 0.8322819168679416,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Drury": {
+      "deals": 1500000,
+      "hit_rate": 5e-05,
+      "single": {
+        "seconds_best": 1.311,
+        "seconds_median": 1.317,
+        "seconds_all": [
+          1.311,
+          1.317,
+          1.321
+        ],
+        "spread_pct": 0.7627765064836011,
+        "deals": 1500000,
+        "deals_per_sec": 1144164.7597254005,
+        "produced": 136,
+        "wall_best": 1.3153264159336686,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.289,
+        "seconds_median": 0.291,
+        "seconds_all": [
+          0.289,
+          0.291,
+          0.3
+        ],
+        "spread_pct": 3.806228373702426,
+        "deals": 1500000,
+        "deals_per_sec": 5190311.418685121,
+        "produced": 136,
+        "wall_best": 0.2939654579386115,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 5000000,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.37,
+            "seconds_median": 4.379,
+            "seconds_all": [
+              4.37,
+              4.379,
+              4.393
+            ],
+            "spread_pct": 0.5263157894736771,
+            "deals": 5000000,
+            "deals_per_sec": 1144164.7597254005,
+            "produced": 472,
+            "wall_best": 4.374254624824971,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.939,
+            "seconds_median": 2.96,
+            "seconds_all": [
+              2.939,
+              2.96,
+              2.976
+            ],
+            "spread_pct": 1.2589316093909466,
+            "deals": 5000000,
+            "deals_per_sec": 1701258.931609391,
+            "produced": 472,
+            "wall_best": 2.942985584028065,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.305,
+            "seconds_median": 2.311,
+            "seconds_all": [
+              2.305,
+              2.311,
+              2.329
+            ],
+            "spread_pct": 1.0412147505423002,
+            "deals": 5000000,
+            "deals_per_sec": 2169197.3969631237,
+            "produced": 472,
+            "wall_best": 2.309996707830578,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.769,
+            "seconds_median": 1.805,
+            "seconds_all": [
+              1.769,
+              1.805,
+              1.823
+            ],
+            "spread_pct": 3.0525720746184315,
+            "deals": 5000000,
+            "deals_per_sec": 2826455.624646693,
+            "produced": 472,
+            "wall_best": 1.7740898746997118,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.429,
+            "seconds_median": 1.432,
+            "seconds_all": [
+              1.429,
+              1.432,
+              1.434
+            ],
+            "spread_pct": 0.34989503149054535,
+            "deals": 5000000,
+            "deals_per_sec": 3498950.3149055284,
+            "produced": 472,
+            "wall_best": 1.433128582779318,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.145,
+            "seconds_median": 1.277,
+            "seconds_all": [
+              1.145,
+              1.277,
+              1.339
+            ],
+            "spread_pct": 16.94323144104803,
+            "deals": 5000000,
+            "deals_per_sec": 4366812.227074236,
+            "produced": 472,
+            "wall_best": 1.1496622497215867,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.154,
+            "seconds_median": 1.23,
+            "seconds_all": [
+              1.154,
+              1.23,
+              1.265
+            ],
+            "spread_pct": 9.618717504332755,
+            "deals": 5000000,
+            "deals_per_sec": 4332755.632582323,
+            "produced": 472,
+            "wall_best": 1.159240416251123,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 1.111,
+            "seconds_median": 1.128,
+            "seconds_all": [
+              1.111,
+              1.128,
+              1.133
+            ],
+            "spread_pct": 1.980198019801982,
+            "deals": 5000000,
+            "deals_per_sec": 4500450.0450045,
+            "produced": 472,
+            "wall_best": 1.1158479158766568,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.99,
+            "seconds_median": 1.041,
+            "seconds_all": [
+              0.99,
+              1.041,
+              1.055
+            ],
+            "spread_pct": 6.56565656565656,
+            "deals": 5000000,
+            "deals_per_sec": 5050505.05050505,
+            "produced": 472,
+            "wall_best": 0.9947786661796272,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.971,
+            "seconds_median": 0.979,
+            "seconds_all": [
+              0.971,
+              0.979,
+              1.068
+            ],
+            "spread_pct": 9.989701338825961,
+            "deals": 5000000,
+            "deals_per_sec": 5149330.587023687,
+            "produced": 472,
+            "wall_best": 0.976641250308603,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Basic_Takeout_Double": {
+      "deals": 1100000,
+      "hit_rate": 0.00535,
+      "single": {
+        "seconds_best": 1.444,
+        "seconds_median": 1.455,
+        "seconds_all": [
+          1.444,
+          1.455,
+          1.467
+        ],
+        "spread_pct": 1.592797783933527,
+        "deals": 1100000,
+        "deals_per_sec": 761772.8531855956,
+        "produced": 6264,
+        "wall_best": 1.4489463330246508,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.275,
+        "seconds_median": 0.308,
+        "seconds_all": [
+          0.275,
+          0.308,
+          0.338
+        ],
+        "spread_pct": 22.909090909090907,
+        "deals": 1100000,
+        "deals_per_sec": 3999999.9999999995,
+        "produced": 6264,
+        "wall_best": 0.2802532911300659,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 3523131,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.63,
+            "seconds_median": 4.659,
+            "seconds_all": [
+              4.63,
+              4.659,
+              4.676
+            ],
+            "spread_pct": 0.9935205183585369,
+            "deals": 3523131,
+            "deals_per_sec": 760935.4211663067,
+            "produced": 19846,
+            "wall_best": 4.634464709088206,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.872,
+            "seconds_median": 2.877,
+            "seconds_all": [
+              2.872,
+              2.877,
+              2.886
+            ],
+            "spread_pct": 0.487465181058504,
+            "deals": 3523131,
+            "deals_per_sec": 1226716.9220055712,
+            "produced": 19846,
+            "wall_best": 2.8764744168147445,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.185,
+            "seconds_median": 2.196,
+            "seconds_all": [
+              2.185,
+              2.196,
+              2.211
+            ],
+            "spread_pct": 1.1899313501144073,
+            "deals": 3523131,
+            "deals_per_sec": 1612416.933638444,
+            "produced": 19846,
+            "wall_best": 2.190536249894649,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.701,
+            "seconds_median": 1.722,
+            "seconds_all": [
+              1.701,
+              1.722,
+              1.729
+            ],
+            "spread_pct": 1.6460905349794255,
+            "deals": 3523131,
+            "deals_per_sec": 2071211.6402116402,
+            "produced": 19846,
+            "wall_best": 1.7057679169811308,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.333,
+            "seconds_median": 1.34,
+            "seconds_all": [
+              1.333,
+              1.34,
+              1.471
+            ],
+            "spread_pct": 10.35258814703677,
+            "deals": 3523131,
+            "deals_per_sec": 2643009.002250563,
+            "produced": 19846,
+            "wall_best": 1.3377232090570033,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.396,
+            "seconds_median": 1.556,
+            "seconds_all": [
+              1.396,
+              1.556,
+              1.799
+            ],
+            "spread_pct": 28.86819484240688,
+            "deals": 3523131,
+            "deals_per_sec": 2523732.808022923,
+            "produced": 19846,
+            "wall_best": 1.400681875180453,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.06,
+            "seconds_median": 1.147,
+            "seconds_all": [
+              1.06,
+              1.147,
+              1.293
+            ],
+            "spread_pct": 21.981132075471685,
+            "deals": 3523131,
+            "deals_per_sec": 3323708.4905660376,
+            "produced": 19846,
+            "wall_best": 1.0652300422079861,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 1.023,
+            "seconds_median": 1.026,
+            "seconds_all": [
+              1.023,
+              1.026,
+              1.149
+            ],
+            "spread_pct": 12.316715542522006,
+            "deals": 3523131,
+            "deals_per_sec": 3443920.8211143697,
+            "produced": 19846,
+            "wall_best": 1.0281148748472333,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 1.021,
+            "seconds_median": 1.023,
+            "seconds_all": [
+              1.021,
+              1.023,
+              1.107
+            ],
+            "spread_pct": 8.423114593535757,
+            "deals": 3523131,
+            "deals_per_sec": 3450666.9931439767,
+            "produced": 19846,
+            "wall_best": 1.0264798747375607,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.963,
+            "seconds_median": 1.043,
+            "seconds_all": [
+              0.963,
+              1.043,
+              1.051
+            ],
+            "spread_pct": 9.138110072689509,
+            "deals": 3523131,
+            "deals_per_sec": 3658495.327102804,
+            "produced": 19846,
+            "wall_best": 0.9680499169044197,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "GIB_1C-P-Resp": {
+      "deals": 1000000,
+      "hit_rate": 0.00555,
+      "single": {
+        "seconds_best": 1.498,
+        "seconds_median": 1.498,
+        "seconds_all": [
+          1.498,
+          1.498,
+          1.513
+        ],
+        "spread_pct": 1.0013351134846395,
+        "deals": 1000000,
+        "deals_per_sec": 667556.7423230974,
+        "produced": 6089,
+        "wall_best": 1.502516749780625,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.286,
+        "seconds_median": 0.295,
+        "seconds_all": [
+          0.286,
+          0.295,
+          0.296
+        ],
+        "spread_pct": 3.4965034965035002,
+        "deals": 1000000,
+        "deals_per_sec": 3496503.496503497,
+        "produced": 6089,
+        "wall_best": 0.2903979169204831,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 2278481,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 3.422,
+            "seconds_median": 3.453,
+            "seconds_all": [
+              3.422,
+              3.453,
+              3.497
+            ],
+            "spread_pct": 2.1917007597895886,
+            "deals": 2278481,
+            "deals_per_sec": 665833.138515488,
+            "produced": 13753,
+            "wall_best": 3.4281505825929344,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.065,
+            "seconds_median": 2.07,
+            "seconds_all": [
+              2.065,
+              2.07,
+              2.124
+            ],
+            "spread_pct": 2.857142857142865,
+            "deals": 2278481,
+            "deals_per_sec": 1103380.6295399517,
+            "produced": 13753,
+            "wall_best": 2.0702464999631047,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 1.551,
+            "seconds_median": 1.57,
+            "seconds_all": [
+              1.551,
+              1.57,
+              1.61
+            ],
+            "spread_pct": 3.803997421018708,
+            "deals": 2278481,
+            "deals_per_sec": 1469039.974210187,
+            "produced": 13753,
+            "wall_best": 1.5557811250910163,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.159,
+            "seconds_median": 1.167,
+            "seconds_all": [
+              1.159,
+              1.167,
+              1.224
+            ],
+            "spread_pct": 5.608283002588434,
+            "deals": 2278481,
+            "deals_per_sec": 1965902.5021570318,
+            "produced": 13753,
+            "wall_best": 1.164328375365585,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 0.971,
+            "seconds_median": 0.972,
+            "seconds_all": [
+              0.971,
+              0.972,
+              0.976
+            ],
+            "spread_pct": 0.5149330587023692,
+            "deals": 2278481,
+            "deals_per_sec": 2346530.3810504633,
+            "produced": 13753,
+            "wall_best": 0.9762163339182734,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 0.857,
+            "seconds_median": 0.907,
+            "seconds_all": [
+              0.857,
+              0.907,
+              1.0
+            ],
+            "spread_pct": 16.686114352392067,
+            "deals": 2278481,
+            "deals_per_sec": 2658670.9451575265,
+            "produced": 13753,
+            "wall_best": 0.8616895829327404,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.76,
+            "seconds_median": 0.784,
+            "seconds_all": [
+              0.76,
+              0.784,
+              0.867
+            ],
+            "spread_pct": 14.07894736842105,
+            "deals": 2278481,
+            "deals_per_sec": 2998001.3157894737,
+            "produced": 13753,
+            "wall_best": 0.7651773751713336,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.726,
+            "seconds_median": 0.729,
+            "seconds_all": [
+              0.726,
+              0.729,
+              0.765
+            ],
+            "spread_pct": 5.371900826446286,
+            "deals": 2278481,
+            "deals_per_sec": 3138403.5812672176,
+            "produced": 13753,
+            "wall_best": 0.7311388752423227,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.67,
+            "seconds_median": 0.695,
+            "seconds_all": [
+              0.67,
+              0.695,
+              0.704
+            ],
+            "spread_pct": 5.07462686567163,
+            "deals": 2278481,
+            "deals_per_sec": 3400717.910447761,
+            "produced": 13753,
+            "wall_best": 0.6749405828304589,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.676,
+            "seconds_median": 0.721,
+            "seconds_all": [
+              0.676,
+              0.721,
+              0.743
+            ],
+            "spread_pct": 9.911242603550289,
+            "deals": 2278481,
+            "deals_per_sec": 3370534.023668639,
+            "produced": 13753,
+            "wall_best": 0.6822878327220678,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Splinters_By_Opener": {
+      "deals": 830000,
+      "hit_rate": 0.0003,
+      "single": {
+        "seconds_best": 1.657,
+        "seconds_median": 1.67,
+        "seconds_all": [
+          1.657,
+          1.67,
+          1.68
+        ],
+        "spread_pct": 1.3880506940253416,
+        "deals": 830000,
+        "deals_per_sec": 500905.2504526252,
+        "produced": 157,
+        "wall_best": 1.6614611661061645,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.315,
+        "seconds_median": 0.33,
+        "seconds_all": [
+          0.315,
+          0.33,
+          0.337
+        ],
+        "spread_pct": 6.9841269841269895,
+        "deals": 830000,
+        "deals_per_sec": 2634920.634920635,
+        "produced": 157,
+        "wall_best": 0.31935987528413534,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 2417475,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.807,
+            "seconds_median": 4.813,
+            "seconds_all": [
+              4.807,
+              4.813,
+              4.838
+            ],
+            "spread_pct": 0.6448928645724921,
+            "deals": 2417475,
+            "deals_per_sec": 502907.218639484,
+            "produced": 427,
+            "wall_best": 4.813840750139207,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.924,
+            "seconds_median": 3.001,
+            "seconds_all": [
+              2.924,
+              3.001,
+              3.064
+            ],
+            "spread_pct": 4.787961696306434,
+            "deals": 2417475,
+            "deals_per_sec": 826769.8358413132,
+            "produced": 427,
+            "wall_best": 2.929067458026111,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.169,
+            "seconds_median": 2.187,
+            "seconds_all": [
+              2.169,
+              2.187,
+              2.214
+            ],
+            "spread_pct": 2.0746887966804946,
+            "deals": 2417475,
+            "deals_per_sec": 1114557.3997233748,
+            "produced": 427,
+            "wall_best": 2.1758544999174774,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.571,
+            "seconds_median": 1.723,
+            "seconds_all": [
+              1.571,
+              1.723,
+              1.723
+            ],
+            "spread_pct": 9.67536600891153,
+            "deals": 2417475,
+            "deals_per_sec": 1538812.8580521962,
+            "produced": 427,
+            "wall_best": 1.5758241661824286,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.322,
+            "seconds_median": 1.423,
+            "seconds_all": [
+              1.322,
+              1.423,
+              1.459
+            ],
+            "spread_pct": 10.363086232980333,
+            "deals": 2417475,
+            "deals_per_sec": 1828649.7730711042,
+            "produced": 427,
+            "wall_best": 1.3263459578156471,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.245,
+            "seconds_median": 1.27,
+            "seconds_all": [
+              1.245,
+              1.27,
+              1.303
+            ],
+            "spread_pct": 4.658634538152596,
+            "deals": 2417475,
+            "deals_per_sec": 1941746.987951807,
+            "produced": 427,
+            "wall_best": 1.2498326669447124,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.01,
+            "seconds_median": 1.064,
+            "seconds_all": [
+              1.01,
+              1.064,
+              1.229
+            ],
+            "spread_pct": 21.68316831683169,
+            "deals": 2417475,
+            "deals_per_sec": 2393539.603960396,
+            "produced": 427,
+            "wall_best": 1.0147018753923476,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 1.036,
+            "seconds_median": 1.098,
+            "seconds_all": [
+              1.036,
+              1.098,
+              1.127
+            ],
+            "spread_pct": 8.78378378378378,
+            "deals": 2417475,
+            "deals_per_sec": 2333470.077220077,
+            "produced": 427,
+            "wall_best": 1.0416099578142166,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.924,
+            "seconds_median": 1.02,
+            "seconds_all": [
+              0.924,
+              1.02,
+              1.067
+            ],
+            "spread_pct": 15.476190476190466,
+            "deals": 2417475,
+            "deals_per_sec": 2616314.935064935,
+            "produced": 427,
+            "wall_best": 0.929008583072573,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.942,
+            "seconds_median": 0.952,
+            "seconds_all": [
+              0.942,
+              0.952,
+              1.09
+            ],
+            "spread_pct": 15.71125265392783,
+            "deals": 2417475,
+            "deals_per_sec": 2566321.6560509554,
+            "produced": 427,
+            "wall_best": 0.9467149996198714,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Gerber_By_Responder": {
+      "deals": 650000,
+      "hit_rate": 0.00025,
+      "single": {
+        "seconds_best": 1.721,
+        "seconds_median": 1.73,
+        "seconds_all": [
+          1.721,
+          1.73,
+          1.735
+        ],
+        "spread_pct": 0.8134805345729234,
+        "deals": 650000,
+        "deals_per_sec": 377687.3910517141,
+        "produced": 106,
+        "wall_best": 1.7259795828722417,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.29,
+        "seconds_median": 0.293,
+        "seconds_all": [
+          0.29,
+          0.293,
+          0.308
+        ],
+        "spread_pct": 6.206896551724144,
+        "deals": 650000,
+        "deals_per_sec": 2241379.310344828,
+        "produced": 106,
+        "wall_best": 0.29468374978750944,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 1887096,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 5.014,
+            "seconds_median": 5.03,
+            "seconds_all": [
+              5.014,
+              5.03,
+              5.085
+            ],
+            "spread_pct": 1.416035101715192,
+            "deals": 1887096,
+            "deals_per_sec": 376365.3769445552,
+            "produced": 306,
+            "wall_best": 5.0189641658216715,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.957,
+            "seconds_median": 2.988,
+            "seconds_all": [
+              2.957,
+              2.988,
+              3.007
+            ],
+            "spread_pct": 1.6909029421711286,
+            "deals": 1887096,
+            "deals_per_sec": 638179.2357118701,
+            "produced": 306,
+            "wall_best": 2.9613000000827014,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.19,
+            "seconds_median": 2.216,
+            "seconds_all": [
+              2.19,
+              2.216,
+              2.231
+            ],
+            "spread_pct": 1.8721461187214579,
+            "deals": 1887096,
+            "deals_per_sec": 861687.6712328767,
+            "produced": 306,
+            "wall_best": 2.1947327498346567,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.594,
+            "seconds_median": 1.649,
+            "seconds_all": [
+              1.594,
+              1.649,
+              1.684
+            ],
+            "spread_pct": 5.646173149309903,
+            "deals": 1887096,
+            "deals_per_sec": 1183874.5294855707,
+            "produced": 306,
+            "wall_best": 1.5986490417271852,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.421,
+            "seconds_median": 1.431,
+            "seconds_all": [
+              1.421,
+              1.431,
+              1.437
+            ],
+            "spread_pct": 1.1259676284306837,
+            "deals": 1887096,
+            "deals_per_sec": 1328005.629838142,
+            "produced": 306,
+            "wall_best": 1.4256270830519497,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.098,
+            "seconds_median": 1.182,
+            "seconds_all": [
+              1.098,
+              1.182,
+              1.217
+            ],
+            "spread_pct": 10.837887067395263,
+            "deals": 1887096,
+            "deals_per_sec": 1718666.6666666665,
+            "produced": 306,
+            "wall_best": 1.1042090407572687,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.071,
+            "seconds_median": 1.076,
+            "seconds_all": [
+              1.071,
+              1.076,
+              1.082
+            ],
+            "spread_pct": 1.0270774976657442,
+            "deals": 1887096,
+            "deals_per_sec": 1761994.3977591037,
+            "produced": 306,
+            "wall_best": 1.0759353330358863,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.994,
+            "seconds_median": 1.003,
+            "seconds_all": [
+              0.994,
+              1.003,
+              1.007
+            ],
+            "spread_pct": 1.3078470824949597,
+            "deals": 1887096,
+            "deals_per_sec": 1898486.921529175,
+            "produced": 306,
+            "wall_best": 0.9990039169788361,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.896,
+            "seconds_median": 0.948,
+            "seconds_all": [
+              0.896,
+              0.948,
+              1.021
+            ],
+            "spread_pct": 13.950892857142843,
+            "deals": 1887096,
+            "deals_per_sec": 2106133.9285714286,
+            "produced": 306,
+            "wall_best": 0.9011865411885083,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.901,
+            "seconds_median": 0.931,
+            "seconds_all": [
+              0.901,
+              0.931,
+              1.025
+            ],
+            "spread_pct": 13.762486126526069,
+            "deals": 1887096,
+            "deals_per_sec": 2094446.1709211986,
+            "produced": 306,
+            "wall_best": 0.9058736669830978,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "_shuffle_baseline": {
+      "deals": 3700000,
+      "hit_rate": 0.00098,
+      "single": {
+        "seconds_best": 0.695,
+        "seconds_median": 0.696,
+        "seconds_all": [
+          0.695,
+          0.696,
+          0.702
+        ],
+        "spread_pct": 1.0071942446043174,
+        "deals": 3700000,
+        "deals_per_sec": 5323741.007194245,
+        "produced": 3883,
+        "wall_best": 0.6990808341652155,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.23,
+        "seconds_median": 0.231,
+        "seconds_all": [
+          0.23,
+          0.231,
+          0.236
+        ],
+        "spread_pct": 2.6086956521739033,
+        "deals": 3700000,
+        "deals_per_sec": 16086956.521739129,
+        "produced": 3883,
+        "wall_best": 0.23429566668346524,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 14230769,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 2.672,
+            "seconds_median": 2.674,
+            "seconds_all": [
+              2.672,
+              2.674,
+              2.691
+            ],
+            "spread_pct": 0.7110778443113653,
+            "deals": 14230769,
+            "deals_per_sec": 5325886.601796407,
+            "produced": 14629,
+            "wall_best": 2.6769814998842776,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 1.488,
+            "seconds_median": 1.493,
+            "seconds_all": [
+              1.488,
+              1.493,
+              1.501
+            ],
+            "spread_pct": 0.873655913978488,
+            "deals": 14230769,
+            "deals_per_sec": 9563688.844086021,
+            "produced": 14629,
+            "wall_best": 1.4926128750666976,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 1.276,
+            "seconds_median": 1.287,
+            "seconds_all": [
+              1.276,
+              1.287,
+              1.327
+            ],
+            "spread_pct": 3.99686520376175,
+            "deals": 14230769,
+            "deals_per_sec": 11152640.28213166,
+            "produced": 14629,
+            "wall_best": 1.2810773327946663,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.036,
+            "seconds_median": 1.042,
+            "seconds_all": [
+              1.036,
+              1.042,
+              1.052
+            ],
+            "spread_pct": 1.5444015444015458,
+            "deals": 14230769,
+            "deals_per_sec": 13736263.513513513,
+            "produced": 14629,
+            "wall_best": 1.0405642502009869,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.085,
+            "seconds_median": 1.086,
+            "seconds_all": [
+              1.085,
+              1.086,
+              1.088
+            ],
+            "spread_pct": 0.2764976958525451,
+            "deals": 14230769,
+            "deals_per_sec": 13115916.129032258,
+            "produced": 14629,
+            "wall_best": 1.0898095001466572,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 0.98,
+            "seconds_median": 0.986,
+            "seconds_all": [
+              0.98,
+              0.986,
+              0.996
+            ],
+            "spread_pct": 1.6326530612244914,
+            "deals": 14230769,
+            "deals_per_sec": 14521192.857142858,
+            "produced": 14629,
+            "wall_best": 0.9847264159470797,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.913,
+            "seconds_median": 0.941,
+            "seconds_all": [
+              0.913,
+              0.941,
+              0.968
+            ],
+            "spread_pct": 6.024096385542162,
+            "deals": 14230769,
+            "deals_per_sec": 15586822.56297919,
+            "produced": 14629,
+            "wall_best": 0.9176925830543041,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 1.053,
+            "seconds_median": 1.073,
+            "seconds_all": [
+              1.053,
+              1.073,
+              1.09
+            ],
+            "spread_pct": 3.5137701804368606,
+            "deals": 14230769,
+            "deals_per_sec": 13514500.474833809,
+            "produced": 14629,
+            "wall_best": 1.057322375010699,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.917,
+            "seconds_median": 0.928,
+            "seconds_all": [
+              0.917,
+              0.928,
+              0.937
+            ],
+            "spread_pct": 2.1810250817884422,
+            "deals": 14230769,
+            "deals_per_sec": 15518832.061068702,
+            "produced": 14629,
+            "wall_best": 0.9213052908889949,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.906,
+            "seconds_median": 0.929,
+            "seconds_all": [
+              0.906,
+              0.929,
+              0.976
+            ],
+            "spread_pct": 7.726269315673284,
+            "deals": 14230769,
+            "deals_per_sec": 15707250.55187638,
+            "produced": 14629,
+            "wall_best": 0.9108255002647638,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    }
+  },
+  "partial": false,
+  "written": "2026-09-01 09:25:55",
+  "machine": {
+    "model": "Mac16,11",
+    "cpu": "Apple M4 Pro",
+    "logical_cpus": "12",
+    "performance_cpus": "8",
+    "efficiency_cpus": "4"
+  }
+}

--- a/bench/results/dealer3-92f902fd12e4.json
+++ b/bench/results/dealer3-92f902fd12e4.json
@@ -1,0 +1,2231 @@
+{
+  "tool": "bench-dealer3",
+  "revision": "v0.4.0-197-g93bc1ec-dirty",
+  "corpus_id": "7d7033566ed1",
+  "repeats": 3,
+  "scale": 1.0,
+  "scripts": {
+    "Scrambling_2NT": {
+      "deals": 2900000,
+      "hit_rate": 0.00025,
+      "single": {
+        "seconds_best": 1.909,
+        "seconds_median": 1.921,
+        "seconds_all": [
+          1.909,
+          1.921,
+          1.946
+        ],
+        "spread_pct": 1.9381875327396503,
+        "deals": 2900000,
+        "deals_per_sec": 1519119.9580932425,
+        "produced": 280,
+        "wall_best": 1.915098666679114,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.382,
+        "seconds_median": 0.391,
+        "seconds_all": [
+          0.382,
+          0.391,
+          0.392
+        ],
+        "spread_pct": 2.6178010471204214,
+        "deals": 2900000,
+        "deals_per_sec": 7591623.036649214,
+        "produced": 280,
+        "wall_best": 0.38656875025480986,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 6607594,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.345,
+            "seconds_median": 4.351,
+            "seconds_all": [
+              4.345,
+              4.351,
+              4.365
+            ],
+            "spread_pct": 0.4602991944764203,
+            "deals": 6607594,
+            "deals_per_sec": 1520735.097813579,
+            "produced": 618,
+            "wall_best": 4.349770334083587,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.582,
+            "seconds_median": 2.617,
+            "seconds_all": [
+              2.582,
+              2.617,
+              2.687
+            ],
+            "spread_pct": 4.066615027110767,
+            "deals": 6607594,
+            "deals_per_sec": 2559099.1479473277,
+            "produced": 618,
+            "wall_best": 2.5876897908747196,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.023,
+            "seconds_median": 2.025,
+            "seconds_all": [
+              2.023,
+              2.025,
+              2.134
+            ],
+            "spread_pct": 5.486900642609973,
+            "deals": 6607594,
+            "deals_per_sec": 3266235.2941176468,
+            "produced": 618,
+            "wall_best": 2.0283166668377817,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.363,
+            "seconds_median": 1.37,
+            "seconds_all": [
+              1.363,
+              1.37,
+              1.474
+            ],
+            "spread_pct": 8.143800440205428,
+            "deals": 6607594,
+            "deals_per_sec": 4847831.254585473,
+            "produced": 618,
+            "wall_best": 1.3683448750525713,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.236,
+            "seconds_median": 1.299,
+            "seconds_all": [
+              1.236,
+              1.299,
+              1.346
+            ],
+            "spread_pct": 8.899676375404539,
+            "deals": 6607594,
+            "deals_per_sec": 5345949.838187702,
+            "produced": 618,
+            "wall_best": 1.2407304579392076,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.092,
+            "seconds_median": 1.094,
+            "seconds_all": [
+              1.092,
+              1.094,
+              1.177
+            ],
+            "spread_pct": 7.78388278388278,
+            "deals": 6607594,
+            "deals_per_sec": 6050910.256410256,
+            "produced": 618,
+            "wall_best": 1.097376458812505,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.004,
+            "seconds_median": 1.009,
+            "seconds_all": [
+              1.004,
+              1.009,
+              1.033
+            ],
+            "spread_pct": 2.888446215139434,
+            "deals": 6607594,
+            "deals_per_sec": 6581268.924302788,
+            "produced": 618,
+            "wall_best": 1.0091664586216211,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.939,
+            "seconds_median": 0.948,
+            "seconds_all": [
+              0.939,
+              0.948,
+              0.971
+            ],
+            "spread_pct": 3.407880724174657,
+            "deals": 6607594,
+            "deals_per_sec": 7036841.320553781,
+            "produced": 618,
+            "wall_best": 0.9434733749367297,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.903,
+            "seconds_median": 0.924,
+            "seconds_all": [
+              0.903,
+              0.924,
+              1.071
+            ],
+            "spread_pct": 18.604651162790688,
+            "deals": 6607594,
+            "deals_per_sec": 7317379.84496124,
+            "produced": 618,
+            "wall_best": 0.9080723747611046,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.875,
+            "seconds_median": 0.882,
+            "seconds_all": [
+              0.875,
+              0.882,
+              0.885
+            ],
+            "spread_pct": 1.142857142857144,
+            "deals": 6607594,
+            "deals_per_sec": 7551536.0,
+            "produced": 618,
+            "wall_best": 0.8792747920379043,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "GIB_1N_Basic": {
+      "deals": 2800000,
+      "hit_rate": 0.023,
+      "single": {
+        "seconds_best": 1.908,
+        "seconds_median": 1.922,
+        "seconds_all": [
+          1.908,
+          1.922,
+          1.934
+        ],
+        "spread_pct": 1.3626834381551374,
+        "deals": 2800000,
+        "deals_per_sec": 1467505.2410901468,
+        "produced": 67798,
+        "wall_best": 1.9123283340595663,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.356,
+        "seconds_median": 0.36,
+        "seconds_all": [
+          0.356,
+          0.36,
+          0.374
+        ],
+        "spread_pct": 5.056179775280904,
+        "deals": 2800000,
+        "deals_per_sec": 7865168.539325843,
+        "produced": 67798,
+        "wall_best": 0.3608684162609279,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 6885245,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.715,
+            "seconds_median": 4.731,
+            "seconds_all": [
+              4.715,
+              4.731,
+              4.775
+            ],
+            "spread_pct": 1.2725344644750902,
+            "deals": 6885245,
+            "deals_per_sec": 1460285.2598091199,
+            "produced": 167554,
+            "wall_best": 4.719342582859099,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.778,
+            "seconds_median": 2.791,
+            "seconds_all": [
+              2.778,
+              2.791,
+              2.82
+            ],
+            "spread_pct": 1.5118790496760193,
+            "deals": 6885245,
+            "deals_per_sec": 2478489.9208063353,
+            "produced": 167554,
+            "wall_best": 2.7824918748810887,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.191,
+            "seconds_median": 2.192,
+            "seconds_all": [
+              2.191,
+              2.192,
+              2.256
+            ],
+            "spread_pct": 2.9666818804198973,
+            "deals": 6885245,
+            "deals_per_sec": 3142512.5513464175,
+            "produced": 167554,
+            "wall_best": 2.197137124836445,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.59,
+            "seconds_median": 1.613,
+            "seconds_all": [
+              1.59,
+              1.613,
+              1.67
+            ],
+            "spread_pct": 5.031446540880494,
+            "deals": 6885245,
+            "deals_per_sec": 4330342.767295597,
+            "produced": 167554,
+            "wall_best": 1.5945472079329193,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.313,
+            "seconds_median": 1.379,
+            "seconds_all": [
+              1.313,
+              1.379,
+              1.403
+            ],
+            "spread_pct": 6.854531607006861,
+            "deals": 6885245,
+            "deals_per_sec": 5243903.27494288,
+            "produced": 167554,
+            "wall_best": 1.3182614580728114,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.184,
+            "seconds_median": 1.195,
+            "seconds_all": [
+              1.184,
+              1.195,
+              1.293
+            ],
+            "spread_pct": 9.20608108108108,
+            "deals": 6885245,
+            "deals_per_sec": 5815240.709459459,
+            "produced": 167554,
+            "wall_best": 1.1884534587152302,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.019,
+            "seconds_median": 1.027,
+            "seconds_all": [
+              1.019,
+              1.027,
+              1.079
+            ],
+            "spread_pct": 5.888125613346424,
+            "deals": 6885245,
+            "deals_per_sec": 6756864.573110893,
+            "produced": 167554,
+            "wall_best": 1.0237037921324372,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.995,
+            "seconds_median": 1.048,
+            "seconds_all": [
+              0.995,
+              1.048,
+              1.065
+            ],
+            "spread_pct": 7.035175879396981,
+            "deals": 6885245,
+            "deals_per_sec": 6919844.221105528,
+            "produced": 167554,
+            "wall_best": 0.9995620409026742,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.919,
+            "seconds_median": 0.951,
+            "seconds_all": [
+              0.919,
+              0.951,
+              1.067
+            ],
+            "spread_pct": 16.104461371055486,
+            "deals": 6885245,
+            "deals_per_sec": 7492105.549510337,
+            "produced": 167554,
+            "wall_best": 0.9241017922759056,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.86,
+            "seconds_median": 0.921,
+            "seconds_all": [
+              0.86,
+              0.921,
+              0.945
+            ],
+            "spread_pct": 9.883720930232553,
+            "deals": 6885245,
+            "deals_per_sec": 8006098.837209302,
+            "produced": 167554,
+            "wall_best": 0.8663766672834754,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Slam_After_Major_Fit": {
+      "deals": 2700000,
+      "hit_rate": 0.0016,
+      "single": {
+        "seconds_best": 1.829,
+        "seconds_median": 1.846,
+        "seconds_all": [
+          1.829,
+          1.846,
+          1.847
+        ],
+        "spread_pct": 0.9841443411700391,
+        "deals": 2700000,
+        "deals_per_sec": 1476216.5117550574,
+        "produced": 4588,
+        "wall_best": 1.8356285830959678,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.336,
+        "seconds_median": 0.353,
+        "seconds_all": [
+          0.336,
+          0.353,
+          0.371
+        ],
+        "spread_pct": 10.416666666666659,
+        "deals": 2700000,
+        "deals_per_sec": 8035714.285714285,
+        "produced": 4588,
+        "wall_best": 0.3404922909103334,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 6883852,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.65,
+            "seconds_median": 4.651,
+            "seconds_all": [
+              4.65,
+              4.651,
+              4.669
+            ],
+            "spread_pct": 0.40860215053761806,
+            "deals": 6883852,
+            "deals_per_sec": 1480398.2795698924,
+            "produced": 11653,
+            "wall_best": 4.654538874980062,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.753,
+            "seconds_median": 2.777,
+            "seconds_all": [
+              2.753,
+              2.777,
+              2.83
+            ],
+            "spread_pct": 2.7969487831456576,
+            "deals": 6883852,
+            "deals_per_sec": 2500491.100617508,
+            "produced": 11653,
+            "wall_best": 2.7581701669842005,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.196,
+            "seconds_median": 2.205,
+            "seconds_all": [
+              2.196,
+              2.205,
+              2.211
+            ],
+            "spread_pct": 0.6830601092896029,
+            "deals": 6883852,
+            "deals_per_sec": 3134723.1329690344,
+            "produced": 11653,
+            "wall_best": 2.203056334052235,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.452,
+            "seconds_median": 1.457,
+            "seconds_all": [
+              1.452,
+              1.457,
+              1.515
+            ],
+            "spread_pct": 4.338842975206608,
+            "deals": 6883852,
+            "deals_per_sec": 4740944.903581267,
+            "produced": 11653,
+            "wall_best": 1.456480999942869,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.294,
+            "seconds_median": 1.316,
+            "seconds_all": [
+              1.294,
+              1.316,
+              1.357
+            ],
+            "spread_pct": 4.86862442040185,
+            "deals": 6883852,
+            "deals_per_sec": 5319823.802163833,
+            "produced": 11653,
+            "wall_best": 1.2988041252829134,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.103,
+            "seconds_median": 1.161,
+            "seconds_all": [
+              1.103,
+              1.161,
+              1.235
+            ],
+            "spread_pct": 11.967361740707174,
+            "deals": 6883852,
+            "deals_per_sec": 6241026.291931097,
+            "produced": 11653,
+            "wall_best": 1.1078721671365201,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.061,
+            "seconds_median": 1.076,
+            "seconds_all": [
+              1.061,
+              1.076,
+              1.089
+            ],
+            "spread_pct": 2.639019792648447,
+            "deals": 6883852,
+            "deals_per_sec": 6488079.1705937795,
+            "produced": 11653,
+            "wall_best": 1.0657902909442782,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.984,
+            "seconds_median": 1.039,
+            "seconds_all": [
+              0.984,
+              1.039,
+              1.054
+            ],
+            "spread_pct": 7.113821138211389,
+            "deals": 6883852,
+            "deals_per_sec": 6995784.552845528,
+            "produced": 11653,
+            "wall_best": 0.9883954161778092,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.918,
+            "seconds_median": 0.948,
+            "seconds_all": [
+              0.918,
+              0.948,
+              1.021
+            ],
+            "spread_pct": 11.220043572984736,
+            "deals": 6883852,
+            "deals_per_sec": 7498749.45533769,
+            "produced": 11653,
+            "wall_best": 0.9227316253818572,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.912,
+            "seconds_median": 0.917,
+            "seconds_all": [
+              0.912,
+              0.917,
+              0.923
+            ],
+            "spread_pct": 1.206140350877194,
+            "deals": 6883852,
+            "deals_per_sec": 7548083.333333333,
+            "produced": 11653,
+            "wall_best": 0.9169301670044661,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "After_Partner_Overcalls": {
+      "deals": 1900000,
+      "hit_rate": 0.0002,
+      "single": {
+        "seconds_best": 1.892,
+        "seconds_median": 1.897,
+        "seconds_all": [
+          1.892,
+          1.897,
+          1.906
+        ],
+        "spread_pct": 0.7399577167019034,
+        "deals": 1900000,
+        "deals_per_sec": 1004228.3298097252,
+        "produced": 367,
+        "wall_best": 1.8966891253367066,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.371,
+        "seconds_median": 0.373,
+        "seconds_all": [
+          0.371,
+          0.373,
+          0.517
+        ],
+        "spread_pct": 39.353099730458226,
+        "deals": 1900000,
+        "deals_per_sec": 5121293.800539084,
+        "produced": 367,
+        "wall_best": 0.37527258321642876,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 4763231,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.765,
+            "seconds_median": 4.773,
+            "seconds_all": [
+              4.765,
+              4.773,
+              4.805
+            ],
+            "spread_pct": 0.8394543546694656,
+            "deals": 4763231,
+            "deals_per_sec": 999628.7513116475,
+            "produced": 898,
+            "wall_best": 4.769409625325352,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.961,
+            "seconds_median": 2.996,
+            "seconds_all": [
+              2.961,
+              2.996,
+              2.996
+            ],
+            "spread_pct": 1.1820330969267188,
+            "deals": 4763231,
+            "deals_per_sec": 1608656.1972306655,
+            "produced": 898,
+            "wall_best": 2.9656655001454055,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.289,
+            "seconds_median": 2.292,
+            "seconds_all": [
+              2.289,
+              2.292,
+              2.315
+            ],
+            "spread_pct": 1.1358671909130538,
+            "deals": 4763231,
+            "deals_per_sec": 2080922.236784622,
+            "produced": 898,
+            "wall_best": 2.2939896248281,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.581,
+            "seconds_median": 1.669,
+            "seconds_all": [
+              1.581,
+              1.669,
+              1.758
+            ],
+            "spread_pct": 11.195445920303609,
+            "deals": 4763231,
+            "deals_per_sec": 3012796.3314358,
+            "produced": 898,
+            "wall_best": 1.585389249958098,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.403,
+            "seconds_median": 1.425,
+            "seconds_all": [
+              1.403,
+              1.425,
+              1.477
+            ],
+            "spread_pct": 5.274411974340703,
+            "deals": 4763231,
+            "deals_per_sec": 3395032.7868852457,
+            "produced": 898,
+            "wall_best": 1.4075272497721016,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.25,
+            "seconds_median": 1.253,
+            "seconds_all": [
+              1.25,
+              1.253,
+              1.263
+            ],
+            "spread_pct": 1.039999999999992,
+            "deals": 4763231,
+            "deals_per_sec": 3810584.8,
+            "produced": 898,
+            "wall_best": 1.2551292912103236,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.099,
+            "seconds_median": 1.1,
+            "seconds_all": [
+              1.099,
+              1.1,
+              1.122
+            ],
+            "spread_pct": 2.092811646951786,
+            "deals": 4763231,
+            "deals_per_sec": 4334150.136487716,
+            "produced": 898,
+            "wall_best": 1.1037775832228363,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 1.054,
+            "seconds_median": 1.079,
+            "seconds_all": [
+              1.054,
+              1.079,
+              1.163
+            ],
+            "spread_pct": 10.3415559772296,
+            "deals": 4763231,
+            "deals_per_sec": 4519194.4971537,
+            "produced": 898,
+            "wall_best": 1.0587206250056624,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.958,
+            "seconds_median": 0.958,
+            "seconds_all": [
+              0.958,
+              0.958,
+              1.012
+            ],
+            "spread_pct": 5.63674321503132,
+            "deals": 4763231,
+            "deals_per_sec": 4972057.411273487,
+            "produced": 898,
+            "wall_best": 0.9624795829877257,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.931,
+            "seconds_median": 0.943,
+            "seconds_all": [
+              0.931,
+              0.943,
+              0.953
+            ],
+            "spread_pct": 2.363050483351225,
+            "deals": 4763231,
+            "deals_per_sec": 5116252.416756175,
+            "produced": 898,
+            "wall_best": 0.9361795000731945,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Major_Suit_Fit": {
+      "deals": 1800000,
+      "hit_rate": 0.0024,
+      "single": {
+        "seconds_best": 1.856,
+        "seconds_median": 1.857,
+        "seconds_all": [
+          1.856,
+          1.857,
+          1.87
+        ],
+        "spread_pct": 0.7543103448275869,
+        "deals": 1800000,
+        "deals_per_sec": 969827.5862068965,
+        "produced": 5400,
+        "wall_best": 1.8606205405667424,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.346,
+        "seconds_median": 0.35,
+        "seconds_all": [
+          0.346,
+          0.35,
+          0.351
+        ],
+        "spread_pct": 1.4450867052023135,
+        "deals": 1800000,
+        "deals_per_sec": 5202312.138728324,
+        "produced": 5400,
+        "wall_best": 0.35090933414176106,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 4308510,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.442,
+            "seconds_median": 4.452,
+            "seconds_all": [
+              4.442,
+              4.452,
+              4.468
+            ],
+            "spread_pct": 0.5853219270598784,
+            "deals": 4308510,
+            "deals_per_sec": 969948.2215218369,
+            "produced": 12900,
+            "wall_best": 4.446987458039075,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.687,
+            "seconds_median": 2.696,
+            "seconds_all": [
+              2.687,
+              2.696,
+              2.713
+            ],
+            "spread_pct": 0.9676218831410587,
+            "deals": 4308510,
+            "deals_per_sec": 1603464.8306661705,
+            "produced": 12900,
+            "wall_best": 2.6917596249841154,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.052,
+            "seconds_median": 2.059,
+            "seconds_all": [
+              2.052,
+              2.059,
+              2.077
+            ],
+            "spread_pct": 1.218323586744635,
+            "deals": 4308510,
+            "deals_per_sec": 2099663.7426900584,
+            "produced": 12900,
+            "wall_best": 2.0568477921187878,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.531,
+            "seconds_median": 1.534,
+            "seconds_all": [
+              1.531,
+              1.534,
+              1.544
+            ],
+            "spread_pct": 0.8491182233834176,
+            "deals": 4308510,
+            "deals_per_sec": 2814180.2743305033,
+            "produced": 12900,
+            "wall_best": 1.5355361672118306,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.345,
+            "seconds_median": 1.361,
+            "seconds_all": [
+              1.345,
+              1.361,
+              1.37
+            ],
+            "spread_pct": 1.8587360594795637,
+            "deals": 4308510,
+            "deals_per_sec": 3203353.159851301,
+            "produced": 12900,
+            "wall_best": 1.35017970809713,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.153,
+            "seconds_median": 1.179,
+            "seconds_all": [
+              1.153,
+              1.179,
+              1.219
+            ],
+            "spread_pct": 5.724197745013015,
+            "deals": 4308510,
+            "deals_per_sec": 3736782.307025152,
+            "produced": 12900,
+            "wall_best": 1.1583916661329567,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.005,
+            "seconds_median": 1.038,
+            "seconds_all": [
+              1.005,
+              1.038,
+              1.057
+            ],
+            "spread_pct": 5.174129353233836,
+            "deals": 4308510,
+            "deals_per_sec": 4287074.626865672,
+            "produced": 12900,
+            "wall_best": 1.0099622500129044,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.981,
+            "seconds_median": 0.996,
+            "seconds_all": [
+              0.981,
+              0.996,
+              1.002
+            ],
+            "spread_pct": 2.1406727828746197,
+            "deals": 4308510,
+            "deals_per_sec": 4391957.186544343,
+            "produced": 12900,
+            "wall_best": 0.9859542921185493,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.914,
+            "seconds_median": 0.985,
+            "seconds_all": [
+              0.914,
+              0.985,
+              1.032
+            ],
+            "spread_pct": 12.910284463894966,
+            "deals": 4308510,
+            "deals_per_sec": 4713905.90809628,
+            "produced": 12900,
+            "wall_best": 0.9191494169645011,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.844,
+            "seconds_median": 0.859,
+            "seconds_all": [
+              0.844,
+              0.859,
+              0.867
+            ],
+            "spread_pct": 2.7251184834123245,
+            "deals": 4308510,
+            "deals_per_sec": 5104869.668246445,
+            "produced": 12900,
+            "wall_best": 0.8487644158303738,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Drury": {
+      "deals": 1500000,
+      "hit_rate": 5e-05,
+      "single": {
+        "seconds_best": 1.829,
+        "seconds_median": 1.834,
+        "seconds_all": [
+          1.829,
+          1.834,
+          1.84
+        ],
+        "spread_pct": 0.6014215418261412,
+        "deals": 1500000,
+        "deals_per_sec": 820120.2843083652,
+        "produced": 136,
+        "wall_best": 1.8344174167141318,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.343,
+        "seconds_median": 0.389,
+        "seconds_all": [
+          0.343,
+          0.389,
+          0.458
+        ],
+        "spread_pct": 33.52769679300291,
+        "deals": 1500000,
+        "deals_per_sec": 4373177.842565597,
+        "produced": 136,
+        "wall_best": 0.34807316586375237,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 3658536,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.459,
+            "seconds_median": 4.491,
+            "seconds_all": [
+              4.459,
+              4.491,
+              4.577
+            ],
+            "spread_pct": 2.646333258578164,
+            "deals": 3658536,
+            "deals_per_sec": 820483.5164835165,
+            "produced": 342,
+            "wall_best": 4.463616375345737,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.786,
+            "seconds_median": 2.817,
+            "seconds_all": [
+              2.786,
+              2.817,
+              2.86
+            ],
+            "spread_pct": 2.6561378320172233,
+            "deals": 3658536,
+            "deals_per_sec": 1313185.9296482413,
+            "produced": 342,
+            "wall_best": 2.7909046658314764,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.159,
+            "seconds_median": 2.174,
+            "seconds_all": [
+              2.159,
+              2.174,
+              2.196
+            ],
+            "spread_pct": 1.713756368689225,
+            "deals": 3658536,
+            "deals_per_sec": 1694551.1811023625,
+            "produced": 342,
+            "wall_best": 2.163745875004679,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.566,
+            "seconds_median": 1.572,
+            "seconds_all": [
+              1.566,
+              1.572,
+              1.581
+            ],
+            "spread_pct": 0.9578544061302618,
+            "deals": 3658536,
+            "deals_per_sec": 2336229.885057471,
+            "produced": 342,
+            "wall_best": 1.5704463748261333,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.354,
+            "seconds_median": 1.527,
+            "seconds_all": [
+              1.354,
+              1.527,
+              1.588
+            ],
+            "spread_pct": 17.2821270310192,
+            "deals": 3658536,
+            "deals_per_sec": 2702020.679468242,
+            "produced": 342,
+            "wall_best": 1.3588838330470026,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.142,
+            "seconds_median": 1.188,
+            "seconds_all": [
+              1.142,
+              1.188,
+              1.236
+            ],
+            "spread_pct": 8.231173380035035,
+            "deals": 3658536,
+            "deals_per_sec": 3203621.7162872157,
+            "produced": 342,
+            "wall_best": 1.147047416307032,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.016,
+            "seconds_median": 1.017,
+            "seconds_all": [
+              1.016,
+              1.017,
+              1.045
+            ],
+            "spread_pct": 2.8543307086614087,
+            "deals": 3658536,
+            "deals_per_sec": 3600921.2598425196,
+            "produced": 342,
+            "wall_best": 1.0210220841690898,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.99,
+            "seconds_median": 1.03,
+            "seconds_all": [
+              0.99,
+              1.03,
+              1.045
+            ],
+            "spread_pct": 5.555555555555549,
+            "deals": 3658536,
+            "deals_per_sec": 3695490.909090909,
+            "produced": 342,
+            "wall_best": 0.9952717088162899,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.933,
+            "seconds_median": 0.977,
+            "seconds_all": [
+              0.933,
+              0.977,
+              1.094
+            ],
+            "spread_pct": 17.256162915326907,
+            "deals": 3658536,
+            "deals_per_sec": 3921260.4501607716,
+            "produced": 342,
+            "wall_best": 0.9381948332302272,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.896,
+            "seconds_median": 0.916,
+            "seconds_all": [
+              0.896,
+              0.916,
+              0.961
+            ],
+            "spread_pct": 7.254464285714279,
+            "deals": 3658536,
+            "deals_per_sec": 4083187.5,
+            "produced": 342,
+            "wall_best": 0.900797083042562,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Basic_Takeout_Double": {
+      "deals": 1100000,
+      "hit_rate": 0.00535,
+      "single": {
+        "seconds_best": 1.845,
+        "seconds_median": 1.846,
+        "seconds_all": [
+          1.845,
+          1.846,
+          1.866
+        ],
+        "spread_pct": 1.1382113821138282,
+        "deals": 1100000,
+        "deals_per_sec": 596205.9620596207,
+        "produced": 6264,
+        "wall_best": 1.8500297907739878,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.34,
+        "seconds_median": 0.399,
+        "seconds_all": [
+          0.34,
+          0.399,
+          0.42
+        ],
+        "spread_pct": 23.52941176470587,
+        "deals": 1100000,
+        "deals_per_sec": 3235294.117647059,
+        "produced": 6264,
+        "wall_best": 0.34435645770281553,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 2147505,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 3.597,
+            "seconds_median": 3.6,
+            "seconds_all": [
+              3.597,
+              3.6,
+              3.614
+            ],
+            "spread_pct": 0.4726160689463415,
+            "deals": 2147505,
+            "deals_per_sec": 597026.6889074228,
+            "produced": 12080,
+            "wall_best": 3.6019443343393505,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.135,
+            "seconds_median": 2.142,
+            "seconds_all": [
+              2.135,
+              2.142,
+              2.176
+            ],
+            "spread_pct": 1.9203747072599708,
+            "deals": 2147505,
+            "deals_per_sec": 1005857.142857143,
+            "produced": 12080,
+            "wall_best": 2.1399420839734375,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 1.64,
+            "seconds_median": 1.645,
+            "seconds_all": [
+              1.64,
+              1.645,
+              1.72
+            ],
+            "spread_pct": 4.878048780487809,
+            "deals": 2147505,
+            "deals_per_sec": 1309454.268292683,
+            "produced": 12080,
+            "wall_best": 1.6449911668896675,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.196,
+            "seconds_median": 1.217,
+            "seconds_all": [
+              1.196,
+              1.217,
+              1.269
+            ],
+            "spread_pct": 6.103678929765883,
+            "deals": 2147505,
+            "deals_per_sec": 1795572.7424749164,
+            "produced": 12080,
+            "wall_best": 1.2004148331470788,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 0.993,
+            "seconds_median": 1.114,
+            "seconds_all": [
+              0.993,
+              1.114,
+              1.125
+            ],
+            "spread_pct": 13.293051359516618,
+            "deals": 2147505,
+            "deals_per_sec": 2162643.504531722,
+            "produced": 12080,
+            "wall_best": 0.9992904174141586,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 0.925,
+            "seconds_median": 1.056,
+            "seconds_all": [
+              0.925,
+              1.056,
+              1.147
+            ],
+            "spread_pct": 23.999999999999996,
+            "deals": 2147505,
+            "deals_per_sec": 2321627.0270270268,
+            "produced": 12080,
+            "wall_best": 0.9297757921740413,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.864,
+            "seconds_median": 0.902,
+            "seconds_all": [
+              0.864,
+              0.902,
+              0.902
+            ],
+            "spread_pct": 4.398148148148152,
+            "deals": 2147505,
+            "deals_per_sec": 2485538.1944444445,
+            "produced": 12080,
+            "wall_best": 0.8691750830039382,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.751,
+            "seconds_median": 0.883,
+            "seconds_all": [
+              0.751,
+              0.883,
+              0.942
+            ],
+            "spread_pct": 25.432756324900126,
+            "deals": 2147505,
+            "deals_per_sec": 2859527.296937417,
+            "produced": 12080,
+            "wall_best": 0.7561440416611731,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.697,
+            "seconds_median": 0.763,
+            "seconds_all": [
+              0.697,
+              0.763,
+              0.823
+            ],
+            "spread_pct": 18.077474892395983,
+            "deals": 2147505,
+            "deals_per_sec": 3081068.866571019,
+            "produced": 12080,
+            "wall_best": 0.7020572498440742,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.717,
+            "seconds_median": 0.72,
+            "seconds_all": [
+              0.717,
+              0.72,
+              0.855
+            ],
+            "spread_pct": 19.246861924686197,
+            "deals": 2147505,
+            "deals_per_sec": 2995125.5230125524,
+            "produced": 12080,
+            "wall_best": 0.7218815833330154,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "GIB_1C-P-Resp": {
+      "deals": 1000000,
+      "hit_rate": 0.00555,
+      "single": {
+        "seconds_best": 1.861,
+        "seconds_median": 1.866,
+        "seconds_all": [
+          1.861,
+          1.866,
+          1.881
+        ],
+        "spread_pct": 1.0746910263299312,
+        "deals": 1000000,
+        "deals_per_sec": 537345.5131649651,
+        "produced": 6089,
+        "wall_best": 1.8667874159291387,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.315,
+        "seconds_median": 0.321,
+        "seconds_all": [
+          0.315,
+          0.321,
+          0.338
+        ],
+        "spread_pct": 7.301587301587308,
+        "deals": 1000000,
+        "deals_per_sec": 3174603.1746031744,
+        "produced": 6089,
+        "wall_best": 0.3196155419573188,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 2452316,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.571,
+            "seconds_median": 4.582,
+            "seconds_all": [
+              4.571,
+              4.582,
+              4.625
+            ],
+            "spread_pct": 1.1813607525705594,
+            "deals": 2452316,
+            "deals_per_sec": 536494.4213520018,
+            "produced": 14790,
+            "wall_best": 4.575986667070538,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.649,
+            "seconds_median": 2.73,
+            "seconds_all": [
+              2.649,
+              2.73,
+              2.741
+            ],
+            "spread_pct": 3.4730086825217095,
+            "deals": 2452316,
+            "deals_per_sec": 925751.604379011,
+            "produced": 14790,
+            "wall_best": 2.6542981672100723,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.015,
+            "seconds_median": 2.019,
+            "seconds_all": [
+              2.015,
+              2.019,
+              2.027
+            ],
+            "spread_pct": 0.5955334987593057,
+            "deals": 2452316,
+            "deals_per_sec": 1217030.2729528535,
+            "produced": 14790,
+            "wall_best": 2.0197910419665277,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.464,
+            "seconds_median": 1.509,
+            "seconds_all": [
+              1.464,
+              1.509,
+              1.57
+            ],
+            "spread_pct": 7.240437158469952,
+            "deals": 2452316,
+            "deals_per_sec": 1675079.2349726777,
+            "produced": 14790,
+            "wall_best": 1.4700614172033966,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.226,
+            "seconds_median": 1.319,
+            "seconds_all": [
+              1.226,
+              1.319,
+              1.355
+            ],
+            "spread_pct": 10.522022838499185,
+            "deals": 2452316,
+            "deals_per_sec": 2000257.748776509,
+            "produced": 14790,
+            "wall_best": 1.230912959203124,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.066,
+            "seconds_median": 1.08,
+            "seconds_all": [
+              1.066,
+              1.08,
+              1.202
+            ],
+            "spread_pct": 12.75797373358348,
+            "deals": 2452316,
+            "deals_per_sec": 2300484.052532833,
+            "produced": 14790,
+            "wall_best": 1.0706891249865294,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.991,
+            "seconds_median": 1.04,
+            "seconds_all": [
+              0.991,
+              1.04,
+              1.083
+            ],
+            "spread_pct": 9.283551967709382,
+            "deals": 2452316,
+            "deals_per_sec": 2474587.285570131,
+            "produced": 14790,
+            "wall_best": 0.9956151247024536,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.921,
+            "seconds_median": 0.928,
+            "seconds_all": [
+              0.921,
+              0.928,
+              0.958
+            ],
+            "spread_pct": 4.017372421281207,
+            "deals": 2452316,
+            "deals_per_sec": 2662666.6666666665,
+            "produced": 14790,
+            "wall_best": 0.9261511247605085,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.804,
+            "seconds_median": 0.842,
+            "seconds_all": [
+              0.804,
+              0.842,
+              0.844
+            ],
+            "spread_pct": 4.975124378109443,
+            "deals": 2452316,
+            "deals_per_sec": 3050144.278606965,
+            "produced": 14790,
+            "wall_best": 0.8095863340422511,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.8,
+            "seconds_median": 0.809,
+            "seconds_all": [
+              0.8,
+              0.809,
+              0.833
+            ],
+            "spread_pct": 4.124999999999989,
+            "deals": 2452316,
+            "deals_per_sec": 3065395.0,
+            "produced": 14790,
+            "wall_best": 0.8045072918757796,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Splinters_By_Opener": {
+      "deals": 830000,
+      "hit_rate": 0.0003,
+      "single": {
+        "seconds_best": 1.951,
+        "seconds_median": 1.962,
+        "seconds_all": [
+          1.951,
+          1.962,
+          1.99
+        ],
+        "spread_pct": 1.9989748846745221,
+        "deals": 830000,
+        "deals_per_sec": 425422.86007175804,
+        "produced": 157,
+        "wall_best": 1.9570896667428315,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.374,
+        "seconds_median": 0.39,
+        "seconds_all": [
+          0.374,
+          0.39,
+          0.39
+        ],
+        "spread_pct": 4.278074866310164,
+        "deals": 830000,
+        "deals_per_sec": 2219251.336898396,
+        "produced": 157,
+        "wall_best": 0.37891054106876254,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 2035422,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.755,
+            "seconds_median": 4.766,
+            "seconds_all": [
+              4.755,
+              4.766,
+              4.788
+            ],
+            "spread_pct": 0.6940063091482727,
+            "deals": 2035422,
+            "deals_per_sec": 428059.30599369085,
+            "produced": 359,
+            "wall_best": 4.760046834126115,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.771,
+            "seconds_median": 2.789,
+            "seconds_all": [
+              2.771,
+              2.789,
+              2.905
+            ],
+            "spread_pct": 4.835799350415009,
+            "deals": 2035422,
+            "deals_per_sec": 734544.207867196,
+            "produced": 359,
+            "wall_best": 2.7759781661443412,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.112,
+            "seconds_median": 2.125,
+            "seconds_all": [
+              2.112,
+              2.125,
+              2.132
+            ],
+            "spread_pct": 0.9469696969696977,
+            "deals": 2035422,
+            "deals_per_sec": 963741.4772727272,
+            "produced": 359,
+            "wall_best": 2.117632166016847,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.517,
+            "seconds_median": 1.521,
+            "seconds_all": [
+              1.517,
+              1.521,
+              1.566
+            ],
+            "spread_pct": 3.230059327620314,
+            "deals": 2035422,
+            "deals_per_sec": 1341741.5952537905,
+            "produced": 359,
+            "wall_best": 1.5217771250754595,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.296,
+            "seconds_median": 1.378,
+            "seconds_all": [
+              1.296,
+              1.378,
+              1.415
+            ],
+            "spread_pct": 9.182098765432098,
+            "deals": 2035422,
+            "deals_per_sec": 1570541.6666666665,
+            "produced": 359,
+            "wall_best": 1.3029661667533219,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.114,
+            "seconds_median": 1.163,
+            "seconds_all": [
+              1.114,
+              1.163,
+              1.205
+            ],
+            "spread_pct": 8.168761220825848,
+            "deals": 2035422,
+            "deals_per_sec": 1827129.263913824,
+            "produced": 359,
+            "wall_best": 1.1185189168900251,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.979,
+            "seconds_median": 0.982,
+            "seconds_all": [
+              0.979,
+              0.982,
+              1.002
+            ],
+            "spread_pct": 2.349336057201228,
+            "deals": 2035422,
+            "deals_per_sec": 2079082.7374872318,
+            "produced": 359,
+            "wall_best": 0.9839619169943035,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.897,
+            "seconds_median": 0.957,
+            "seconds_all": [
+              0.897,
+              0.957,
+              1.094
+            ],
+            "spread_pct": 21.962095875139358,
+            "deals": 2035422,
+            "deals_per_sec": 2269143.81270903,
+            "produced": 359,
+            "wall_best": 0.9021902498789132,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.875,
+            "seconds_median": 0.916,
+            "seconds_all": [
+              0.875,
+              0.916,
+              0.952
+            ],
+            "spread_pct": 8.799999999999995,
+            "deals": 2035422,
+            "deals_per_sec": 2326196.5714285714,
+            "produced": 359,
+            "wall_best": 0.8813675842247903,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.821,
+            "seconds_median": 0.867,
+            "seconds_all": [
+              0.821,
+              0.867,
+              0.916
+            ],
+            "spread_pct": 11.5712545676005,
+            "deals": 2035422,
+            "deals_per_sec": 2479198.538367844,
+            "produced": 359,
+            "wall_best": 0.8262684158980846,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "Gerber_By_Responder": {
+      "deals": 650000,
+      "hit_rate": 0.00025,
+      "single": {
+        "seconds_best": 1.97,
+        "seconds_median": 2.001,
+        "seconds_all": [
+          1.97,
+          2.001,
+          2.251
+        ],
+        "spread_pct": 14.26395939086294,
+        "deals": 650000,
+        "deals_per_sec": 329949.2385786802,
+        "produced": 106,
+        "wall_best": 1.974899958819151,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.319,
+        "seconds_median": 0.327,
+        "seconds_all": [
+          0.319,
+          0.327,
+          0.347
+        ],
+        "spread_pct": 8.77742946708463,
+        "deals": 650000,
+        "deals_per_sec": 2037617.5548589341,
+        "produced": 106,
+        "wall_best": 0.3235544585622847,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 1710526,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 5.177,
+            "seconds_median": 5.203,
+            "seconds_all": [
+              5.177,
+              5.203,
+              5.241
+            ],
+            "spread_pct": 1.2362372030133293,
+            "deals": 1710526,
+            "deals_per_sec": 330408.7309252463,
+            "produced": 276,
+            "wall_best": 5.181536083109677,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.954,
+            "seconds_median": 2.957,
+            "seconds_all": [
+              2.954,
+              2.957,
+              2.958
+            ],
+            "spread_pct": 0.13540961408259997,
+            "deals": 1710526,
+            "deals_per_sec": 579054.163845633,
+            "produced": 276,
+            "wall_best": 2.9606892918236554,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 2.209,
+            "seconds_median": 2.216,
+            "seconds_all": [
+              2.209,
+              2.216,
+              2.263
+            ],
+            "spread_pct": 2.444545043005877,
+            "deals": 1710526,
+            "deals_per_sec": 774344.0470801267,
+            "produced": 276,
+            "wall_best": 2.2139664157293737,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.621,
+            "seconds_median": 1.628,
+            "seconds_all": [
+              1.621,
+              1.628,
+              1.631
+            ],
+            "spread_pct": 0.6169031462060462,
+            "deals": 1710526,
+            "deals_per_sec": 1055228.8710672425,
+            "produced": 276,
+            "wall_best": 1.62609629239887,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.39,
+            "seconds_median": 1.402,
+            "seconds_all": [
+              1.39,
+              1.402,
+              1.467
+            ],
+            "spread_pct": 5.5395683453237545,
+            "deals": 1710526,
+            "deals_per_sec": 1230594.2446043165,
+            "produced": 276,
+            "wall_best": 1.3945659580640495,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.188,
+            "seconds_median": 1.203,
+            "seconds_all": [
+              1.188,
+              1.203,
+              1.228
+            ],
+            "spread_pct": 3.3670033670033703,
+            "deals": 1710526,
+            "deals_per_sec": 1439836.7003367003,
+            "produced": 276,
+            "wall_best": 1.1928635002113879,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 1.006,
+            "seconds_median": 1.029,
+            "seconds_all": [
+              1.006,
+              1.029,
+              1.188
+            ],
+            "spread_pct": 18.091451292246514,
+            "deals": 1710526,
+            "deals_per_sec": 1700324.055666004,
+            "produced": 276,
+            "wall_best": 1.0112047498114407,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 0.94,
+            "seconds_median": 0.943,
+            "seconds_all": [
+              0.94,
+              0.943,
+              0.949
+            ],
+            "spread_pct": 0.9574468085106391,
+            "deals": 1710526,
+            "deals_per_sec": 1819708.510638298,
+            "produced": 276,
+            "wall_best": 0.9446731670759618,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.927,
+            "seconds_median": 0.929,
+            "seconds_all": [
+              0.927,
+              0.929,
+              0.953
+            ],
+            "spread_pct": 2.804746494066873,
+            "deals": 1710526,
+            "deals_per_sec": 1845227.61596548,
+            "produced": 276,
+            "wall_best": 0.9338120422326028,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.895,
+            "seconds_median": 0.923,
+            "seconds_all": [
+              0.895,
+              0.923,
+              1.063
+            ],
+            "spread_pct": 18.770949720670384,
+            "deals": 1710526,
+            "deals_per_sec": 1911202.2346368714,
+            "produced": 276,
+            "wall_best": 0.899356750305742,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    },
+    "_shuffle_baseline": {
+      "deals": 3700000,
+      "hit_rate": 0.00098,
+      "single": {
+        "seconds_best": 1.977,
+        "seconds_median": 1.98,
+        "seconds_all": [
+          1.977,
+          1.98,
+          1.985
+        ],
+        "spread_pct": 0.4046535154274156,
+        "deals": 3700000,
+        "deals_per_sec": 1871522.5088517955,
+        "produced": 3883,
+        "wall_best": 1.9817415000870824,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "auto": {
+        "seconds_best": 0.386,
+        "seconds_median": 0.394,
+        "seconds_all": [
+          0.386,
+          0.394,
+          0.396
+        ],
+        "spread_pct": 2.5906735751295358,
+        "deals": 3700000,
+        "deals_per_sec": 9585492.227979274,
+        "produced": 3883,
+        "wall_best": 0.3911910830065608,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "sweep_deals": 8538461,
+      "sweep": {
+        "default": {
+          "1": {
+            "seconds_best": 4.595,
+            "seconds_median": 4.609,
+            "seconds_all": [
+              4.595,
+              4.609,
+              4.621
+            ],
+            "spread_pct": 0.5658324265506135,
+            "deals": 8538461,
+            "deals_per_sec": 1858206.9640914039,
+            "produced": 8768,
+            "wall_best": 4.599726957734674,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "2": {
+            "seconds_best": 2.432,
+            "seconds_median": 2.432,
+            "seconds_all": [
+              2.432,
+              2.432,
+              2.453
+            ],
+            "spread_pct": 0.8634868421052594,
+            "deals": 8538461,
+            "deals_per_sec": 3510880.345394737,
+            "produced": 8768,
+            "wall_best": 2.4364103339612484,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "3": {
+            "seconds_best": 1.957,
+            "seconds_median": 1.965,
+            "seconds_all": [
+              1.957,
+              1.965,
+              1.97
+            ],
+            "spread_pct": 0.6642820643842565,
+            "deals": 8538461,
+            "deals_per_sec": 4363035.769034236,
+            "produced": 8768,
+            "wall_best": 1.961832749657333,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "4": {
+            "seconds_best": 1.403,
+            "seconds_median": 1.423,
+            "seconds_all": [
+              1.403,
+              1.423,
+              1.455
+            ],
+            "spread_pct": 3.70634354953671,
+            "deals": 8538461,
+            "deals_per_sec": 6085859.5866001425,
+            "produced": 8768,
+            "wall_best": 1.4074472077190876,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "5": {
+            "seconds_best": 1.292,
+            "seconds_median": 1.297,
+            "seconds_all": [
+              1.292,
+              1.297,
+              1.313
+            ],
+            "spread_pct": 1.6253869969040176,
+            "deals": 8538461,
+            "deals_per_sec": 6608715.9442724455,
+            "produced": 8768,
+            "wall_best": 1.296547541860491,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "6": {
+            "seconds_best": 1.117,
+            "seconds_median": 1.122,
+            "seconds_all": [
+              1.117,
+              1.122,
+              1.128
+            ],
+            "spread_pct": 0.9847806624888003,
+            "deals": 8538461,
+            "deals_per_sec": 7644101.163831692,
+            "produced": 8768,
+            "wall_best": 1.1221732501871884,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "7": {
+            "seconds_best": 0.994,
+            "seconds_median": 1.002,
+            "seconds_all": [
+              0.994,
+              1.002,
+              1.008
+            ],
+            "spread_pct": 1.4084507042253533,
+            "deals": 8538461,
+            "deals_per_sec": 8590001.006036218,
+            "produced": 8768,
+            "wall_best": 0.9983180407434702,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "8": {
+            "seconds_best": 1.017,
+            "seconds_median": 1.044,
+            "seconds_all": [
+              1.017,
+              1.044,
+              1.06
+            ],
+            "spread_pct": 4.2281219272369865,
+            "deals": 8538461,
+            "deals_per_sec": 8395733.529990168,
+            "produced": 8768,
+            "wall_best": 1.0239589172415435,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "10": {
+            "seconds_best": 0.92,
+            "seconds_median": 0.929,
+            "seconds_all": [
+              0.92,
+              0.929,
+              0.929
+            ],
+            "spread_pct": 0.9782608695652182,
+            "deals": 8538461,
+            "deals_per_sec": 9280935.869565217,
+            "produced": 8768,
+            "wall_best": 0.9242596249096096,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          },
+          "12": {
+            "seconds_best": 0.903,
+            "seconds_median": 0.904,
+            "seconds_all": [
+              0.903,
+              0.904,
+              0.915
+            ],
+            "spread_pct": 1.328903654485051,
+            "deals": 8538461,
+            "deals_per_sec": 9455660.022148393,
+            "produced": 8768,
+            "wall_best": 0.908311374951154,
+            "timing": "self",
+            "overhead_subtracted": 0.0
+          }
+        }
+      }
+    }
+  },
+  "partial": false,
+  "written": "2026-09-01 09:05:30",
+  "machine": {
+    "model": "Mac16,11",
+    "cpu": "Apple M4 Pro",
+    "logical_cpus": "12",
+    "performance_cpus": "8",
+    "efficiency_cpus": "4"
+  },
+  "source_id": "92f902fd12e4",
+  "source_id_note": "stamped after the run; git confirmed no .rs file changed between the run and the stamp, and the binary was not rebuilt"
+}

--- a/bench/results/reference-7d7033566ed1.json
+++ b/bench/results/reference-7d7033566ed1.json
@@ -1,0 +1,590 @@
+{
+  "tool": "bench-reference",
+  "windows_vm": {
+    "architecture": "ARM64",
+    "identifier": "ARMv8 (64-bit) Family 8 Model 0 Revision   0,",
+    "cpus": "4",
+    "note": "dealer.exe is PE32/i386; on an ARM64 VM it runs emulated"
+  },
+  "corpus_id": "7d7033566ed1",
+  "corpus_revision": "v0.4.0-196-g529a79a",
+  "repeats": 3,
+  "scale": 1.0,
+  "targets": {
+    "dealer.exe": "Windows VM via SSH; wall-clocked with SSH overhead calibrated out, because dealer.exe reports Time needed 0.000 there",
+    "dealer-c": "original C dealer, built natively -- the emulation-free reference for dealer.exe's lineage",
+    "dealerv2_4": "DealerV2_4"
+  },
+  "scripts": {
+    "Scrambling_2NT": {
+      "deals": 2900000,
+      "dealer.exe": {
+        "seconds_best": 12.572647416964173,
+        "seconds_median": 12.616555499844253,
+        "seconds_all": [
+          12.572647416964173,
+          12.616555499844253,
+          12.645852167159319
+        ],
+        "spread_pct": 0.5822540612756787,
+        "deals": 2900000,
+        "deals_per_sec": 230659.45491218127,
+        "produced": 252,
+        "wall_best": 12.89785929210484,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 1.053,
+        "seconds_median": 1.06,
+        "seconds_all": [
+          1.053,
+          1.06,
+          1.06
+        ],
+        "spread_pct": 0.6647673314340092,
+        "deals": 2900000,
+        "deals_per_sec": 2754036.087369421,
+        "produced": 252,
+        "wall_best": 1.055842166300863,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 2.199,
+        "seconds_median": 2.209,
+        "seconds_all": [
+          2.199,
+          2.209,
+          2.222
+        ],
+        "spread_pct": 1.0459299681673548,
+        "deals": 2900000,
+        "deals_per_sec": 1318781.264211005,
+        "produced": 240,
+        "wall_best": 2.2041440829634666,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    },
+    "GIB_1N_Basic": {
+      "deals": 2800000,
+      "dealer.exe": {
+        "seconds_best": 12.393759957980365,
+        "seconds_median": 12.421690125018358,
+        "seconds_all": [
+          12.393759957980365,
+          12.421690125018358,
+          12.527360667008907
+        ],
+        "spread_pct": 1.077967537547121,
+        "deals": 2800000,
+        "deals_per_sec": 225920.14122373532,
+        "produced": 68356,
+        "wall_best": 12.718971833121032,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 0.998,
+        "seconds_median": 1.004,
+        "seconds_all": [
+          0.998,
+          1.004,
+          1.02
+        ],
+        "spread_pct": 2.2044088176352723,
+        "deals": 2800000,
+        "deals_per_sec": 2805611.2224448896,
+        "produced": 68356,
+        "wall_best": 1.0003463746979833,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 2.143,
+        "seconds_median": 2.143,
+        "seconds_all": [
+          2.143,
+          2.143,
+          2.152
+        ],
+        "spread_pct": 0.4199720018665582,
+        "deals": 2800000,
+        "deals_per_sec": 1306579.561362576,
+        "produced": 68265,
+        "wall_best": 2.1464203340001404,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    },
+    "Slam_After_Major_Fit": {
+      "deals": 2700000,
+      "dealer.exe": {
+        "seconds_best": 12.080058665946126,
+        "seconds_median": 12.104941749945283,
+        "seconds_all": [
+          12.080058665946126,
+          12.104941749945283,
+          12.313357333187014
+        ],
+        "spread_pct": 1.9312709788286082,
+        "deals": 2700000,
+        "deals_per_sec": 223508.84831473063,
+        "produced": 4560,
+        "wall_best": 12.405270541086793,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 0.969,
+        "seconds_median": 0.97,
+        "seconds_all": [
+          0.969,
+          0.97,
+          0.982
+        ],
+        "spread_pct": 1.341589267285863,
+        "deals": 2700000,
+        "deals_per_sec": 2786377.7089783284,
+        "produced": 4560,
+        "wall_best": 0.9715395420789719,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 2.062,
+        "seconds_median": 2.064,
+        "seconds_all": [
+          2.062,
+          2.064,
+          2.098
+        ],
+        "spread_pct": 1.745877788554803,
+        "deals": 2700000,
+        "deals_per_sec": 1309408.341416101,
+        "produced": 4615,
+        "wall_best": 2.067043417133391,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    },
+    "After_Partner_Overcalls": {
+      "deals": 1900000,
+      "dealer.exe": {
+        "seconds_best": 9.277775832917541,
+        "seconds_median": 9.323103083763272,
+        "seconds_all": [
+          9.277775832917541,
+          9.323103083763272,
+          9.365764582529664
+        ],
+        "spread_pct": 0.9483819311514162,
+        "deals": 1900000,
+        "deals_per_sec": 204790.46209101126,
+        "produced": 337,
+        "wall_best": 9.602987708058208,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 0.913,
+        "seconds_median": 0.916,
+        "seconds_all": [
+          0.913,
+          0.916,
+          0.928
+        ],
+        "spread_pct": 1.6429353778751383,
+        "deals": 1900000,
+        "deals_per_sec": 2081051.47864184,
+        "produced": 337,
+        "wall_best": 0.9157390831969678,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 1.652,
+        "seconds_median": 1.656,
+        "seconds_all": [
+          1.652,
+          1.656,
+          1.683
+        ],
+        "spread_pct": 1.8765133171912918,
+        "deals": 1900000,
+        "deals_per_sec": 1150121.0653753027,
+        "produced": 363,
+        "wall_best": 1.6554972501471639,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    },
+    "Major_Suit_Fit": {
+      "deals": 1800000,
+      "dealer.exe": {
+        "seconds_best": 9.304163165856153,
+        "seconds_median": 9.345461915712804,
+        "seconds_all": [
+          9.304163165856153,
+          9.345461915712804,
+          9.452611208893359
+        ],
+        "spread_pct": 1.5955012867999936,
+        "deals": 1800000,
+        "deals_per_sec": 193461.78349553558,
+        "produced": 5373,
+        "wall_best": 9.62937504099682,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 1.037,
+        "seconds_median": 1.062,
+        "seconds_all": [
+          1.037,
+          1.062,
+          1.066
+        ],
+        "spread_pct": 2.796528447444565,
+        "deals": 1800000,
+        "deals_per_sec": 1735776.2777242046,
+        "produced": 5373,
+        "wall_best": 1.040252042002976,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 1.711,
+        "seconds_median": 1.711,
+        "seconds_all": [
+          1.711,
+          1.711,
+          1.728
+        ],
+        "spread_pct": 0.9935710111046115,
+        "deals": 1800000,
+        "deals_per_sec": 1052016.3646990063,
+        "produced": 5476,
+        "wall_best": 1.714590541087091,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    },
+    "Drury": {
+      "deals": 1500000,
+      "dealer.exe": {
+        "seconds_best": 7.181887790560722,
+        "seconds_median": 7.227778458036482,
+        "seconds_all": [
+          7.181887790560722,
+          7.227778458036482,
+          7.281813833862543
+        ],
+        "spread_pct": 1.3913618009063753,
+        "deals": 1500000,
+        "deals_per_sec": 208858.73516033983,
+        "produced": 163,
+        "wall_best": 7.507099665701389,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 0.674,
+        "seconds_median": 0.674,
+        "seconds_all": [
+          0.674,
+          0.674,
+          0.687
+        ],
+        "spread_pct": 1.9287833827893193,
+        "deals": 1500000,
+        "deals_per_sec": 2225519.2878338275,
+        "produced": 163,
+        "wall_best": 0.6773857502266765,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 1.267,
+        "seconds_median": 1.269,
+        "seconds_all": [
+          1.267,
+          1.269,
+          1.27
+        ],
+        "spread_pct": 0.2367797947908535,
+        "deals": 1500000,
+        "deals_per_sec": 1183898.9739542226,
+        "produced": 134,
+        "wall_best": 1.2699155420996249,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    },
+    "Basic_Takeout_Double": {
+      "deals": 1100000,
+      "dealer.exe": {
+        "seconds_best": 6.497418249491602,
+        "seconds_median": 6.559055166784674,
+        "seconds_all": [
+          6.497418249491602,
+          6.559055166784674,
+          6.615740874782205
+        ],
+        "spread_pct": 1.8210713970870003,
+        "deals": 1100000,
+        "deals_per_sec": 169298.01311252677,
+        "produced": 6159,
+        "wall_best": 6.822630124632269,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 0.922,
+        "seconds_median": 0.924,
+        "seconds_all": [
+          0.922,
+          0.924,
+          0.945
+        ],
+        "spread_pct": 2.494577006507582,
+        "deals": 1100000,
+        "deals_per_sec": 1193058.568329718,
+        "produced": 6159,
+        "wall_best": 0.925167000386864,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 1.258,
+        "seconds_median": 1.26,
+        "seconds_all": [
+          1.258,
+          1.26,
+          1.292
+        ],
+        "spread_pct": 2.702702702702705,
+        "deals": 1100000,
+        "deals_per_sec": 874403.8155802862,
+        "produced": 6026,
+        "wall_best": 1.261028750333935,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    },
+    "GIB_1C-P-Resp": {
+      "deals": 1000000,
+      "dealer.exe": {
+        "seconds_best": 5.703944208100438,
+        "seconds_median": 5.758786624763161,
+        "seconds_all": [
+          5.703944208100438,
+          5.758786624763161,
+          5.759113207925111
+        ],
+        "spread_pct": 0.967207914592237,
+        "deals": 1000000,
+        "deals_per_sec": 175317.2828338421,
+        "produced": 6090,
+        "wall_best": 6.029156083241105,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 0.77,
+        "seconds_median": 0.77,
+        "seconds_all": [
+          0.77,
+          0.77,
+          0.784
+        ],
+        "spread_pct": 1.81818181818182,
+        "deals": 1000000,
+        "deals_per_sec": 1298701.2987012987,
+        "produced": 6090,
+        "wall_best": 0.7726980000734329,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 1.099,
+        "seconds_median": 1.1,
+        "seconds_all": [
+          1.099,
+          1.1,
+          1.111
+        ],
+        "spread_pct": 1.0919017288444048,
+        "deals": 1000000,
+        "deals_per_sec": 909918.1073703367,
+        "produced": 6084,
+        "wall_best": 1.102797499857843,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    },
+    "Splinters_By_Opener": {
+      "deals": 830000,
+      "dealer.exe": {
+        "seconds_best": 8.524669624865055,
+        "seconds_median": 8.53882316686213,
+        "seconds_all": [
+          8.524669624865055,
+          8.53882316686213,
+          8.553122165612876
+        ],
+        "spread_pct": 0.333767078372515,
+        "deals": 830000,
+        "deals_per_sec": 97364.4770442513,
+        "produced": 134,
+        "wall_best": 8.849881500005722,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 1.956,
+        "seconds_median": 1.957,
+        "seconds_all": [
+          1.956,
+          1.957,
+          1.962
+        ],
+        "spread_pct": 0.306748466257669,
+        "deals": 830000,
+        "deals_per_sec": 424335.37832310837,
+        "produced": 134,
+        "wall_best": 1.9586732499301434,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 1.937,
+        "seconds_median": 1.958,
+        "seconds_all": [
+          1.937,
+          1.958,
+          1.991
+        ],
+        "spread_pct": 2.787816210635005,
+        "deals": 830000,
+        "deals_per_sec": 428497.67681982444,
+        "produced": 153,
+        "wall_best": 1.9405825841240585,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    },
+    "Gerber_By_Responder": {
+      "deals": 650000,
+      "dealer.exe": {
+        "seconds_best": 6.636124874930829,
+        "seconds_median": 6.777178625110537,
+        "seconds_all": [
+          6.636124874930829,
+          6.777178625110537,
+          6.82399370893836
+        ],
+        "spread_pct": 2.8310020915555727,
+        "deals": 650000,
+        "deals_per_sec": 97948.72945436779,
+        "produced": 104,
+        "wall_best": 6.961336750071496,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 1.962,
+        "seconds_median": 1.974,
+        "seconds_all": [
+          1.962,
+          1.974,
+          1.976
+        ],
+        "spread_pct": 0.71355759429154,
+        "deals": 650000,
+        "deals_per_sec": 331294.59734964324,
+        "produced": 104,
+        "wall_best": 1.9669607090763748,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 1.686,
+        "seconds_median": 1.689,
+        "seconds_all": [
+          1.686,
+          1.689,
+          1.702
+        ],
+        "spread_pct": 0.9489916963226581,
+        "deals": 650000,
+        "deals_per_sec": 385527.8766310795,
+        "produced": 108,
+        "wall_best": 1.68927516695112,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    },
+    "_shuffle_baseline": {
+      "deals": 3700000,
+      "dealer.exe": {
+        "seconds_best": 5.493093125056475,
+        "seconds_median": 5.618589125107974,
+        "seconds_all": [
+          5.493093125056475,
+          5.618589125107974,
+          5.641643374692649
+        ],
+        "spread_pct": 2.7043096895366396,
+        "deals": 3700000,
+        "deals_per_sec": 673573.1428114028,
+        "produced": 3763,
+        "wall_best": 5.818305000197142,
+        "timing": "wall",
+        "overhead_subtracted": 0.32521187514066696
+      },
+      "dealer-c": {
+        "seconds_best": 0.65,
+        "seconds_median": 0.654,
+        "seconds_all": [
+          0.65,
+          0.654,
+          0.661
+        ],
+        "spread_pct": 1.6923076923076936,
+        "deals": 3700000,
+        "deals_per_sec": 5692307.692307692,
+        "produced": 3763,
+        "wall_best": 0.6530356672592461,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      },
+      "dealerv2_4": {
+        "seconds_best": 0.996,
+        "seconds_median": 0.997,
+        "seconds_all": [
+          0.996,
+          0.997,
+          1.007
+        ],
+        "spread_pct": 1.1044176706827207,
+        "deals": 3700000,
+        "deals_per_sec": 3714859.437751004,
+        "produced": 3782,
+        "wall_best": 0.9995920830406249,
+        "timing": "self",
+        "overhead_subtracted": 0.0
+      }
+    }
+  },
+  "partial": false,
+  "written": "2026-09-01 08:54:40",
+  "machine": {
+    "model": "Mac16,11",
+    "cpu": "Apple M4 Pro",
+    "logical_cpus": "12",
+    "performance_cpus": "8",
+    "efficiency_cpus": "4"
+  }
+}

--- a/dealer-core/src/fast_deal.rs
+++ b/dealer-core/src/fast_deal.rs
@@ -145,6 +145,23 @@ pub fn generate_deal_from_seed_no_predeal(seed: u64) -> Deal {
 
 /// Convert a shuffled deck array to a Deal.
 #[inline]
+/// Build a `Deal` from a shuffled deck.
+///
+/// The hands come out in deal order, not sorted. Sorting here cost about
+/// 340ns of the roughly 530ns it took to produce a deal -- two thirds of all
+/// generation -- and it was paid on every deal generated, while a run
+/// typically keeps well under 1% of them. Nothing needed it:
+///
+///   - The counting functions (`hcp`, `top4`, `suit_length`, `controls`, and
+///     the rest) are sums and filters, so order cannot reach them.
+///   - The rank-position ones (`losers_in_suit`, `suit_quality`, `cccc`) each
+///     sort their own local copy first.
+///   - Every output formatter -- PBN, printall, printoneline, compact -- sorts
+///     the suit it is about to print.
+///   - `dealer_dds`'s memo key is a bitmask.
+///
+/// Sort a hand explicitly with [`Hand::sort`] or [`Hand::sorted`] where order
+/// is wanted.
 fn deck_to_deal(deck: &[u8; 52]) -> Deal {
     let mut deal = Deal::new();
 
@@ -154,7 +171,6 @@ fn deck_to_deal(deck: &[u8; 52]) -> Deal {
         deal.hand_mut(position).add_card(card);
     }
 
-    deal.sort_all_hands();
     deal
 }
 

--- a/dealer-core/src/hand.rs
+++ b/dealer-core/src/hand.rs
@@ -30,11 +30,21 @@ const FILLER: Card = Card {
 };
 
 impl PartialEq for Hand {
-    /// The cards a hand holds, not the slots it does not. Derived equality would
-    /// compare the filler too, which is the same value everywhere today and so
-    /// would agree — but only by accident, and not if the filler ever changes.
+    /// The cards a hand holds, as a set: same cards means equal, whatever order
+    /// they arrived in.
+    ///
+    /// This used to compare the slices, which made equality depend on order.
+    /// That was survivable only because every dealt hand was sorted on the way
+    /// out of `deck_to_deal`, canonicalizing it. Dealing no longer sorts — the
+    /// sort cost two thirds of generation and nothing needed it — so comparing
+    /// sequences would now call two hands holding identical cards unequal,
+    /// depending on how the shuffle happened to lay them out.
+    ///
+    /// A 52-bit mask is the honest comparison and is cheaper than the slice
+    /// compare it replaces. `len` is checked too so that a malformed hand
+    /// holding a duplicate cannot collapse into an equal-looking one.
     fn eq(&self, other: &Self) -> bool {
-        self.cards() == other.cards()
+        self.len == other.len && self.card_mask() == other.card_mask()
     }
 }
 
@@ -71,6 +81,13 @@ impl Hand {
         );
         self.cards[self.len as usize] = card;
         self.len += 1;
+    }
+
+    /// The hand as a 52-bit set, one bit per card. Order-independent.
+    fn card_mask(&self) -> u64 {
+        self.cards()
+            .iter()
+            .fold(0u64, |mask, card| mask | 1u64 << card.to_index())
     }
 
     /// Get all cards in the hand

--- a/dealer-core/src/hand.rs
+++ b/dealer-core/src/hand.rs
@@ -262,7 +262,7 @@ impl Hand {
     /// - 3+ cards: Start with 3, subtract 1 for each A/K/Q in top 3 positions
     pub fn losers_in_suit(&self, suit: Suit) -> u8 {
         let mut cards: Vec<Card> = self
-            .cards
+            .cards()
             .iter()
             .filter(|c| c.suit == suit)
             .copied()
@@ -491,7 +491,7 @@ impl Hand {
     /// Returns quality value multiplied by 100 to use integer math
     pub fn suit_quality(&self, suit: Suit) -> i32 {
         let mut cards: Vec<Card> = self
-            .cards
+            .cards()
             .iter()
             .filter(|c| c.suit == suit)
             .copied()
@@ -575,7 +575,7 @@ impl Hand {
         // Evaluate each suit
         for suit in [Suit::Spades, Suit::Hearts, Suit::Diamonds, Suit::Clubs] {
             let mut cards: Vec<Card> = self
-                .cards
+                .cards()
                 .iter()
                 .filter(|c| c.suit == suit)
                 .copied()
@@ -737,5 +737,48 @@ mod tests {
         hand.add_card(Card::new(Suit::Diamonds, Rank::Ace)); // 2
 
         assert_eq!(hand.controls(), 5);
+    }
+
+    #[test]
+    fn a_partial_hand_does_not_count_its_empty_slots() {
+        // `losers_in_suit`, `suit_quality` and `cccc` used to read the whole
+        // thirteen-slot array rather than `cards()`, so on a hand holding fewer
+        // than thirteen cards they counted the filler. The filler is a club
+        // two, which made an empty club suit look like a long weak one — three
+        // losers where there should be none, and a suit quality for a suit the
+        // hand does not hold.
+        //
+        // Every hand the generator produces is full, so this was unreachable
+        // from a run; predeal and hand-built hands are not, which is why it is
+        // worth a test rather than an argument.
+        let mut hand = Hand::new();
+        for rank in [Rank::Ace, Rank::King, Rank::Queen] {
+            hand.add_card(Card::new(Suit::Spades, rank));
+        }
+        assert_eq!(hand.len(), 3);
+
+        assert_eq!(hand.suit_length(Suit::Clubs), 0, "hand holds no clubs");
+        assert_eq!(
+            hand.losers_in_suit(Suit::Clubs),
+            0,
+            "a void has no losers; filler slots must not be counted as cards"
+        );
+        assert_eq!(
+            hand.suit_quality(Suit::Clubs),
+            0,
+            "a suit the hand does not hold has no quality"
+        );
+
+        // AKQ bare is three winners in spades and nothing anywhere else. The
+        // point is that cccc() sees three cards, not three plus ten filler.
+        let filled = hand.cccc();
+        let mut same_hand_via_vec = Hand::from_cards(hand.cards().to_vec());
+        assert_eq!(filled, same_hand_via_vec.cccc());
+        same_hand_via_vec.sort();
+        assert_eq!(
+            filled,
+            same_hand_via_vec.cccc(),
+            "cccc is order-independent"
+        );
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -110,6 +110,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which has nothing to walk through.
 
 ### Changed
+- **Dealing is about 1.6x faster, and generating a deal nearly 3x.** Every deal
+  generated had all four of its hands sorted on the way out, which cost about
+  two thirds of the time to produce one — and was paid on every deal, while a
+  run keeps well under 1% of them. Nothing needed it: the counting functions
+  are sums and filters, the three that care about rank position sort their own
+  copies, every output formatter sorts the suit it is about to print, and the
+  double-dummy memo key is a bitmask. Generation now costs 188ns a deal against
+  534ns, which is parity with the original C dealer built natively for the same
+  machine, where it had been three times slower. `Hand`'s equality no longer
+  depends on card order, since the sort was the only thing making that safe.
+  Measured over a ten-script corpus in `bench/`.
+
 - **`-u` is accepted and ignored rather than refused.** It does nothing in
   dealer.exe either: `case 'u'` sets a flag read only by the `representation`
   macro in `dealer.c`, and that macro is never invoked — every output path calls
@@ -168,6 +180,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   divide by, so its bar means something.
 
 ### Fixed
+- **`losers_in_suit`, `suit_quality` and `cccc` counted a partial hand's empty
+  slots as cards.** They read the raw thirteen-slot array where every other
+  accessor reads the slice bounded by the hand's length, so a hand holding
+  fewer than thirteen cards had its filler counted — and the filler is a club
+  two, which made an empty club suit look like a long weak one. A void reported
+  three losers. Unreachable from a normal run, since the generator only ever
+  hands them complete hands, but reachable through predeal and hands built by
+  hand, and it failed quietly with plausible numbers rather than crashing.
+
 - **An `action` naming only statistics printed deals, and measured 25x fewer of
   them.** Both from one rule dealer3 did not have: an `action` list *replaces*
   the default action, and `printall` is the default, so a list holding only

--- a/scripts/bench-corpus.py
+++ b/scripts/bench-corpus.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""
+bench-corpus.py - Pick and normalize the benchmark scripts.
+
+Builds `bench/corpus/` from the Practice-Bidding-Scenarios `dlr/` directory,
+and writes `bench/corpus.json` describing what got in and why.
+
+Four stages:
+
+  1. **Normalize.** Each candidate is rewritten by benchlib.normalize_script():
+     block comments out, `produce`/`generate` out (they override `-g`), action
+     block replaced with a cheap one. See benchlib for why each is necessary.
+
+  2. **Verify.** Every candidate is run on every available target at a small
+     deal count. A script that any target rejects is dropped, with the reason
+     recorded. This is what makes the corpus honestly three-way: nothing gets
+     in that dealer.exe cannot parse.
+
+  3. **Calibrate.** Each survivor gets a `deals` count sized so dealer3
+     single-threaded takes about --target-seconds. Cheap conditions therefore
+     run more deals than expensive ones, and every script contributes a
+     comparably-sized measurement instead of some finishing in 20ms.
+
+  4. **Select.** Survivors are sorted by cost per deal and sampled evenly
+     across that range, so the corpus spans cheap and expensive conditions
+     rather than clustering on whatever is alphabetically first.
+
+Run this only when the script selection should change. The results it feeds
+(bench-reference.py, bench-dealer3.py) are what get run routinely.
+
+Usage:
+    scripts/bench-corpus.py [-n 12] [--target-seconds 2.0] [--all-targets]
+
+Options:
+    -n N               Scripts to keep (default: 12)
+    --target-seconds S Calibrate so dealer3 -R1 takes about S seconds (default: 2.0)
+    --source DIR       Where to look for .dlr files
+                       (default: ../Practice-Bidding-Scenarios/dlr)
+    --candidates N     How many source scripts to consider (default: all)
+    --all-targets      Verify against dealer.exe and DealerV2_4 too, not just
+                       dealer3. Slower (each check is an SSH round trip), but
+                       it is the only way to know the corpus runs everywhere.
+    --dealerv2 PATH    DealerV2_4 binary
+    -v, --verbose      Report every rejection
+"""
+import argparse
+import difflib
+import json
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import benchlib as bl
+
+# These runs take minutes and are usually backgrounded into a file, where
+# Python would block-buffer and show nothing until the very end.
+sys.stdout.reconfigure(line_buffering=True)
+
+VERIFY_DEALS = 20_000
+CALIBRATE_DEALS = 100_000
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Build the three-way benchmark corpus from PBS scripts.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("-n", "--count", type=int, default=10,
+                    help="scripts to keep (default: 10)")
+    ap.add_argument("--similarity", type=float, default=0.85,
+                    help="body-similarity threshold above which two scripts count "
+                         "as the same benchmark (default: 0.85)")
+    ap.add_argument("--target-seconds", type=float, default=2.0,
+                    help="calibrate so dealer3 -R1 takes about this long (default: 2.0)")
+    ap.add_argument("--source", default=None, help="directory of source .dlr files")
+    ap.add_argument("--candidates", type=int, default=0,
+                    help="limit how many source scripts are considered (default: all)")
+    ap.add_argument("--all-targets", action="store_true",
+                    help="also verify against dealer.exe and DealerV2_4")
+    ap.add_argument("--dealer3", default=None, help="dealer3 binary")
+    ap.add_argument("--dealerv2", default=None, help="DealerV2_4 binary")
+    ap.add_argument("--baseline-only", action="store_true",
+                    help="regenerate just the synthetic generation baseline in the "
+                         "existing corpus, leaving the selection alone")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    dealer3 = bl.dealer3_target(args.dealer3)
+    ok, why = dealer3.available()
+    if not ok:
+        sys.exit(f"error: dealer3 unavailable ({why}) -- run ./dev-build.sh build --release")
+
+    if args.baseline_only:
+        return _refresh_baseline(dealer3, args)
+
+    source = Path(args.source) if args.source else \
+        bl.REPO.parent / "Practice-Bidding-Scenarios" / "dlr"
+    if not source.is_dir():
+        sys.exit(f"error: no source directory at {source}")
+
+    verifiers = [dealer3]
+    if args.all_targets:
+        for t in (bl.dealer_exe_target(), bl.dealerv2_target(args.dealerv2)):
+            ok, why = t.available()
+            if ok:
+                verifiers.append(t)
+            else:
+                print(f"note: skipping {t.name} in verification ({why})")
+
+    sources = sorted(source.glob("*.dlr"))
+    if args.candidates:
+        random.seed(1)
+        sources = sorted(random.sample(sources, min(args.candidates, len(sources))))
+    print(f"Considering {len(sources)} scripts from {source}")
+    print(f"Verifying against: {', '.join(t.name for t in verifiers)}\n")
+
+    staging = bl.REPO / "bench" / ".staging"
+    staging.mkdir(parents=True, exist_ok=True)
+
+    survivors, rejected = [], []
+
+    for src in sources:
+        text = src.read_text(errors="replace")
+
+        if bl.statements_after_action(text):
+            rejected.append((src.name, "statements follow the action block"))
+            continue
+
+        normalized, notes = bl.normalize_script(text)
+        staged = staging / src.name
+        staged.write_text(normalized)
+
+        entry = None
+        failure = None
+        for target in verifiers:
+            try:
+                sample = bl.run_once(target, staged, VERIFY_DEALS, timeout=180)
+            except bl.BenchError as exc:
+                failure = f"{target.name}: {_brief(exc)}"
+                break
+            if target is dealer3:
+                entry = {
+                    "name": src.stem,
+                    "file": src.name,
+                    "source": str(src.relative_to(source.parent.parent))
+                    if source.parent.parent in src.parents else str(src),
+                    "notes": notes,
+                    "imports": bl.imported_fragments(text),
+                    "signature": bl.body_signature(normalized),
+                    "produced_at_verify": sample.produced,
+                    "hit_rate": sample.produced / VERIFY_DEALS,
+                }
+
+        if failure:
+            rejected.append((src.name, failure))
+            if args.verbose:
+                print(f"  reject {src.name}: {failure}")
+            continue
+
+        # A condition nothing satisfies is not a useful benchmark: it also
+        # never exercises the action or the produced-deal path, and it is
+        # usually a sign the script wanted words this corpus stripped.
+        if entry["produced_at_verify"] == 0:
+            rejected.append((src.name, f"no matches in {VERIFY_DEALS} deals"))
+            if args.verbose:
+                print(f"  reject {src.name}: no matches")
+            continue
+
+        survivors.append((entry, staged))
+
+    print(f"\n{len(survivors)} of {len(sources)} scripts run on every target")
+    if rejected:
+        print(f"{len(rejected)} rejected"
+              + ("" if args.verbose else " (use -v to see why)"))
+
+    if not survivors:
+        sys.exit("error: nothing survived verification")
+
+    # --- Calibrate -------------------------------------------------------
+    print(f"\nCalibrating to ~{args.target_seconds}s on dealer3 -R1 ...")
+    for entry, staged in survivors:
+        probe = bl.run_once(dealer3, staged, CALIBRATE_DEALS, threads=1, timeout=300)
+        per_deal = probe.seconds / CALIBRATE_DEALS
+        entry["seconds_per_deal_r1"] = per_deal
+        deals = int(args.target_seconds / per_deal) if per_deal > 0 else 5_000_000
+        entry["deals"] = _round_nicely(deals)
+        if args.verbose:
+            print(f"  {entry['name']:<40} {per_deal*1e9:7.1f} ns/deal"
+                  f"  -> {entry['deals']:>9,} deals")
+
+    # --- Deduplicate, then select ----------------------------------------
+    clusters = _cluster(survivors, args.similarity)
+    collapsed = len(survivors) - len(clusters)
+    print(f"\n{len(clusters)} distinct scripts ({collapsed} near-duplicates collapsed)")
+    chosen = _select_diverse(clusters, args.count)
+
+    if bl.CORPUS_DIR.exists():
+        for old in bl.CORPUS_DIR.glob("*.dlr"):
+            old.unlink()
+    bl.CORPUS_DIR.mkdir(parents=True, exist_ok=True)
+
+    for entry, staged in chosen:
+        (bl.CORPUS_DIR / entry["file"]).write_text(staged.read_text())
+
+    # The generation baseline is synthetic and always present -- it is not
+    # selected from PBS and is not subject to the diversity or duplicate rules,
+    # because it is not there to represent a scenario. It is calibrated the
+    # same way so its deal count is comparable to the rest.
+    baseline_entry, baseline_path = _make_baseline(dealer3, args.target_seconds)
+    chosen.append((baseline_entry, baseline_path))
+    print(f"\nGeneration baseline: {baseline_entry['seconds_per_deal_r1']*1e9:.1f} "
+          f"ns/deal on dealer3 -R1 ({baseline_entry['deals']:,} deals)")
+
+    for staged in staging.glob("*.dlr"):
+        staged.unlink()
+    staging.rmdir()
+
+    index = {
+        "built_with": bl.git_describe(),
+        "source": str(source),
+        "target_seconds": args.target_seconds,
+        "verified_against": [t.name for t in verifiers],
+        "considered": len(sources),
+        "survived": len(survivors),
+        "distinct": len(clusters),
+        "similarity_threshold": args.similarity,
+        "scripts": [e for e, _ in chosen],
+        "rejected": [{"file": f, "reason": r} for f, r in rejected],
+    }
+    bl.CORPUS_INDEX.parent.mkdir(parents=True, exist_ok=True)
+    bl.CORPUS_INDEX.write_text(json.dumps(index, indent=2) + "\n")
+
+    print(f"\nWrote {len(chosen)} scripts to {bl.CORPUS_DIR.relative_to(bl.REPO)}/")
+    print(f"Wrote index to {bl.CORPUS_INDEX.relative_to(bl.REPO)}\n")
+    print(f"{'script':<34} {'ns/deal':>8} {'deals':>10} {'hit':>7} {'==':>4}  imports")
+    print("-" * 100)
+    for entry, _ in chosen:
+        imports = ", ".join(entry["imports"]) or "-"
+        print(f"{entry['name']:<34} {entry['seconds_per_deal_r1']*1e9:8.1f}"
+              f" {entry['deals']:>10,} {entry['hit_rate']:>6.2%}"
+              f" {entry['cluster_size']:>4}  {imports[:44]}")
+    print("\n'==' is how many near-duplicate scripts that row stands for.")
+    if not args.all_targets:
+        print("\nNote: verified against dealer3 only. Re-run with --all-targets to")
+        print("confirm every script also runs on dealer.exe and DealerV2_4.")
+
+
+def _make_baseline(dealer3, target_seconds):
+    """Write the synthetic generation baseline and calibrate it."""
+    path = bl.CORPUS_DIR / f"{bl.BASELINE_NAME}.dlr"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(bl.BASELINE_SCRIPT)
+    probe = bl.run_once(dealer3, path, CALIBRATE_DEALS, threads=1, timeout=300)
+    per_deal = probe.seconds / CALIBRATE_DEALS
+    entry = {
+        "name": bl.BASELINE_NAME,
+        "file": path.name,
+        "source": "synthetic",
+        "synthetic": True,
+        "notes": ["generation baseline: RNG and shuffle, minimal evaluation"],
+        "imports": [],
+        "signature": "",
+        "cluster_size": 1,
+        "cluster_members": [],
+        "produced_at_verify": probe.produced,
+        "hit_rate": probe.produced / CALIBRATE_DEALS,
+        "seconds_per_deal_r1": per_deal,
+        "deals": _round_nicely(int(target_seconds / per_deal) if per_deal else 5_000_000),
+    }
+    return entry, path
+
+
+def _refresh_baseline(dealer3, args):
+    """Update only the baseline in an existing corpus.
+
+    Selecting the corpus means verifying every candidate on every target, which
+    is minutes of SSH round trips, and it is deterministic -- rerunning it after
+    a change that only concerns the synthetic baseline would reproduce exactly
+    the same ten scripts. This path exists so changing the baseline does not
+    cost that.
+    """
+    if not bl.CORPUS_INDEX.exists():
+        sys.exit("error: no corpus to update -- run without --baseline-only first")
+    index = json.loads(bl.CORPUS_INDEX.read_text())
+    target_seconds = index.get("target_seconds", args.target_seconds)
+    entry, _ = _make_baseline(dealer3, target_seconds)
+    index["scripts"] = [e for e in index["scripts"] if e["name"] != bl.BASELINE_NAME]
+    index["scripts"].append(entry)
+    bl.CORPUS_INDEX.write_text(json.dumps(index, indent=2) + "\n")
+    print(f"Generation baseline: {entry['seconds_per_deal_r1']*1e9:.1f} ns/deal "
+          f"on dealer3 -R1 ({entry['deals']:,} deals)")
+    print(f"Updated {bl.CORPUS_INDEX.relative_to(bl.REPO)}; the other "
+          f"{len(index['scripts']) - 1} scripts are unchanged.")
+    return None
+
+
+def _brief(exc):
+    return str(exc).split(": ", 1)[-1][:120]
+
+
+def _round_nicely(n):
+    """Round to two significant figures, so deal counts read as round numbers."""
+    if n < 1000:
+        return max(1000, n)
+    mag = 10 ** (len(str(n)) - 2)
+    return max(1000, (n // mag) * mag)
+
+
+def _cluster(survivors, threshold):
+    """Collapse scripts that are the same benchmark into one entry each.
+
+    The PBS `.dlr` files are generated, and a precompiler expands shared
+    fragments inline -- 155 of the 347 scripts pull in at least one, and 46 of
+    them share the exact same set. On top of that, whole families differ only
+    in a threshold (`Weak_NT_09-12` against `Weak_NT_10-13`). Vendoring ten of
+    those would cost ten files and measure one thing.
+
+    Two passes. Exact signature matches group instantly, which is what most of
+    the redundancy is. The survivors of that are then compared pairwise, and
+    merged when they share an import set *and* their bodies exceed `threshold`.
+    Requiring the import set to match as well means two scripts are never
+    merged just because they both inline the same large shared fragment; what
+    has to be similar is the part that is actually theirs.
+
+    Returns one (entry, path) per cluster, the member of median cost, with
+    `cluster_size` recorded on it.
+    """
+    by_signature = {}
+    for entry, path in survivors:
+        by_signature.setdefault(entry["signature"], []).append((entry, path))
+
+    groups = list(by_signature.values())
+
+    merged = []
+    for group in groups:
+        head = group[0][0]
+        for existing in merged:
+            other = existing[0][0][0]
+            if other["imports"] != head["imports"]:
+                continue
+            ratio = difflib.SequenceMatcher(
+                None, other["signature"], head["signature"]).quick_ratio()
+            if ratio >= threshold and difflib.SequenceMatcher(
+                    None, other["signature"], head["signature"]).ratio() >= threshold:
+                existing.append(group)
+                break
+        else:
+            merged.append([group])
+
+    clusters = []
+    for bundle in merged:
+        members = [m for group in bundle for m in group]
+        members.sort(key=lambda m: m[0]["seconds_per_deal_r1"])
+        entry, path = members[len(members) // 2]          # median cost, deterministic
+        entry = dict(entry, cluster_size=len(members),
+                     cluster_members=sorted(m[0]["name"] for m in members)[:8])
+        clusters.append((entry, path))
+    return clusters
+
+
+def _select_diverse(clusters, count):
+    """Pick `count` clusters spanning both import sets and cost.
+
+    Two axes, because they answer different questions. Different import sets
+    mean genuinely different shared machinery is exercised. Different cost per
+    deal means cheap and expensive conditions are both represented, and a
+    change that only helps one of them cannot hide.
+
+    Round-robin over import sets, taking from each the entry that most extends
+    the cost range covered so far.
+    """
+    if count >= len(clusters):
+        return sorted(clusters, key=lambda c: c[0]["seconds_per_deal_r1"])
+
+    buckets = {}
+    for cluster in clusters:
+        buckets.setdefault(tuple(cluster[0]["imports"]), []).append(cluster)
+    for items in buckets.values():
+        items.sort(key=lambda c: c[0]["seconds_per_deal_r1"])
+
+    # Largest bucket first, so the most-represented shared machinery is not
+    # crowded out by a long tail of one-off import sets.
+    order = sorted(buckets, key=lambda k: (-len(buckets[k]), k))
+    chosen, taken = [], set()
+    while len(chosen) < count:
+        progressed = False
+        for key in order:
+            if len(chosen) >= count:
+                break
+            pool = [c for c in buckets[key] if c[0]["name"] not in taken]
+            if not pool:
+                continue
+            if not chosen:
+                pick = pool[len(pool) // 2]
+            else:
+                have = [c[0]["seconds_per_deal_r1"] for c in chosen]
+                pick = max(pool, key=lambda c: min(
+                    abs(c[0]["seconds_per_deal_r1"] - h) for h in have))
+            chosen.append(pick)
+            taken.add(pick[0]["name"])
+            progressed = True
+        if not progressed:
+            break
+    return sorted(chosen, key=lambda c: c[0]["seconds_per_deal_r1"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench-corpus.py
+++ b/scripts/bench-corpus.py
@@ -209,6 +209,7 @@ def main():
     # same way so its deal count is comparable to the rest.
     baseline_entry, baseline_path = _make_baseline(dealer3, args.target_seconds)
     chosen.append((baseline_entry, baseline_path))
+    chosen.append(_make_solver_entry())
     print(f"\nGeneration baseline: {baseline_entry['seconds_per_deal_r1']*1e9:.1f} "
           f"ns/deal on dealer3 -R1 ({baseline_entry['deals']:,} deals)")
 
@@ -273,6 +274,35 @@ def _make_baseline(dealer3, target_seconds):
     return entry, path
 
 
+def _make_solver_entry():
+    """Write the solver-agreement entry. Verify-only, and not calibrated.
+
+    Nothing to calibrate: it is never timed. Its `deals` is a nominal figure so
+    the shape of a corpus entry stays uniform.
+    """
+    path = bl.CORPUS_DIR / f"{bl.SOLVER_NAME}.dlr"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(bl.SOLVER_SCRIPT)
+    return {
+        "name": bl.SOLVER_NAME,
+        "file": path.name,
+        "source": "synthetic",
+        "synthetic": True,
+        "verify_only": True,
+        "targets": list(bl.SOLVER_TARGETS),
+        "verify_produce": 50,
+        "notes": ["double-dummy agreement between dealer3 and DealerV2_4"],
+        "imports": [],
+        "signature": "",
+        "cluster_size": 1,
+        "cluster_members": [],
+        "produced_at_verify": 0,
+        "hit_rate": 0.0,
+        "seconds_per_deal_r1": 0.0,
+        "deals": 100_000,
+    }, path
+
+
 def _refresh_baseline(dealer3, args):
     """Update only the baseline in an existing corpus.
 
@@ -287,8 +317,10 @@ def _refresh_baseline(dealer3, args):
     index = json.loads(bl.CORPUS_INDEX.read_text())
     target_seconds = index.get("target_seconds", args.target_seconds)
     entry, _ = _make_baseline(dealer3, target_seconds)
-    index["scripts"] = [e for e in index["scripts"] if e["name"] != bl.BASELINE_NAME]
-    index["scripts"].append(entry)
+    solver, _ = _make_solver_entry()
+    index["scripts"] = [e for e in index["scripts"]
+                        if e["name"] not in (bl.BASELINE_NAME, bl.SOLVER_NAME)]
+    index["scripts"].extend([entry, solver])
     index["corpus_id"] = bl.corpus_fingerprint(index["scripts"])
     bl.CORPUS_INDEX.write_text(json.dumps(index, indent=2) + "\n")
     print(f"Generation baseline: {entry['seconds_per_deal_r1']*1e9:.1f} ns/deal "

--- a/scripts/bench-corpus.py
+++ b/scripts/bench-corpus.py
@@ -80,6 +80,9 @@ def main():
                     help="also verify against dealer.exe and DealerV2_4")
     ap.add_argument("--dealer3", default=None, help="dealer3 binary")
     ap.add_argument("--dealerv2", default=None, help="DealerV2_4 binary")
+    ap.add_argument("--recalibrate", action="store_true",
+                    help="with --baseline-only, re-time the generation baseline "
+                         "instead of reusing its deal count")
     ap.add_argument("--baseline-only", action="store_true",
                     help="regenerate just the synthetic generation baseline in the "
                          "existing corpus, leaving the selection alone")
@@ -290,6 +293,16 @@ def _make_solver_entry():
         "synthetic": True,
         "verify_only": True,
         "targets": list(bl.SOLVER_TARGETS),
+        # DealerV2_4 must be put in table mode explicitly. `par` needs all
+        # twenty results, and V2_4 knows it -- it prints "Using Parscore
+        # requires TableMode. Setting Mode and continuing.." and switches. But
+        # the switch happens after DDS has been given its resources for board
+        # mode, and the library then dies with "Memory::GetPtr: 0 vs. 0" and
+        # exit 1. Passing -M 2 up front avoids the switch entirely.
+        #
+        # It is also the mode that makes the comparison fair: dealer3 fills the
+        # whole table, so -M 1 would have the two solving different amounts.
+        "target_args": {"dealerv2_4": ["-M", "2"]},
         "verify_produce": 50,
         "notes": ["double-dummy agreement between dealer3 and DealerV2_4"],
         "imports": [],
@@ -316,17 +329,30 @@ def _refresh_baseline(dealer3, args):
         sys.exit("error: no corpus to update -- run without --baseline-only first")
     index = json.loads(bl.CORPUS_INDEX.read_text())
     target_seconds = index.get("target_seconds", args.target_seconds)
-    entry, _ = _make_baseline(dealer3, target_seconds)
+    previous = next((e for e in index["scripts"] if e["name"] == bl.BASELINE_NAME), None)
+    if previous and not args.recalibrate:
+        # Reuse the deal count rather than re-timing it. Calibration jitter
+        # would otherwise change the baseline's workload, and with it
+        # corpus_id, every time this is run -- invalidating reference numbers
+        # for no reason. --recalibrate asks for a fresh one deliberately.
+        entry = dict(previous)
+        bl.CORPUS_DIR.mkdir(parents=True, exist_ok=True)
+        (bl.CORPUS_DIR / entry["file"]).write_text(bl.BASELINE_SCRIPT)
+        print(f"Generation baseline: reusing {entry['deals']:,} deals "
+              "(--recalibrate to re-time it)")
+    else:
+        entry, _ = _make_baseline(dealer3, target_seconds)
+        print(f"Generation baseline: {entry['seconds_per_deal_r1']*1e9:.1f} ns/deal "
+              f"on dealer3 -R1 ({entry['deals']:,} deals)")
     solver, _ = _make_solver_entry()
     index["scripts"] = [e for e in index["scripts"]
                         if e["name"] not in (bl.BASELINE_NAME, bl.SOLVER_NAME)]
     index["scripts"].extend([entry, solver])
     index["corpus_id"] = bl.corpus_fingerprint(index["scripts"])
     bl.CORPUS_INDEX.write_text(json.dumps(index, indent=2) + "\n")
-    print(f"Generation baseline: {entry['seconds_per_deal_r1']*1e9:.1f} ns/deal "
-          f"on dealer3 -R1 ({entry['deals']:,} deals)")
+    print(f"corpus_id: {index['corpus_id']}")
     print(f"Updated {bl.CORPUS_INDEX.relative_to(bl.REPO)}; the other "
-          f"{len(index['scripts']) - 1} scripts are unchanged.")
+          f"{len(index['scripts']) - 2} scripts are unchanged.")
     return None
 
 

--- a/scripts/bench-corpus.py
+++ b/scripts/bench-corpus.py
@@ -218,6 +218,7 @@ def main():
 
     index = {
         "built_with": bl.git_describe(),
+        "corpus_id": None,          # filled in below, once the files are written
         "source": str(source),
         "target_seconds": args.target_seconds,
         "verified_against": [t.name for t in verifiers],
@@ -228,6 +229,7 @@ def main():
         "scripts": [e for e, _ in chosen],
         "rejected": [{"file": f, "reason": r} for f, r in rejected],
     }
+    index["corpus_id"] = bl.corpus_fingerprint(index["scripts"])
     bl.CORPUS_INDEX.parent.mkdir(parents=True, exist_ok=True)
     bl.CORPUS_INDEX.write_text(json.dumps(index, indent=2) + "\n")
 
@@ -287,6 +289,7 @@ def _refresh_baseline(dealer3, args):
     entry, _ = _make_baseline(dealer3, target_seconds)
     index["scripts"] = [e for e in index["scripts"] if e["name"] != bl.BASELINE_NAME]
     index["scripts"].append(entry)
+    index["corpus_id"] = bl.corpus_fingerprint(index["scripts"])
     bl.CORPUS_INDEX.write_text(json.dumps(index, indent=2) + "\n")
     print(f"Generation baseline: {entry['seconds_per_deal_r1']*1e9:.1f} ns/deal "
           f"on dealer3 -R1 ({entry['deals']:,} deals)")

--- a/scripts/bench-dds.py
+++ b/scripts/bench-dds.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+bench-dds.py - Compare dealer3 and DealerV2_4 on double-dummy throughput.
+
+Separate from bench-reference.py because a solver run is a different
+measurement. There, work is fixed with -g and the answer is deals evaluated per
+second. Here nearly all the time goes into solving the small fraction of deals
+that pass the filter, and the answer wanted is *cost per solved deal*.
+
+dealer.exe and dealer-c have no solver and are not involved.
+
+How it isolates the solver
+--------------------------
+
+Each program runs the same condition twice: once with a double-dummy action,
+once with a cheap one. The difference is the solving, and everything else --
+acquiring the deals, evaluating the filter, the run's fixed overhead --
+cancels, because it is the same program doing the same work in both runs.
+
+That matters most for dealer3, which does not acquire its deals the way
+DealerV2_4 does. There is no way to hand both the same boards directly: V2_4
+reads its own binary .zrd libraries and dealer3 reads PBN. So V2_4 filters its
+own shuffle and writes the deals it matched, and dealer3 solves exactly those.
+dealer3's PBN ingestion costs 3255ns a deal against a shuffle's 269, and V2_4
+additionally filters thousands of deals dealer3 never sees -- subtracting each
+program's own no-solver run removes all of that, rather than hoping it is
+small.
+
+Both programs therefore solve the same cards, which also makes this a
+correctness check: the statistics must agree, or the throughput comparison is
+comparing different answers.
+
+Why the deals are captured with the condition already applied
+-------------------------------------------------------------
+
+The obvious arrangement -- have V2_4 write every deal it generates, then let
+dealer3 filter the same file -- does not work. **DealerV2_4's generated
+sequence depends on the condition in the script.** Measured directly: with an
+always-true condition its produced deals are exactly the unfiltered sequence,
+while `hcp(north) >= 20`, `shape(north, any 4333)` and `hascard(east, 2C)` each
+produce deals that appear nowhere in the unfiltered run of the same seed -- not
+under any seat rotation, and not merely renumbered. Two runs that differ only
+in their condition are looking at different cards, whatever seed they were
+given.
+
+The action does not have this effect: the same condition with `printpbn`,
+with an `average`, and with a `dds` average all produce identical deals. So the
+capture run uses the timed condition and differs only in its action, which is
+sound, while a capture run with no condition would not be.
+
+The mechanism was not chased down; the fact was established and designed
+around.
+
+Why DealerV2_4 gets -M 2, and why it cannot be single-threaded
+--------------------------------------------------------------
+
+`par` needs all twenty double-dummy results. dealer3 fills the whole table, so
+V2_4 must be in table mode (-M 2) or the two are solving different amounts of
+work. V2_4 detects this itself and switches -- and then dies inside DDS with
+"Memory::GetPtr: 0 vs. 0", because the switch happens after the library has
+been given board-mode resources. Passing -M 2 up front avoids both problems.
+
+Table mode will not run single-threaded: setup_dds_mode() overrides nThreads
+to TblModeThreads whenever dds_mode is 2 and nThreads is below 2. So --threads
+is clamped to at least 2 and the figure is a threaded one for both programs.
+A single-threaded double-dummy comparison is not available from V2_4.
+
+Usage:
+    scripts/bench-dds.py [-g 20000] [-s 1] [-r 3] [--threads 4]
+
+Options:
+    -g, --generate N   Deals each program processes (default: 20000)
+    -s, --seed SEED    Seed for DealerV2_4's shuffle (default: 1)
+    -r, --repeats N    Runs per measurement, fastest wins (default: 3)
+    --threads T        Worker/DDS threads for both, minimum 2 (default: 4)
+    --condition EXPR   Override the filter; aim for a few percent acceptance
+    --dealerv2 PATH    DealerV2_4 binary (else $DEALERV2_BIN, else PATH)
+    --keep             Leave the generated scripts and PBN in place
+"""
+import argparse
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import benchlib as bl
+
+sys.stdout.reconfigure(line_buffering=True)
+
+# About 2.9% of deals, measured. Low enough that solving dominates without the
+# run taking all day, high enough to reach a few hundred solves quickly.
+# `hascard` takes rank then suit, so the club two is `2C`.
+DEFAULT_CONDITION = "hascard(east, 2C) and hcp(north) >= 12 and hcp(south) >= 11"
+
+# Every token has to parse in both languages. DealerV2_4's lexer is
+# case-sensitive and inconsistent about it -- compasses lowercase, sides
+# uppercase -- so `par(NS)` with `dds(north, ...)` is the spelling that runs on
+# both unchanged. par is the strongest thing to ask for: it is derived from all
+# twenty results, so agreement means the whole table agrees.
+DD_ACTION = ('action average "dds N NT" dds(north, notrump), '
+             'average "dds S spades" dds(south, spades), '
+             'average "par NS" par(NS)')
+CHEAP_ACTION = 'action average "hcp N" hcp(north)'
+
+PBN_DEAL_RE = re.compile(r'^\[Deal\s+"', re.MULTILINE)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Compare dealer3 and DealerV2_4 on "
+                                             "double-dummy throughput.")
+    ap.add_argument("-g", "--generate", type=int, default=20000)
+    ap.add_argument("-s", "--seed", type=int, default=1)
+    ap.add_argument("-r", "--repeats", type=int, default=3)
+    ap.add_argument("--threads", type=int, default=4)
+    ap.add_argument("--condition", default=DEFAULT_CONDITION)
+    ap.add_argument("--dealerv2", default=None)
+    ap.add_argument("--keep", action="store_true")
+    args = ap.parse_args()
+
+    threads = max(2, args.threads)
+    if threads != args.threads:
+        print(f"note: --threads raised to {threads}; DealerV2_4's table mode "
+              "overrides anything below 2\n")
+
+    dealer3 = bl.dealer3_target()
+    v2 = bl.dealerv2_target(args.dealerv2)
+    for t in (dealer3, v2):
+        ok, why = t.available()
+        if not ok:
+            sys.exit(f"error: {t.name} unavailable ({why})")
+
+    work = bl.REPO / "bench" / ".dds"
+    work.mkdir(parents=True, exist_ok=True)
+
+    dd = work / "dd.dlr"
+    nodd = work / "nodd.dlr"
+    emit = work / "emit.dlr"
+    pbn = work / "deals.pbn"
+    header = f"# Generated by scripts/bench-dds.py\ncondition {args.condition}\n"
+    dd.write_text(header + DD_ACTION + "\n")
+    nodd.write_text(header + CHEAP_ACTION + "\n")
+    # Same condition as the timed runs -- see the module docstring on why an
+    # unfiltered capture would be looking at different cards.
+    emit.write_text(header + "action printpbn\n")
+
+    print(f"condition : {args.condition}")
+    print(f"deals     : {args.generate:,}   seed {args.seed}   "
+          f"threads {threads}   best of {args.repeats}\n")
+
+    # DealerV2_4 shuffles; dealer3 has no way to read its libraries, so the
+    # boards are handed over as PBN. Untimed: this run only exists to produce
+    # the file, and it prints every deal, which the timed runs do not.
+    print(f"Capturing the deals DealerV2_4 matches in {args.generate:,} "
+          f"(seed {args.seed}) ...")
+    out = subprocess.run(
+        v2.command + ["-g", str(args.generate), "-p", str(bl.NO_PRODUCE_LIMIT),
+                      "-s", str(args.seed), str(emit)],
+        capture_output=True, text=True, timeout=1800)
+    n_written = len(PBN_DEAL_RE.findall(out.stdout))
+    if n_written == 0:
+        sys.exit("error: the condition matched nothing -- loosen it or raise -g")
+    pbn.write_text(out.stdout)
+    print(f"    {n_written:,} matched ({n_written/args.generate:.1%}), "
+          f"{pbn.stat().st_size/1e6:.1f} MB\n")
+
+    results = {}
+    for name, argv_for in (
+        ("dealerv2_4", lambda script: v2.command + ["-M", "2", "-R", str(threads),
+                                                    "-g", str(args.generate),
+                                                    "-p", str(bl.NO_PRODUCE_LIMIT),
+                                                    "-s", str(args.seed), str(script)]),
+        # dealer3 is handed the deals V2_4 already matched, so it re-applies the
+        # same condition to deals that all satisfy it. Anything it rejects is a
+        # semantic disagreement, and _verdict says so.
+        ("dealer3", lambda script: dealer3.command + ["-v", "-R", str(threads),
+                                                      "-p", str(bl.NO_PRODUCE_LIMIT),
+                                                      "--input-deals", str(pbn),
+                                                      str(script)]),
+    ):
+        print(f"{name}")
+        with_dd = _timed(argv_for(dd), args.repeats, name, "with solver")
+        without = _timed(argv_for(nodd), args.repeats, name, "no solver")
+        solved = with_dd["produced"]
+        if solved != without["produced"]:
+            sys.exit(f"error: {name} produced {solved} deals with the solver and "
+                     f"{without['produced']} without -- the condition is not stable")
+        dd_seconds = with_dd["seconds"] - without["seconds"]
+        results[name] = {
+            "with": with_dd, "without": without, "solved": solved,
+            "dd_seconds": dd_seconds,
+            "ns_per_solve": dd_seconds / solved * 1e9 if solved else float("nan"),
+        }
+        print(f"    with solver  {with_dd['seconds']:8.3f}s")
+        print(f"    no solver    {without['seconds']:8.3f}s")
+        print(f"    solving      {dd_seconds:8.3f}s over {solved:,} deals"
+              f"  ->  {results[name]['ns_per_solve']/1e6:.2f} ms per solved deal\n")
+
+    _verdict(results, args, threads)
+
+    if not args.keep:
+        for f in (dd, nodd, emit, pbn):
+            f.unlink(missing_ok=True)
+        try:
+            work.rmdir()
+        except OSError:
+            pass
+
+
+def _timed(argv, repeats, name, label):
+    """Best of `repeats`, returning self-reported seconds and the produced count."""
+    best, produced, stats = None, None, None
+    for _ in range(repeats):
+        started = time.monotonic()
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=7200)
+        wall = time.monotonic() - started
+        if proc.returncode != 0:
+            sys.exit(f"error: {name} ({label}) exit {proc.returncode}: "
+                     f"{bl._first_real_line(proc.stdout + proc.stderr)}")
+        text = proc.stdout + proc.stderr
+        m = bl.TIME_RE.search(text)
+        # DealerV2_4 reports honestly; if a program ever does not, wall time is
+        # the fallback. Both runs of a pair use the same clock, so the
+        # subtraction stays valid either way.
+        seconds = float(m.group(1)) if m and float(m.group(1)) > 0 else wall
+        p = bl.PRODUCED_RE.search(text)
+        produced = int(p.group(1)) if p else 0
+        if best is None or seconds < best:
+            best, stats = seconds, _statistics(text)
+    return {"seconds": best, "produced": produced, "stats": stats}
+
+
+def _statistics(text):
+    """The `average` lines, by label and value, tolerating each program's format.
+
+    DealerV2_4 writes `label: Mean=   10.6600, Std Dev= ...` where dealer3
+    writes `label: 10.66`. Same answer, different spelling.
+    """
+    out = {}
+    for line in text.splitlines():
+        m = re.match(r"^([^:]*?):\s*(?:Mean=\s*)?(-?\d+(?:\.\d+)?)", line.strip())
+        if m and "Time needed" not in line:
+            out[m.group(1).strip()] = float(m.group(2))
+    return out
+
+
+def _verdict(results, args, threads):
+    a, b = results["dealerv2_4"], results["dealer3"]
+
+    print("=" * 64)
+    if a["solved"] != b["solved"]:
+        print(f"WARNING: DealerV2_4 solved {a['solved']:,} deals and dealer3 "
+              f"{b['solved']:,}.")
+        print("dealer3 was handed the very deals DealerV2_4 matched, so it should")
+        print("accept every one. A shortfall is a real disagreement about what the")
+        print("condition means. The figures below are not comparing the same work.")
+    else:
+        print(f"Both solved the same {a['solved']:,} deals "
+              f"({a['solved']/args.generate:.1%} of {args.generate:,} generated).")
+
+    shared = set(a["with"]["stats"]) & set(b["with"]["stats"])
+    disagree = [k for k in sorted(shared)
+                if round(a["with"]["stats"][k], 2) != round(b["with"]["stats"][k], 2)]
+    if disagree:
+        print("\nWARNING: the two disagree on double-dummy results over identical")
+        print("cards, so this is not a like-for-like comparison:")
+        for k in disagree:
+            print(f"  {k}: DealerV2_4 {a['with']['stats'][k]}, "
+                  f"dealer3 {b['with']['stats'][k]}")
+    elif shared:
+        print(f"Statistics agree on all {len(shared)} measures, so both solved the "
+              "same cards to the same answers.")
+
+    print()
+    print(f"{'':<12} {'solving':>10} {'per solve':>12} {'solves/sec':>12}")
+    print("-" * 64)
+    for name, r in (("DealerV2_4", a), ("dealer3", b)):
+        rate = r["solved"] / r["dd_seconds"] if r["dd_seconds"] > 0 else float("nan")
+        print(f"{name:<12} {r['dd_seconds']:>9.3f}s {r['ns_per_solve']/1e6:>11.2f}ms"
+              f" {rate:>12.1f}")
+    print("-" * 64)
+    if a["ns_per_solve"] > 0 and b["ns_per_solve"] > 0:
+        ratio = a["ns_per_solve"] / b["ns_per_solve"]
+        verdict = (f"{ratio:.2f}x faster" if ratio >= 1 else f"{1/ratio:.2f}x slower")
+        print(f"dealer3's solver is {verdict} than DealerV2_4's, at {threads} threads.")
+    print("\nSolving time is the with-solver run minus the no-solver run, per")
+    print("program, so deal acquisition and filtering cancel out. Both are")
+    print("threaded: DealerV2_4's table mode will not run below two threads.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench-dds.py
+++ b/scripts/bench-dds.py
@@ -79,6 +79,7 @@ Options:
 """
 import argparse
 import re
+import resource
 import subprocess
 import sys
 import time
@@ -167,17 +168,15 @@ def main():
 
     results = {}
     for name, argv_for in (
-        ("dealerv2_4", lambda script: v2.command + ["-M", "2", "-R", str(threads),
-                                                    "-g", str(args.generate),
-                                                    "-p", str(bl.NO_PRODUCE_LIMIT),
-                                                    "-s", str(args.seed), str(script)]),
+        ("dealerv2_4", lambda script, t=None: v2.command
+            + ["-M", "2", "-R", str(t or threads), "-g", str(args.generate),
+               "-p", str(bl.NO_PRODUCE_LIMIT), "-s", str(args.seed), str(script)]),
         # dealer3 is handed the deals V2_4 already matched, so it re-applies the
         # same condition to deals that all satisfy it. Anything it rejects is a
         # semantic disagreement, and _verdict says so.
-        ("dealer3", lambda script: dealer3.command + ["-v", "-R", str(threads),
-                                                      "-p", str(bl.NO_PRODUCE_LIMIT),
-                                                      "--input-deals", str(pbn),
-                                                      str(script)]),
+        ("dealer3", lambda script, t=None: dealer3.command
+            + ["-v", "-R", str(t or threads), "-p", str(bl.NO_PRODUCE_LIMIT),
+               "--input-deals", str(pbn), str(script)]),
     ):
         print(f"{name}")
         with_dd = _timed(argv_for(dd), args.repeats, name, "with solver")
@@ -187,15 +186,23 @@ def main():
             sys.exit(f"error: {name} produced {solved} deals with the solver and "
                      f"{without['produced']} without -- the condition is not stable")
         dd_seconds = with_dd["seconds"] - without["seconds"]
+        dd_cpu = with_dd["cpu"] - without["cpu"]
         results[name] = {
             "with": with_dd, "without": without, "solved": solved,
-            "dd_seconds": dd_seconds,
+            "dd_seconds": dd_seconds, "dd_cpu": dd_cpu,
+            "parallelism": dd_cpu / dd_seconds if dd_seconds > 0 else float("nan"),
             "ns_per_solve": dd_seconds / solved * 1e9 if solved else float("nan"),
+            "cpu_per_solve": dd_cpu / solved * 1e9 if solved else float("nan"),
         }
         print(f"    with solver  {with_dd['seconds']:8.3f}s")
         print(f"    no solver    {without['seconds']:8.3f}s")
         print(f"    solving      {dd_seconds:8.3f}s over {solved:,} deals"
-              f"  ->  {results[name]['ns_per_solve']/1e6:.2f} ms per solved deal\n")
+              f"  ->  {results[name]['ns_per_solve']/1e6:.2f} ms per solved deal")
+        par = results[name]["parallelism"]
+        note = "single-threaded" if par < 1.2 else f"{par:.1f} cores busy"
+        print(f"    cpu          {dd_cpu:8.3f}s"
+              f"  ->  {results[name]['cpu_per_solve']/1e6:.1f} ms cpu per solve"
+              f"  ({note})\n")
 
     _verdict(results, args, threads)
 
@@ -209,12 +216,23 @@ def main():
 
 
 def _timed(argv, repeats, name, label):
-    """Best of `repeats`, returning self-reported seconds and the produced count."""
-    best, produced, stats = None, None, None
+    """Best of `repeats`: wall seconds, CPU seconds, and the produced count.
+
+    CPU comes from getrusage(RUSAGE_CHILDREN), differenced across the call.
+    Measuring it is the whole point: a thread count on the command line says
+    what was *asked for*, not what was used, and the two programs disagree about
+    what the switch even means. CPU divided by wall says how many cores actually
+    worked, and needs no assumption at all.
+    """
+    best, produced, stats, best_cpu = None, None, None, None
     for _ in range(repeats):
+        before = resource.getrusage(resource.RUSAGE_CHILDREN)
         started = time.monotonic()
         proc = subprocess.run(argv, capture_output=True, text=True, timeout=7200)
         wall = time.monotonic() - started
+        after = resource.getrusage(resource.RUSAGE_CHILDREN)
+        cpu = ((after.ru_utime - before.ru_utime)
+               + (after.ru_stime - before.ru_stime))
         if proc.returncode != 0:
             sys.exit(f"error: {name} ({label}) exit {proc.returncode}: "
                      f"{bl._first_real_line(proc.stdout + proc.stderr)}")
@@ -227,8 +245,8 @@ def _timed(argv, repeats, name, label):
         p = bl.PRODUCED_RE.search(text)
         produced = int(p.group(1)) if p else 0
         if best is None or seconds < best:
-            best, stats = seconds, _statistics(text)
-    return {"seconds": best, "produced": produced, "stats": stats}
+            best, stats, best_cpu = seconds, _statistics(text), cpu
+    return {"seconds": best, "cpu": best_cpu, "produced": produced, "stats": stats}
 
 
 def _statistics(text):
@@ -243,6 +261,19 @@ def _statistics(text):
         if m and "Time needed" not in line:
             out[m.group(1).strip()] = float(m.group(2))
     return out
+
+
+def _x(dealer3, other):
+    """dealer3's cost against another program's, in words.
+
+    Takes the two costs rather than a ratio, because a bare ratio invites
+    getting the direction backwards -- which is exactly what happened here
+    once. Costs, so larger is worse.
+    """
+    if other <= 0:
+        return "not comparable"
+    ratio = dealer3 / other
+    return f"{ratio:.2f}x slower" if ratio >= 1 else f"{1/ratio:.2f}x faster"
 
 
 def _verdict(results, args, threads):
@@ -273,20 +304,49 @@ def _verdict(results, args, threads):
               "same cards to the same answers.")
 
     print()
-    print(f"{'':<12} {'solving':>10} {'per solve':>12} {'solves/sec':>12}")
-    print("-" * 64)
+    print(f"{'':<12} {'wall/solve':>11} {'cpu/solve':>11} {'cores busy':>11}"
+          f" {'solves/s':>9}")
+    print("-" * 68)
     for name, r in (("DealerV2_4", a), ("dealer3", b)):
         rate = r["solved"] / r["dd_seconds"] if r["dd_seconds"] > 0 else float("nan")
-        print(f"{name:<12} {r['dd_seconds']:>9.3f}s {r['ns_per_solve']/1e6:>11.2f}ms"
-              f" {rate:>12.1f}")
-    print("-" * 64)
+        print(f"{name:<12} {r['ns_per_solve']/1e6:>10.1f}ms"
+              f" {r['cpu_per_solve']/1e6:>10.1f}ms {r['parallelism']:>10.1f}x"
+              f" {rate:>9.1f}")
+    print("-" * 68)
+
+    # Cores busy is CPU divided by wall, measured rather than asked for. It is
+    # the only honest way to compare here: --threads is passed to both, but
+    # DealerV2_4 hands it to DDS while dealer3's -R threads deal generation,
+    # which a solver-bound run barely does. And DealerV2_4 cannot be made
+    # single-threaded in table mode at all -- setup_dds_mode() overrides
+    # anything below 2 up to TblModeThreads, which is 9 -- so asking it for one
+    # thread and believing the answer is how the first version of this script
+    # got the comparison wrong.
+    solo = [n for n, r in (("DealerV2_4", a), ("dealer3", b))
+            if r["parallelism"] < 1.2]
+    if solo and len(solo) < 2:
+        print(f"{' and '.join(solo)} solved single-threaded while the other did not.")
+        print("Read cpu/solve for the solvers themselves and wall/solve for what a")
+        print("user waits; the difference between the two columns is parallelism,")
+        print("not solver quality.")
+        print()
+
     if a["ns_per_solve"] > 0 and b["ns_per_solve"] > 0:
-        ratio = a["ns_per_solve"] / b["ns_per_solve"]
-        verdict = (f"{ratio:.2f}x faster" if ratio >= 1 else f"{1/ratio:.2f}x slower")
-        print(f"dealer3's solver is {verdict} than DealerV2_4's, at {threads} threads.")
+        print(f"Wall clock:  dealer3 is "
+              f"{_x(b['ns_per_solve'], a['ns_per_solve'])} than DealerV2_4.")
+        print(f"Per core:    dealer3 is "
+              f"{_x(b['cpu_per_solve'], a['cpu_per_solve'])} than DealerV2_4.")
+        wall = b["ns_per_solve"] / a["ns_per_solve"]
+        cpu = b["cpu_per_solve"] / a["cpu_per_solve"] if a["cpu_per_solve"] else 0
+        if wall > 1 and cpu > 0:
+            print(f"\nOf the {wall:.2f}x wall-clock gap, about {wall/cpu:.2f}x is "
+                  f"parallelism DealerV2_4\nuses and dealer3 does not, and about "
+                  f"{cpu:.2f}x is the cost of one solve on one core.")
+            print("Those multiply rather than add.")
+
     print("\nSolving time is the with-solver run minus the no-solver run, per")
-    print("program, so deal acquisition and filtering cancel out. Both are")
-    print("threaded: DealerV2_4's table mode will not run below two threads.")
+    print("program, so deal acquisition and filtering cancel out. DealerV2_4's")
+    print("table mode will not run below two threads, so --threads is at least 2.")
 
 
 if __name__ == "__main__":

--- a/scripts/bench-dealer3.py
+++ b/scripts/bench-dealer3.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+bench-dealer3.py - Measure dealer3 over the benchmark corpus.
+
+This is the one to run whenever dealer3 changes substantively. It records
+three things:
+
+  - **Single-threaded** (`-R 1`), the number that compares like-for-like
+    against dealer.exe and DealerV2_4, which have no threading.
+  - **Auto** (`-R 0`), what a user actually gets by default.
+  - **A thread sweep**, one run per worker count, which is what turns "our
+    multithreading peaks somewhere around 4-5" into a curve with a number on it.
+
+The sweep is the diagnostic. For each script it reports speedup against the
+single-threaded time and marks where the curve turns over. A curve that
+*plateaus* past the physical core count is ordinary saturation; one that
+*regresses* -- gets slower with more workers -- is contention, and that is a
+bug rather than a limit. The two look identical if you only ever measure at one
+workload size, so --scale exists to check the shape holds:
+
+    scripts/bench-dealer3.py --sweep-only --scale 0.2     # short runs
+    scripts/bench-dealer3.py --sweep-only --scale 4       # long runs
+
+If the turnover moves when the workload does, the cost is per-run (thread
+startup, the final merge) rather than per-deal. If it stays put, it is
+contention in the generate loop.
+
+--batch-sizes adds a second dimension, since the work-unit size is the obvious
+suspect for a shared-state bottleneck.
+
+Usage:
+    scripts/bench-dealer3.py [-r 3] [--sweep-only | --no-sweep]
+
+Options:
+    -r, --repeats N     Runs per measurement, fastest wins (default: 3)
+    --threads LIST      Sweep these worker counts (default: derived from CPU count)
+    --batch-sizes LIST  Also sweep --batch-size at each thread count
+    --scale F           Multiply every script's calibrated deal count by F
+    --scripts NAMES     Comma-separated subset of the corpus
+    -1, --quick         One representative script only. For iterating on a
+                        performance change, where the whole corpus is too slow
+                        a loop and the absolute number matters less than
+                        whether it moved.
+    --sweep-only        Only the thread sweep
+    --no-sweep          Skip the thread sweep
+    --binary PATH       dealer3 binary (default: target/release/dealer)
+    -o, --output PATH   Where to write results (default: bench/results/dealer3-<rev>.json)
+"""
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import benchlib as bl
+
+# These runs take minutes and are usually backgrounded into a file, where
+# Python would block-buffer and show nothing until the very end.
+sys.stdout.reconfigure(line_buffering=True)
+
+
+def default_thread_list():
+    """1..physical cores in steps of 1, then coarser out to every logical CPU.
+
+    The interesting region is at and just past the physical core count, so it
+    is sampled densely; beyond that the question is only whether the curve
+    keeps falling, which needs fewer points.
+    """
+    try:
+        ncpu = int(subprocess.run(["sysctl", "-n", "hw.ncpu"], capture_output=True,
+                                  text=True, timeout=5).stdout.strip())
+    except (OSError, ValueError, subprocess.SubprocessError):
+        ncpu = 8
+    try:
+        perf = int(subprocess.run(["sysctl", "-n", "hw.perflevel0.logicalcpu"],
+                                  capture_output=True, text=True, timeout=5).stdout.strip())
+    except (OSError, ValueError, subprocess.SubprocessError):
+        perf = ncpu
+    dense = list(range(1, min(perf, ncpu) + 1))
+    coarse = [n for n in range(perf + 2, ncpu + 1, 2)]
+    return sorted(set(dense + coarse + [ncpu]))
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Benchmark dealer3 over the corpus.")
+    ap.add_argument("-r", "--repeats", type=int, default=3)
+    ap.add_argument("--threads", default=None, help="comma-separated worker counts")
+    ap.add_argument("--batch-sizes", default=None, help="comma-separated --batch-size values")
+    ap.add_argument("--scale", type=float, default=1.0)
+    ap.add_argument("--min-sweep-seconds", type=float, default=0.75,
+                    help="scale the sweep up until the fastest thread count runs "
+                         "at least this long (default: 0.75; 0 disables)")
+    ap.add_argument("--scripts", default=None, help="comma-separated corpus subset")
+    ap.add_argument("-1", "--quick", action="store_true",
+                    help="one representative script only, for iterating on a change")
+    ap.add_argument("--sweep-only", action="store_true")
+    ap.add_argument("--no-sweep", action="store_true")
+    ap.add_argument("--binary", default=None)
+    ap.add_argument("-o", "--output", default=None)
+    args = ap.parse_args()
+
+    target = bl.dealer3_target(args.binary)
+    ok, why = target.available()
+    if not ok:
+        sys.exit(f"error: {why} -- run ./dev-build.sh build --release")
+
+    corpus = bl.load_corpus()
+    if args.scripts:
+        wanted = {s.strip() for s in args.scripts.split(",")}
+        corpus = [e for e in corpus if e["name"] in wanted]
+        if not corpus:
+            sys.exit("error: no corpus scripts matched --scripts")
+    elif args.quick:
+        corpus = [bl.representative(corpus)]
+        print(f"--quick: {corpus[0]['name']} only\n")
+
+    threads = ([int(t) for t in args.threads.split(",")] if args.threads
+               else default_thread_list())
+    batch_sizes = [int(b) for b in args.batch_sizes.split(",")] if args.batch_sizes else [None]
+
+    rev = bl.git_describe()
+    machine = bl.machine_info()
+    print(f"dealer3 {rev} on {machine.get('cpu') or machine.get('model') or 'unknown'} "
+          f"({machine.get('logical_cpus', '?')} logical, "
+          f"{machine.get('performance_cpus', '?')}P + {machine.get('efficiency_cpus', '?')}E)")
+    print(f"{len(corpus)} scripts, {args.repeats} repeats, fastest run wins\n")
+
+    results = {"tool": "bench-dealer3", "revision": rev, "repeats": args.repeats,
+               "scale": args.scale, "scripts": {}}
+
+    for entry in corpus:
+        deals = max(1000, int(entry["deals"] * args.scale))
+        name = entry["name"]
+        record = {"deals": deals, "hit_rate": entry.get("hit_rate")}
+        print(f"{name}  ({deals:,} deals)")
+
+        if not args.sweep_only:
+            for label, nthreads in (("single", 1), ("auto", 0)):
+                try:
+                    r = bl.run_repeated(target, entry["path"], deals,
+                                        threads=nthreads, repeats=args.repeats)
+                except bl.BenchError as exc:
+                    print(f"    {label:<8} FAILED: {exc}")
+                    continue
+                record[label] = r
+                print(f"    {label:<8} {r['seconds_best']:7.3f}s"
+                      f"  {r['deals_per_sec']/1e6:6.2f} M deals/s"
+                      f"  (spread {r['spread_pct']:.1f}%)")
+                _warn_spread(label, r)
+
+        if not args.no_sweep:
+            sweep_deals = _size_sweep(target, entry["path"], deals, max(threads),
+                                      args.min_sweep_seconds)
+            if sweep_deals != deals:
+                print(f"    sweep scaled to {sweep_deals:,} deals so the fastest"
+                      f" thread count still runs >{args.min_sweep_seconds}s")
+            record["sweep_deals"] = sweep_deals
+            sweep = {}
+            for batch in batch_sizes:
+                key = "default" if batch is None else str(batch)
+                rows = {}
+                for n in threads:
+                    try:
+                        r = _run_with_batch(target, entry["path"], sweep_deals, n, batch,
+                                            args.repeats)
+                    except bl.BenchError as exc:
+                        print(f"    -R {n:<3} FAILED: {exc}")
+                        continue
+                    rows[str(n)] = r
+                sweep[key] = rows
+                _print_sweep(rows, threads, prefix=(f"    batch={key}  " if batch else "    "))
+            record["sweep"] = sweep
+
+        results["scripts"][name] = record
+        print()
+
+    # A partial run must never land on the canonical path. Otherwise a quick
+    # --quick or --scripts check silently overwrites a full corpus run measured
+    # against the same revision, and the record for that revision is gone with
+    # nothing to say it happened. (Which is exactly how this was found.)
+    partial = bool(args.scripts or args.quick or args.no_sweep or args.sweep_only)
+    if args.output:
+        out = Path(args.output)
+    else:
+        suffix = "-partial" if partial else ""
+        out = bl.RESULTS_DIR / f"dealer3-{rev}{suffix}.json"
+    results["partial"] = partial
+    if partial:
+        results["partial_reason"] = {
+            "scripts": args.scripts, "quick": args.quick,
+            "no_sweep": args.no_sweep, "sweep_only": args.sweep_only,
+        }
+    bl.write_results(out, results)
+    print(f"Wrote {out.relative_to(bl.REPO) if bl.REPO in out.parents else out}")
+
+    if not args.no_sweep:
+        _summarise_scaling(results, threads)
+
+
+def _size_sweep(target, script, deals, max_threads, floor):
+    """Grow the deal count until even the fastest configuration runs long enough.
+
+    A sweep is only worth reading if every point in it is a real measurement.
+    The calibration in bench-corpus.py sizes runs against `-R 1`; at the top of
+    the sweep the same work finishes several times faster, and a run of a
+    couple hundred milliseconds is mostly thread startup and the final merge.
+    Measured that way the curve comes out monotone and the interesting part --
+    where throughput turns over -- is buried in noise.
+
+    So: pilot the highest thread count, and if it lands under `floor`, scale
+    the whole sweep up by the shortfall. Every thread count then runs the same
+    (larger) number of deals, which is what keeps the speedup ratios valid.
+    """
+    if floor <= 0:
+        return deals
+    try:
+        pilot = bl.run_once(target, script, deals, threads=max_threads)
+    except bl.BenchError:
+        return deals
+    if pilot.seconds >= floor:
+        return deals
+    factor = floor / pilot.seconds if pilot.seconds > 0 else 8.0
+    return int(deals * min(factor * 1.2, 50))
+
+
+def _warn_spread(label, r, limit=15.0):
+    """A wide spread means the machine was busy, not that the code got slower."""
+    if r.get("spread_pct", 0) > limit:
+        print(f"    {'':<8} note: {label} varied {r['spread_pct']:.0f}% across runs; "
+              "treat it as indicative only")
+
+
+def _run_with_batch(target, script, deals, nthreads, batch, repeats):
+    """run_repeated, with --batch-size appended when one is being swept."""
+    if batch is None:
+        return bl.run_repeated(target, script, deals, threads=nthreads, repeats=repeats)
+    patched = bl.Target(name=target.name, kind=target.kind,
+                        command=target.command + ["--batch-size", str(batch)],
+                        threaded=True, note=target.note,
+                        verbose_flag=target.verbose_flag)
+    return bl.run_repeated(patched, script, deals, threads=nthreads, repeats=repeats)
+
+
+def _print_sweep(rows, threads, prefix="    "):
+    base = rows.get("1", {}).get("seconds_best")
+    cells = []
+    best_n, best_speedup = None, 0.0
+    for n in threads:
+        r = rows.get(str(n))
+        if not r:
+            continue
+        if base:
+            sp = base / r["seconds_best"]
+            if sp > best_speedup:
+                best_n, best_speedup = n, sp
+            cells.append(f"{n}:{sp:.2f}x")
+        else:
+            cells.append(f"{n}:{r['seconds_best']:.3f}s")
+    print(prefix + "  ".join(cells))
+    if best_n is not None:
+        tail = [n for n in threads if n > best_n and str(n) in rows]
+        verdict = ""
+        if tail:
+            worst_tail = min(base / rows[str(n)]["seconds_best"] for n in tail)
+            if worst_tail < best_speedup * 0.92:
+                verdict = "  <- REGRESSES past peak"
+        print(f"{prefix}peak {best_speedup:.2f}x at {best_n} threads{verdict}")
+
+
+def _summarise_scaling(results, threads):
+    """Aggregate the sweep across scripts -- the headline for the threading work."""
+    print("\n" + "=" * 66)
+    print("Thread scaling, averaged over the corpus")
+    print("=" * 66)
+    print(f"{'threads':>7} {'speedup':>9} {'efficiency':>11}")
+    print("-" * 66)
+
+    per_thread = {}
+    for record in results["scripts"].values():
+        rows = record.get("sweep", {}).get("default", {})
+        base = rows.get("1", {}).get("seconds_best")
+        if not base:
+            continue
+        for n_str, r in rows.items():
+            per_thread.setdefault(int(n_str), []).append(base / r["seconds_best"])
+
+    if not per_thread:
+        return
+    peak_n, peak_sp = None, 0.0
+    for n in sorted(per_thread):
+        sp = sum(per_thread[n]) / len(per_thread[n])
+        if sp > peak_sp:
+            peak_n, peak_sp = n, sp
+        print(f"{n:>7} {sp:>8.2f}x {sp/n:>10.0%}")
+
+    print("-" * 66)
+    print(f"Peak {peak_sp:.2f}x at {peak_n} threads.")
+    tail = [n for n in sorted(per_thread) if n > peak_n]
+    if tail:
+        worst = min(sum(per_thread[n]) / len(per_thread[n]) for n in tail)
+        if worst < peak_sp * 0.92:
+            print(f"Past the peak it falls back to {worst:.2f}x. Adding workers makes")
+            print("it slower, which is contention rather than saturation -- re-run with")
+            print("--scale to see whether the turnover moves with the workload size.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench-dealer3.py
+++ b/scripts/bench-dealer3.py
@@ -106,6 +106,10 @@ def main():
         sys.exit(f"error: {why} -- run ./dev-build.sh build --release")
 
     corpus = bl.load_corpus()
+    # Verify-only entries are for bench-verify.py. They are not timed: their
+    # cost is dominated by solving produced deals, and the programs do not
+    # produce the same number from a fixed -g, so the figure would not compare.
+    corpus = [e for e in corpus if not e.get("verify_only")]
     if args.scripts:
         wanted = {s.strip() for s in args.scripts.split(",")}
         corpus = [e for e in corpus if e["name"] in wanted]

--- a/scripts/bench-dealer3.py
+++ b/scripts/bench-dealer3.py
@@ -126,7 +126,9 @@ def main():
           f"{machine.get('performance_cpus', '?')}P + {machine.get('efficiency_cpus', '?')}E)")
     print(f"{len(corpus)} scripts, {args.repeats} repeats, fastest run wins\n")
 
-    results = {"tool": "bench-dealer3", "revision": rev, "repeats": args.repeats,
+    results = {"tool": "bench-dealer3", "revision": rev,
+               "corpus_id": json.loads(bl.CORPUS_INDEX.read_text()).get("corpus_id"),
+               "repeats": args.repeats,
                "scale": args.scale, "scripts": {}}
 
     for entry in corpus:

--- a/scripts/bench-dealer3.py
+++ b/scripts/bench-dealer3.py
@@ -128,9 +128,11 @@ def main():
     print(f"dealer3 {rev} on {machine.get('cpu') or machine.get('model') or 'unknown'} "
           f"({machine.get('logical_cpus', '?')} logical, "
           f"{machine.get('performance_cpus', '?')}P + {machine.get('efficiency_cpus', '?')}E)")
-    print(f"{len(corpus)} scripts, {args.repeats} repeats, fastest run wins\n")
+    print(f"source {bl.source_fingerprint()}, {len(corpus)} scripts, "
+          f"{args.repeats} repeats, fastest run wins\n")
 
     results = {"tool": "bench-dealer3", "revision": rev,
+               "source_id": bl.source_fingerprint(),
                "corpus_id": json.loads(bl.CORPUS_INDEX.read_text()).get("corpus_id"),
                "repeats": args.repeats,
                "scale": args.scale, "scripts": {}}
@@ -190,7 +192,9 @@ def main():
         out = Path(args.output)
     else:
         suffix = "-partial" if partial else ""
-        out = bl.RESULTS_DIR / f"dealer3-{rev}{suffix}.json"
+        # Named for the source that produced the binary, not the repo state --
+        # see benchlib.source_fingerprint(). Mirrors reference-<corpus_id>.json.
+        out = bl.RESULTS_DIR / f"dealer3-{results['source_id']}{suffix}.json"
     results["partial"] = partial
     if partial:
         results["partial_reason"] = {

--- a/scripts/bench-reference.py
+++ b/scripts/bench-reference.py
@@ -108,7 +108,7 @@ def main():
         sys.exit(f"error: corpus at {bl.CORPUS_DIR} is not under $WINDOWS_GITHUB_HOME "
                  f"({gh}), so the VM cannot read it")
 
-    print(f"Corpus {index.get('built_with', '?')}: {len(corpus)} scripts, "
+    print(f"Corpus {index.get('corpus_id', '?')}: {len(corpus)} scripts, "
           f"{args.repeats} repeats, fastest run wins")
     print(f"Targets: {', '.join(t.name for t in live)}\n")
 
@@ -133,6 +133,7 @@ def main():
         print()
 
     results = {"tool": "bench-reference", "windows_vm": vm,
+               "corpus_id": index.get("corpus_id"),
                "corpus_revision": index.get("built_with"),
                "repeats": args.repeats, "scale": args.scale,
                "targets": {t.name: t.note for t in live}, "scripts": {}}
@@ -157,7 +158,7 @@ def main():
         results["scripts"][entry["name"]] = record
         print()
 
-    rev = index.get("built_with", "unknown")
+    rev = index.get("corpus_id") or index.get("built_with", "unknown")
     # As in bench-dealer3.py: a subset run must not overwrite the full record.
     partial = bool(args.scripts or args.quick or args.only)
     results["partial"] = partial

--- a/scripts/bench-reference.py
+++ b/scripts/bench-reference.py
@@ -63,6 +63,10 @@ def main():
     args = ap.parse_args()
 
     corpus = bl.load_corpus()
+    # Verify-only entries are for bench-verify.py. They are not timed: their
+    # cost is dominated by solving produced deals, and the programs do not
+    # produce the same number from a fixed -g, so the figure would not compare.
+    corpus = [e for e in corpus if not e.get("verify_only")]
     index = json.loads(bl.CORPUS_INDEX.read_text())
     if args.scripts:
         wanted = {s.strip() for s in args.scripts.split(",")}

--- a/scripts/bench-reference.py
+++ b/scripts/bench-reference.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+bench-reference.py - Measure dealer.exe and DealerV2_4 over the corpus.
+
+The slow half of the comparison, and the half that rarely needs re-running.
+dealer.exe lives on the Windows VM and every run costs an SSH round trip;
+neither program changes. Re-run this only when the corpus changes -- or when
+the VM or the DealerV2_4 build does, since both are part of what the numbers
+describe.
+
+Results go to `bench/results/reference-<corpus-rev>.json`, keyed to the corpus
+they were measured against. bench-report.py refuses to compare a dealer3 run
+against reference numbers taken on a different corpus, because the calibrated
+deal counts would differ and the ratio would be meaningless.
+
+Timing differs by target, and the script says which it used. DealerV2_4's own
+`Time needed` is trusted if it reports one. dealer.exe's is not: on Windows it
+prints `Time needed 0.000 sec` however long the run took, so that target is
+wall-clocked and the SSH round trip plus process startup -- measured once at
+the top of the run, about 0.28s -- is subtracted. Runs are sized so the
+residual error in that subtraction is well under the spread between repeats.
+
+Usage:
+    scripts/bench-reference.py [-r 3] [--only dealer.exe]
+
+Options:
+    -r, --repeats N    Runs per measurement, fastest wins (default: 3)
+    --only NAME        Just one target ("dealer.exe", "dealer-c" or "dealerv2_4")
+    --scripts NAMES    Comma-separated corpus subset
+    -1, --quick        One representative script only
+    --scale F          Multiply every script's calibrated deal count by F
+    --dealerv2 PATH    DealerV2_4 binary (else $DEALERV2_BIN, else PATH)
+    --dealer-c PATH    Natively-built original C dealer (else $DEALER_C_BIN)
+    --ssh-timeout S    Per-run timeout for the Windows VM (default: 600)
+    -o, --output PATH  Where to write results
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import benchlib as bl
+
+# These runs take minutes and are usually backgrounded into a file, where
+# Python would block-buffer and show nothing until the very end.
+sys.stdout.reconfigure(line_buffering=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Benchmark dealer.exe and DealerV2_4.")
+    ap.add_argument("-r", "--repeats", type=int, default=3)
+    ap.add_argument("--only", default=None)
+    ap.add_argument("--scripts", default=None)
+    ap.add_argument("-1", "--quick", action="store_true",
+                    help="one representative script only")
+    ap.add_argument("--scale", type=float, default=1.0)
+    ap.add_argument("--dealerv2", default=None)
+    ap.add_argument("--dealer-c", default=None,
+                    help="natively-built original C dealer (else $DEALER_C_BIN)")
+    ap.add_argument("--ssh-timeout", type=int, default=600)
+    ap.add_argument("-o", "--output", default=None)
+    args = ap.parse_args()
+
+    corpus = bl.load_corpus()
+    index = json.loads(bl.CORPUS_INDEX.read_text())
+    if args.scripts:
+        wanted = {s.strip() for s in args.scripts.split(",")}
+        corpus = [e for e in corpus if e["name"] in wanted]
+        if not corpus:
+            sys.exit("error: no corpus scripts matched --scripts")
+    elif args.quick:
+        corpus = [bl.representative(corpus)]
+        print(f"--quick: {corpus[0]['name']} only\n")
+
+    targets = [bl.dealer_exe_target(args.ssh_timeout),
+               bl.dealer_c_target(args.dealer_c),
+               bl.dealerv2_target(args.dealerv2)]
+    if args.only:
+        targets = [t for t in targets if t.name == args.only]
+        if not targets:
+            sys.exit(f"error: unknown target {args.only!r} "
+                     "(expected 'dealer.exe', 'dealer-c' or 'dealerv2_4')")
+
+    live = []
+    for t in targets:
+        ok, why = t.available()
+        if ok:
+            live.append(t)
+        else:
+            print(f"skipping {t.name}: {why}")
+            if t.name == "dealer-c":
+                print("  Build it with scripts/build-dealer-c-macos.sh.")
+            elif t.name == "dealerv2_4":
+                print("  Build it and point --dealerv2 or $DEALERV2_BIN at the binary.")
+                print("  The upstream repo ships only a Linux x86-64 build.")
+            elif t.name == "dealer.exe":
+                print("  Set WINDOWS_HOST / WINDOWS_USER / WINDOWS_GITHUB_HOME in ~/.zshrc.")
+    if not live:
+        sys.exit("error: no reference targets available")
+
+    # dealer.exe reads the script off the shared drive, so the corpus has to
+    # sit under the directory Parallels maps into the VM. win-dealer.sh raises
+    # the same objection later; catching it here saves a slow failure.
+    import os
+    gh = os.environ.get("WINDOWS_GITHUB_HOME")
+    if any(t.kind == "ssh" for t in live) and gh and not str(bl.CORPUS_DIR).startswith(gh):
+        sys.exit(f"error: corpus at {bl.CORPUS_DIR} is not under $WINDOWS_GITHUB_HOME "
+                 f"({gh}), so the VM cannot read it")
+
+    print(f"Corpus {index.get('built_with', '?')}: {len(corpus)} scripts, "
+          f"{args.repeats} repeats, fastest run wins")
+    print(f"Targets: {', '.join(t.name for t in live)}\n")
+
+    # Anything wall-clocked needs its fixed cost measured before the real runs,
+    # so it can be subtracted rather than counted as dealing time.
+    for t in live:
+        if t.timing != "self":
+            overhead = bl.calibrate_overhead(t, corpus[0]["path"])
+            print(f"{t.name}: {overhead:.2f}s startup/SSH overhead, "
+                  f"subtracted from every wall-clocked run")
+    if any(t.timing != "self" for t in live):
+        print()
+
+    vm = bl.windows_vm_info() if any(t.kind == "ssh" for t in live) else {}
+    if vm:
+        print(f"Windows VM: {vm['architecture']}, {vm['cpus']} cpus, {vm['identifier']}")
+        if "ARM" in vm["architecture"].upper():
+            print("  NOTE: dealer.exe is a 32-bit x86 binary, so on this ARM64 VM it runs")
+            print("  under emulation. Its throughput is what you get in practice, but it")
+            print("  is not a like-for-like measure of the C implementation. Compare")
+            print("  dealer-c -- the same source built natively -- for that.")
+        print()
+
+    results = {"tool": "bench-reference", "windows_vm": vm,
+               "corpus_revision": index.get("built_with"),
+               "repeats": args.repeats, "scale": args.scale,
+               "targets": {t.name: t.note for t in live}, "scripts": {}}
+
+    for entry in corpus:
+        deals = max(1000, int(entry["deals"] * args.scale))
+        print(f"{entry['name']}  ({deals:,} deals)")
+        record = {"deals": deals}
+        for target in live:
+            try:
+                r = bl.run_repeated(target, entry["path"], deals,
+                                    repeats=args.repeats, timeout=args.ssh_timeout + 60)
+            except bl.BenchError as exc:
+                print(f"    {target.name:<12} FAILED: {exc}")
+                record[target.name] = {"error": str(exc)}
+                continue
+            record[target.name] = r
+            overhead = r["wall_best"] - r["seconds_best"]
+            print(f"    {target.name:<12} {r['seconds_best']:8.3f}s"
+                  f"  {r['deals_per_sec']/1e6:6.3f} M deals/s"
+                  f"  (spread {r['spread_pct']:.1f}%, {overhead:.1f}s overhead excluded)")
+        results["scripts"][entry["name"]] = record
+        print()
+
+    rev = index.get("built_with", "unknown")
+    # As in bench-dealer3.py: a subset run must not overwrite the full record.
+    partial = bool(args.scripts or args.quick or args.only)
+    results["partial"] = partial
+    if args.output:
+        out = Path(args.output)
+    else:
+        out = bl.RESULTS_DIR / f"reference-{rev}{'-partial' if partial else ''}.json"
+    bl.write_results(out, results)
+    print(f"Wrote {out.relative_to(bl.REPO) if bl.REPO in out.parents else out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench-report.py
+++ b/scripts/bench-report.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+bench-report.py - Join the reference and dealer3 results into one table.
+
+Reads the newest `bench/results/reference-*.json` and `dealer3-*.json` (or the
+files named on the command line) and prints the comparison:
+
+  - deals/sec for dealer.exe, DealerV2_4, dealer3 single-threaded and dealer3
+    with threads on;
+  - the speedup of dealer3 over each reference, single-threaded, which is the
+    only like-for-like comparison since neither reference threads;
+  - the thread-scaling summary from the sweep.
+
+Both halves must have been measured against the same corpus revision. The deal
+counts are calibrated per script, so numbers taken against a different corpus
+describe different amounts of work and cannot be divided by each other.
+
+Usage:
+    scripts/bench-report.py [--reference FILE] [--dealer3 FILE] [--markdown]
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import benchlib as bl
+
+
+def newest(pattern):
+    """Newest full run, preferring it over any partial one.
+
+    A partial run is a spot check, not a record of a revision, so it is only
+    used if there is nothing else -- and _plain() says so when it happens.
+    """
+    files = sorted(bl.RESULTS_DIR.glob(pattern), key=lambda p: p.stat().st_mtime)
+    full = [f for f in files if "-partial" not in f.name]
+    return (full or files)[-1] if files else None
+
+
+def rate(record, key, sub=None):
+    """deals/sec out of a result record, or None if it is missing or failed."""
+    r = record.get(key)
+    if not isinstance(r, dict) or "error" in r or "deals_per_sec" not in r:
+        return None
+    return r["deals_per_sec"]
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Compare dealer.exe, DealerV2_4 and dealer3.")
+    ap.add_argument("--reference", default=None)
+    ap.add_argument("--dealer3", default=None)
+    ap.add_argument("--markdown", action="store_true", help="emit a markdown table")
+    ap.add_argument("--against", default=None,
+                    help="an earlier dealer3-*.json; adds a before/after delta")
+    args = ap.parse_args()
+
+    ref_path = Path(args.reference) if args.reference else newest("reference-*.json")
+    d3_path = Path(args.dealer3) if args.dealer3 else newest("dealer3-*.json")
+    if not d3_path:
+        sys.exit("error: no dealer3 results -- run scripts/bench-dealer3.py")
+
+    d3 = json.loads(d3_path.read_text())
+    ref = json.loads(ref_path.read_text()) if ref_path else None
+
+    if ref:
+        corpus_rev = json.loads(bl.CORPUS_INDEX.read_text()).get("built_with")
+        if ref.get("corpus_revision") != corpus_rev:
+            print(f"warning: reference numbers were taken against corpus "
+                  f"{ref.get('corpus_revision')}, but the corpus is now {corpus_rev}.")
+            print("         Re-run scripts/bench-reference.py before trusting the ratios.\n")
+
+    print(f"dealer3 results : {d3_path.name}  (rev {d3.get('revision')})")
+    print(f"reference       : {ref_path.name if ref_path else 'none -- run bench-reference.py'}")
+    m = d3.get("machine", {})
+    print(f"machine         : {m.get('cpu') or m.get('model')}  "
+          f"{m.get('logical_cpus')} logical ({m.get('performance_cpus')}P+{m.get('efficiency_cpus')}E)\n")
+
+    rows = []
+    baseline = {}
+    for name, rec in d3["scripts"].items():
+        if name != bl.BASELINE_NAME:
+            continue
+        refrec = (ref or {}).get("scripts", {}).get(name, {})
+        baseline = {"exe": rate(refrec, "dealer.exe"), "c": rate(refrec, "dealer-c"),
+                    "v2": rate(refrec, "dealerv2_4"), "d3_1": rate(rec, "single")}
+
+    for name, rec in d3["scripts"].items():
+        if name == bl.BASELINE_NAME:
+            continue
+        refrec = (ref or {}).get("scripts", {}).get(name, {})
+        rows.append({
+            "name": name,
+            "exe": rate(refrec, "dealer.exe"),
+            "c": rate(refrec, "dealer-c"),
+            "v2": rate(refrec, "dealerv2_4"),
+            "d3_1": rate(rec, "single"),
+            "d3_auto": rate(rec, "auto"),
+        })
+
+    if args.markdown:
+        _markdown(rows)
+    else:
+        _plain(rows)
+
+    _generation(baseline, rows)
+    if args.against:
+        _delta(json.loads(Path(args.against).read_text()), d3, Path(args.against).name)
+    _scaling(d3)
+
+
+def _fmt(v, width=9):
+    return f"{v/1e6:{width}.3f}" if v else " " * (width - 1) + "-"
+
+
+def _ratio(a, b):
+    return f"{a/b:6.1f}x" if a and b else "     -"
+
+
+def _plain(rows):
+    print(f"{'script':<28} {'exe*':>8} {'dealer-c':>9} {'V2_4':>8} {'d3 -R1':>8} "
+          f"{'d3 auto':>8} {'vs C':>7} {'vs V2':>7}")
+    print(f"{'':<28} {'M/s':>8} {'M/s':>9} {'M/s':>8} {'M/s':>8} {'M/s':>8} "
+          f"{'(-R1)':>7} {'(-R1)':>7}")
+    print("-" * 94)
+    for r in rows:
+        print(f"{r['name']:<28} {_fmt(r['exe'],8)} {_fmt(r['c'],9)} {_fmt(r['v2'],8)}"
+              f" {_fmt(r['d3_1'],8)} {_fmt(r['d3_auto'],8)}"
+              f" {_ratio(r['d3_1'], r['c']):>7} {_ratio(r['d3_1'], r['v2']):>7}")
+    print("-" * 94)
+    print("* dealer.exe runs x86-emulated on an ARM64 VM; dealer-c is the same")
+    print("  source built natively, and is the fair comparison for its lineage.")
+    _totals(rows)
+
+
+def _markdown(rows):
+    print("| script | dealer.exe* | dealer-c | DealerV2_4 | dealer3 `-R1` | dealer3 auto "
+          "| vs dealer-c | vs V2_4 |")
+    print("|---|---:|---:|---:|---:|---:|---:|---:|")
+    for r in rows:
+        print(f"| {r['name']} | {_fmt(r['exe'],1).strip()} | {_fmt(r['c'],1).strip()} "
+              f"| {_fmt(r['v2'],1).strip()} | {_fmt(r['d3_1'],1).strip()} "
+              f"| {_fmt(r['d3_auto'],1).strip()} "
+              f"| {_ratio(r['d3_1'], r['c']).strip()} | {_ratio(r['d3_1'], r['v2']).strip()} |")
+    print("\nAll rates in millions of deals evaluated per second; higher is better.")
+    print("\n\\* dealer.exe runs x86-emulated on an ARM64 VM. `dealer-c` is the same")
+    print("source built natively and is the like-for-like comparison.")
+    _totals(rows)
+
+
+def _totals(rows):
+    def gmean(vals):
+        vals = [v for v in vals if v]
+        if not vals:
+            return None
+        prod = 1.0
+        for v in vals:
+            prod *= v
+        return prod ** (1 / len(vals))
+
+    print()
+    pairs = [(r["d3_1"] / r["c"]) for r in rows if r["d3_1"] and r["c"]]
+    if pairs:
+        print(f"dealer3 -R1 is {gmean(pairs):.1f}x the original C dealer, built natively "
+              "(geometric mean).")
+    pairs = [(r["d3_1"] / r["exe"]) for r in rows if r["d3_1"] and r["exe"]]
+    if pairs:
+        print(f"dealer3 -R1 is {gmean(pairs):.1f}x dealer.exe as run on the VM "
+              "(emulated -- not a like-for-like figure).")
+    pairs = [(r["d3_1"] / r["v2"]) for r in rows if r["d3_1"] and r["v2"]]
+    if pairs:
+        print(f"dealer3 -R1 is {gmean(pairs):.1f}x DealerV2_4 across the corpus (geometric mean).")
+    pairs = [(r["d3_auto"] / r["d3_1"]) for r in rows if r["d3_auto"] and r["d3_1"]]
+    if pairs:
+        print(f"Threading (auto) buys {gmean(pairs):.2f}x over single-threaded.")
+
+
+def _times(x):
+    """Render a ratio without the "0.3x faster" trap, which reads as a speedup."""
+    if x >= 1.0:
+        return f"is {x:.1f}x faster"
+    return f"is {1/x:.1f}x SLOWER" if x > 0 else "is immeasurably slower"
+
+
+def _generation(baseline, rows):
+    """Split the win into generating deals and evaluating conditions.
+
+    dealer3 rewrote the RNG and the shuffle, and the originals were slow, so a
+    lot of any headline ratio is generation rather than evaluation. Those are
+    different pieces of work and improve for different reasons, and a single
+    deals/sec number cannot tell them apart -- on a cheap condition the shuffle
+    dominates, on an expensive one it barely registers.
+
+    The `_shuffle_baseline` corpus entry runs a near-free condition, so its
+    cost per deal is essentially generation. Subtracting it from a real
+    script's cost per deal leaves evaluation. Both are then per-deal times, in
+    nanoseconds, which subtract honestly -- unlike rates, which do not.
+    """
+    if not baseline.get("d3_1"):
+        return
+    print("\nWhere the time goes, per deal (ns)")
+    print(f"{'':<12} {'generate':>10} {'evaluate':>10} {'total':>10}"
+          f"  {'gen share':>10}")
+    print("-" * 58)
+
+    labels = {"exe": "dealer.exe", "c": "dealer-c", "v2": "DealerV2_4", "d3_1": "dealer3 -R1"}
+    summary = {}
+    for key, label in labels.items():
+        gen_rate = baseline.get(key)
+        if not gen_rate:
+            continue
+        totals = [1e9 / r[key] for r in rows if r.get(key)]
+        if not totals:
+            continue
+        gen = 1e9 / gen_rate
+        total = sum(totals) / len(totals)
+        # A script cannot evaluate in less than no time; if the baseline comes
+        # out slower than a real script the difference is noise, not a negative
+        # cost, so it is floored rather than reported as one.
+        evaluate = max(total - gen, 0.0)
+        summary[key] = (gen, evaluate)
+        print(f"{label:<12} {gen:>10.0f} {evaluate:>10.0f} {total:>10.0f}"
+              f"  {gen/total:>9.0%}")
+    print("-" * 58)
+    print("Mean over the corpus. 'generate' is the _shuffle_baseline entry:")
+    print("RNG and shuffle with a near-free condition.")
+
+    for key, label in (("c", "the original C dealer"), ("v2", "DealerV2_4"),
+                       ("exe", "dealer.exe (emulated)")):
+        if key in summary and "d3_1" in summary:
+            gen_ref, eval_ref = summary[key]
+            gen_d3, eval_d3 = summary["d3_1"]
+            gen_x = gen_ref / gen_d3 if gen_d3 else 0
+            eval_x = eval_ref / eval_d3 if eval_d3 else 0
+            print(f"\nAgainst {label}: dealer3 {_times(gen_x)} at generating "
+                  f"and {_times(eval_x)} at evaluating.")
+
+
+def _delta(old, new, old_name):
+    """Before/after on the same corpus, which is the point of keeping results.
+
+    Only comparable when both sides ran the same corpus: the deal counts are
+    calibrated per script, so a row measured against a different corpus is
+    describing a different amount of work. Rows present on one side only are
+    listed rather than silently dropped, because a script disappearing is
+    usually a corpus change rather than a result.
+    """
+    print(f"\nChange against {old_name}")
+    print(f"{'script':<28} {'before':>10} {'after':>10} {'change':>10}")
+    print("-" * 62)
+
+    ratios = []
+    for name, rec in new["scripts"].items():
+        before = old.get("scripts", {}).get(name, {}).get("single", {}).get("deals_per_sec")
+        after = rec.get("single", {}).get("deals_per_sec")
+        if not before or not after:
+            continue
+        ratio = after / before
+        ratios.append(ratio)
+        arrow = "faster" if ratio >= 1 else "SLOWER"
+        shown = ratio if ratio >= 1 else 1 / ratio
+        print(f"{name:<28} {before/1e6:>9.3f} {after/1e6:>9.3f} {shown:>8.2f}x {arrow}")
+    print("-" * 62)
+    print("M deals/s, single-threaded (-R 1).")
+
+    missing = set(old.get("scripts", {})) ^ set(new["scripts"])
+    if missing:
+        print(f"Not compared (present on one side only): {', '.join(sorted(missing))}")
+
+    if ratios:
+        prod = 1.0
+        for r in ratios:
+            prod *= r
+        g = prod ** (1 / len(ratios))
+        verdict = f"{g:.2f}x faster" if g >= 1 else f"{1/g:.2f}x slower"
+        print(f"\nOverall: {verdict} across {len(ratios)} scripts (geometric mean).")
+
+
+def _scaling(d3):
+    per_thread = {}
+    for rec in d3["scripts"].values():
+        rows = rec.get("sweep", {}).get("default", {})
+        base = rows.get("1", {}).get("seconds_best")
+        if not base:
+            continue
+        for n_str, r in rows.items():
+            per_thread.setdefault(int(n_str), []).append(base / r["seconds_best"])
+    if not per_thread:
+        return
+
+    print("\nThread scaling (corpus mean)")
+    print(f"{'threads':>7} {'speedup':>9} {'efficiency':>11}  {'':<24}")
+    print("-" * 56)
+    peak_n, peak_sp = None, 0.0
+    scale = {}
+    for n in sorted(per_thread):
+        sp = sum(per_thread[n]) / len(per_thread[n])
+        scale[n] = sp
+        if sp > peak_sp:
+            peak_n, peak_sp = n, sp
+    for n in sorted(scale):
+        bar = "#" * int(scale[n] * 4)
+        print(f"{n:>7} {scale[n]:>8.2f}x {scale[n]/n:>10.0%}  {bar}")
+    print("-" * 56)
+    print(f"Peak {peak_sp:.2f}x at {peak_n} threads.")
+    tail = [n for n in sorted(scale) if n > peak_n]
+    if tail and min(scale[n] for n in tail) < peak_sp * 0.92:
+        print(f"Falls to {min(scale[n] for n in tail):.2f}x beyond that -- more workers,")
+        print("less throughput. That is contention, not saturation.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench-report.py
+++ b/scripts/bench-report.py
@@ -73,7 +73,9 @@ def main():
                 print("         Deal counts are calibrated per script, so those rows")
                 print("         describe different amounts of work. Re-measure.\n")
 
-    print(f"dealer3 results : {d3_path.name}  (rev {d3.get('revision')})")
+    print(f"dealer3 results : {d3_path.name}")
+    print(f"                  source {d3.get('source_id', '?')}, "
+          f"repo {d3.get('revision', '?')}")
     print(f"reference       : {ref_path.name if ref_path else 'none -- run bench-reference.py'}")
     m = d3.get("machine", {})
     print(f"machine         : {m.get('cpu') or m.get('model')}  "
@@ -249,6 +251,12 @@ def _delta(old, new, old_name):
     usually a corpus change rather than a result.
     """
     print(f"\nChange against {old_name}")
+    if old.get("source_id") and new.get("source_id"):
+        if old["source_id"] == new["source_id"]:
+            print(f"  NOTE: both sides have source {old['source_id']} -- the code did "
+                  "not change, so this is run-to-run noise.")
+        else:
+            print(f"  source {old['source_id']} -> {new['source_id']}")
     print(f"{'script':<28} {'before':>10} {'after':>10} {'change':>10}")
     print("-" * 62)
 

--- a/scripts/bench-report.py
+++ b/scripts/bench-report.py
@@ -88,7 +88,8 @@ def main():
             continue
         refrec = (ref or {}).get("scripts", {}).get(name, {})
         baseline = {"exe": rate(refrec, "dealer.exe"), "c": rate(refrec, "dealer-c"),
-                    "v2": rate(refrec, "dealerv2_4"), "d3_1": rate(rec, "single")}
+                    "v2": rate(refrec, "dealerv2_4"), "d3_1": rate(rec, "single"),
+                    "d3_auto": rate(rec, "auto")}
 
     for name, rec in d3["scripts"].items():
         if name == bl.BASELINE_NAME:
@@ -208,7 +209,8 @@ def _generation(baseline, rows):
           f"  {'gen share':>10}")
     print("-" * 58)
 
-    labels = {"exe": "dealer.exe", "c": "dealer-c", "v2": "DealerV2_4", "d3_1": "dealer3 -R1"}
+    labels = {"exe": "dealer.exe", "c": "dealer-c", "v2": "DealerV2_4",
+              "d3_1": "dealer3 -R1", "d3_auto": "dealer3 auto"}
     summary = {}
     for key, label in labels.items():
         gen_rate = baseline.get(key)
@@ -229,6 +231,12 @@ def _generation(baseline, rows):
     print("-" * 58)
     print("Mean over the corpus. 'generate' is the _shuffle_baseline entry:")
     print("RNG and shuffle with a near-free condition.")
+
+    if "d3_auto" in summary:
+        print("\n'dealer3 auto' is wall time per deal with every core working, so it is\n"
+              "throughput per deal and not work per deal -- the only row here that is\n"
+              "not one core's effort. It is also the noisiest: repeats vary by tens of\n"
+              "percent where the single-threaded rows vary by one or two.")
 
     for key, label in (("c", "the original C dealer"), ("v2", "DealerV2_4"),
                        ("exe", "dealer.exe (emulated)")):

--- a/scripts/bench-report.py
+++ b/scripts/bench-report.py
@@ -64,11 +64,14 @@ def main():
     ref = json.loads(ref_path.read_text()) if ref_path else None
 
     if ref:
-        corpus_rev = json.loads(bl.CORPUS_INDEX.read_text()).get("built_with")
-        if ref.get("corpus_revision") != corpus_rev:
-            print(f"warning: reference numbers were taken against corpus "
-                  f"{ref.get('corpus_revision')}, but the corpus is now {corpus_rev}.")
-            print("         Re-run scripts/bench-reference.py before trusting the ratios.\n")
+        corpus_id = json.loads(bl.CORPUS_INDEX.read_text()).get("corpus_id")
+        for label, payload in (("reference", ref), ("dealer3", d3)):
+            got = payload.get("corpus_id")
+            if got and corpus_id and got != corpus_id:
+                print(f"warning: the {label} numbers were measured against corpus "
+                      f"{got}, but the corpus is now {corpus_id}.")
+                print("         Deal counts are calibrated per script, so those rows")
+                print("         describe different amounts of work. Re-measure.\n")
 
     print(f"dealer3 results : {d3_path.name}  (rev {d3.get('revision')})")
     print(f"reference       : {ref_path.name if ref_path else 'none -- run bench-reference.py'}")

--- a/scripts/bench-verify.py
+++ b/scripts/bench-verify.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+bench-verify.py - Check dealer3 agrees with the reference programs, over the
+benchmark corpus.
+
+A performance number is worth nothing if the three programs are not doing the
+same thing, so the corpus does double duty: the same scripts that measure
+throughput also check semantics. For each script and each reference program:
+
+  1. The reference runs with `printpbn` added to its action list, so it emits
+     both the deals it produced and its statistics.
+  2. Those deals go back into dealer3 through `--input-deals`, script unchanged.
+  3. Two things must hold.
+
+     **Acceptance.** Every deal the reference matched, dealer3 must also match.
+     Both are looking at identical cards, so anything less than 100% is a real
+     disagreement about what the condition means -- never an artefact of the
+     shuffle, which is exactly why this works despite the two programs having
+     dealt differently since 0.5.0.
+
+     **Statistics.** The `average` over those deals must come out the same.
+     Same cards in, same number out.
+
+This is `scripts/test-filter.py`'s check (dealer.exe only, acceptance only)
+widened to both references and to the statistics, and run over the whole corpus
+in one go. The PBN plumbing is imported from `scripts/compare-stats.py` rather
+than reimplemented, so the two cannot drift.
+
+Usage:
+    scripts/bench-verify.py [-p 200] [-s 1] [--only dealerv2_4]
+
+Options:
+    -p, --produce N   Deals for the reference to produce per script (default: 200)
+    -s, --seed SEED   Reference seed (default: 1)
+    --only NAME       Just one reference ("dealer.exe" or "dealerv2_4")
+    --scripts NAMES   Comma-separated corpus subset
+    -1, --quick       One representative script only
+    --dealerv2 PATH   DealerV2_4 binary (else $DEALERV2_BIN, else PATH)
+    -v, --verbose     Show the differing statistics lines
+"""
+import argparse
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import benchlib as bl
+
+# These runs take minutes and are usually backgrounded into a file, where
+# Python would block-buffer and show nothing until the very end.
+sys.stdout.reconfigure(line_buffering=True)
+
+
+def _load_compare_stats():
+    """Import compare-stats.py despite the hyphen in its name.
+
+    Reused rather than copied: with_printpbn() knows the three shapes an
+    `action` line can take, and statistics() knows which trailer lines are not
+    comparable. Duplicating either would guarantee they drift apart.
+    """
+    path = Path(__file__).resolve().parent / "compare-stats.py"
+    spec = importlib.util.spec_from_file_location("compare_stats", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+PBN_DEAL_RE = re.compile(r'^\[Deal\s+"', re.MULTILINE)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Check dealer3 agrees with the references.")
+    ap.add_argument("-p", "--produce", type=int, default=200)
+    ap.add_argument("-s", "--seed", type=int, default=1)
+    ap.add_argument("--only", default=None)
+    ap.add_argument("--scripts", default=None)
+    ap.add_argument("-1", "--quick", action="store_true",
+                    help="one representative script only")
+    ap.add_argument("--dealerv2", default=None)
+    ap.add_argument("--ssh-timeout", type=int, default=300)
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    cs = _load_compare_stats()
+
+    dealer3 = bl.dealer3_target()
+    ok, why = dealer3.available()
+    if not ok:
+        sys.exit(f"error: dealer3 unavailable ({why})")
+
+    corpus = bl.load_corpus()
+    if args.scripts:
+        wanted = {s.strip() for s in args.scripts.split(",")}
+        corpus = [e for e in corpus if e["name"] in wanted]
+        if not corpus:
+            sys.exit("error: no corpus scripts matched --scripts")
+    elif args.quick:
+        corpus = [bl.representative(corpus)]
+        print(f"--quick: {corpus[0]['name']} only\n")
+
+    refs = [bl.dealer_exe_target(args.ssh_timeout), bl.dealerv2_target(args.dealerv2)]
+    if args.only:
+        refs = [t for t in refs if t.name == args.only]
+        if not refs:
+            sys.exit(f"error: unknown target {args.only!r}")
+    live = []
+    for t in refs:
+        good, reason = t.available()
+        if good:
+            live.append(t)
+        else:
+            print(f"skipping {t.name}: {reason}")
+    if not live:
+        sys.exit("error: no reference programs available")
+
+    # Temp scripts and PBN files must live under the directory Parallels maps
+    # into the VM, or dealer.exe cannot read them.
+    work = bl.REPO / "bench" / ".verify"
+    work.mkdir(parents=True, exist_ok=True)
+
+    print(f"{len(corpus)} scripts, {args.produce} deals each, seed {args.seed}")
+    print(f"References: {', '.join(t.name for t in live)}\n")
+
+    failures = []
+    for entry in corpus:
+        script = entry["path"].read_text()
+        ref_script, _ = cs.with_printpbn(script)
+        staged = work / f"{entry['name']}.dlr"
+        staged.write_text(ref_script)
+
+        print(f"{entry['name']}")
+        for target in live:
+            verdict = check(target, dealer3, staged, args, cs, work, entry["name"])
+            status = verdict["status"]
+            print(f"    {target.name:<12} {status}")
+            if verdict.get("detail") and (args.verbose or status.startswith("MISMATCH")):
+                for line in verdict["detail"]:
+                    print(f"        {line}")
+            if not status.startswith("ok"):
+                failures.append((entry["name"], target.name, status))
+
+    print()
+    if failures:
+        print(f"{len(failures)} check(s) failed:")
+        for name, tgt, status in failures:
+            print(f"  {name} / {tgt}: {status}")
+        return 1
+    print("All scripts agree on every deal the references produced.")
+    return 0
+
+
+def check(target, dealer3, staged, args, cs, work, name):
+    """Run one reference, replay its deals through dealer3, compare."""
+    try:
+        argv = list(target.command)
+        if target.verbose_flag:
+            argv.append(target.verbose_flag)
+        argv += ["-p", str(args.produce), "-s", str(args.seed), str(staged)]
+        ref = subprocess.run(argv, capture_output=True, text=True,
+                             timeout=args.ssh_timeout + 60)
+    except subprocess.TimeoutExpired:
+        return {"status": "ERROR: reference timed out"}
+    if ref.returncode != 0:
+        return {"status": f"ERROR: reference exit {ref.returncode}: "
+                          f"{bl._first_real_line(ref.stdout + ref.stderr)}"}
+
+    ref_out = ref.stdout
+    n_deals = len(PBN_DEAL_RE.findall(ref_out))
+    if n_deals == 0:
+        return {"status": "ERROR: reference emitted no PBN deals"}
+
+    pbn = work / f"{name}.{target.name}.pbn"
+    pbn.write_text(ref_out)
+
+    try:
+        rep = subprocess.run(
+            list(dealer3.command) + ["-p", str(max(n_deals, args.produce)),
+                                     "--input-deals", str(pbn), str(staged)],
+            capture_output=True, text=True, timeout=300)
+    except subprocess.TimeoutExpired:
+        return {"status": "ERROR: dealer3 timed out replaying"}
+    if rep.returncode != 0:
+        return {"status": f"ERROR: dealer3 exit {rep.returncode}: "
+                          f"{bl._first_real_line(rep.stdout + rep.stderr)}"}
+
+    accepted = len(PBN_DEAL_RE.findall(rep.stdout))
+    if accepted != n_deals:
+        return {"status": f"MISMATCH: reference matched {n_deals} deals, "
+                          f"dealer3 accepted {accepted}"}
+
+    # Same cards in, so every statistic must come out to the same *value*.
+    # `statistics()` already drops the run trailer, which differs by
+    # construction: one program dealt these boards and the other read them.
+    ref_stats = cs.statistics(ref_out, True)
+    rep_stats = cs.statistics(rep.stdout, True)
+    diffs = compare_statistics(ref_stats, rep_stats, target.name)
+    if diffs:
+        return {"status": f"MISMATCH: statistics differ over {n_deals} identical deals",
+                "detail": diffs[:8]}
+
+    return {"status": f"ok ({n_deals} deals, statistics agree)"}
+
+
+# An `average` line does not have one spelling across the three programs.
+# dealer.exe and dealer3 print `label: 10.66`; DealerV2_4 prints
+# `label: Mean=   10.6600, Std Dev= ..., Var= ..., Sample Size=50`. Those are
+# the same answer, so comparing the text would report a difference that is
+# purely cosmetic -- and, worse, would hide the real ones in noise. What is
+# compared is the label and the value.
+STAT_RE = re.compile(
+    r"^(?P<label>[^:]*?):\s*(?:Mean=\s*)?(?P<value>-?\d+(?:\.\d+)?)\s*(?:,|$)"
+)
+
+
+def _parsed(lines):
+    out = []
+    for line in lines:
+        m = STAT_RE.match(line.strip())
+        if m:
+            out.append((m.group("label").strip(), m.group("value")))
+    return out
+
+
+def compare_statistics(ref_lines, rep_lines, ref_name):
+    """Compare statistics by value, tolerating each program's formatting.
+
+    The two are compared to the precision of whichever printed fewer decimals:
+    dealer3's `10.66` and DealerV2_4's `10.6600` are the same measurement
+    reported to different widths, and demanding they match as strings would
+    fail every time while telling you nothing.
+    """
+    ref, rep = _parsed(ref_lines), _parsed(rep_lines)
+    diffs = []
+    if len(ref) != len(rep):
+        diffs.append(f"{ref_name} reported {len(ref)} statistic(s), dealer3 {len(rep)}")
+        return diffs
+    for (rlabel, rval), (plabel, pval) in zip(ref, rep):
+        if rlabel != plabel:
+            diffs.append(f"label differs: {ref_name} {rlabel!r} vs dealer3 {plabel!r}")
+            continue
+        decimals = min(len(rval.partition(".")[2]), len(pval.partition(".")[2]))
+        if round(float(rval), decimals) != round(float(pval), decimals):
+            diffs.append(f"{rlabel}: {ref_name} {rval} vs dealer3 {pval}")
+    return diffs
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench-verify.py
+++ b/scripts/bench-verify.py
@@ -140,7 +140,8 @@ def main():
                 print(f"    {target.name:<12} n/a (script needs a double-dummy solver)")
                 continue
             verdict = check(target, dealer3, staged, args, cs, work, entry["name"],
-                            produce=entry.get("verify_produce"))
+                            produce=entry.get("verify_produce"),
+                            extra=entry.get("target_args", {}).get(target.name))
             status = verdict["status"]
             print(f"    {target.name:<12} {status}")
             if verdict.get("detail") and (args.verbose or status.startswith("MISMATCH")):
@@ -159,18 +160,20 @@ def main():
     return 0
 
 
-def check(target, dealer3, staged, args, cs, work, name, produce=None):
+def check(target, dealer3, staged, args, cs, work, name, produce=None, extra=None):
     """Run one reference, replay its deals through dealer3, compare.
 
     `produce` overrides the run-wide count for entries that are expensive per
     deal -- a script calling the solver spends milliseconds on each produced
-    deal rather than microseconds.
+    deal rather than microseconds. `extra` passes switches an entry needs for a
+    particular program, such as putting DealerV2_4 in table mode.
     """
     produce = produce or args.produce
     try:
         argv = list(target.command)
         if target.verbose_flag:
             argv.append(target.verbose_flag)
+        argv += list(extra or [])
         argv += ["-p", str(produce), "-s", str(args.seed), str(staged)]
         ref = subprocess.run(argv, capture_output=True, text=True,
                              timeout=args.ssh_timeout + 60)

--- a/scripts/bench-verify.py
+++ b/scripts/bench-verify.py
@@ -131,8 +131,16 @@ def main():
         staged.write_text(ref_script)
 
         print(f"{entry['name']}")
+        # An entry may name the targets it applies to: the solver-agreement
+        # script uses words dealer.exe and dealer-c do not have, and would
+        # otherwise be reported as a failure rather than as inapplicable.
+        allowed = entry.get("targets")
         for target in live:
-            verdict = check(target, dealer3, staged, args, cs, work, entry["name"])
+            if allowed and target.name not in allowed:
+                print(f"    {target.name:<12} n/a (script needs a double-dummy solver)")
+                continue
+            verdict = check(target, dealer3, staged, args, cs, work, entry["name"],
+                            produce=entry.get("verify_produce"))
             status = verdict["status"]
             print(f"    {target.name:<12} {status}")
             if verdict.get("detail") and (args.verbose or status.startswith("MISMATCH")):
@@ -151,13 +159,19 @@ def main():
     return 0
 
 
-def check(target, dealer3, staged, args, cs, work, name):
-    """Run one reference, replay its deals through dealer3, compare."""
+def check(target, dealer3, staged, args, cs, work, name, produce=None):
+    """Run one reference, replay its deals through dealer3, compare.
+
+    `produce` overrides the run-wide count for entries that are expensive per
+    deal -- a script calling the solver spends milliseconds on each produced
+    deal rather than microseconds.
+    """
+    produce = produce or args.produce
     try:
         argv = list(target.command)
         if target.verbose_flag:
             argv.append(target.verbose_flag)
-        argv += ["-p", str(args.produce), "-s", str(args.seed), str(staged)]
+        argv += ["-p", str(produce), "-s", str(args.seed), str(staged)]
         ref = subprocess.run(argv, capture_output=True, text=True,
                              timeout=args.ssh_timeout + 60)
     except subprocess.TimeoutExpired:
@@ -176,7 +190,7 @@ def check(target, dealer3, staged, args, cs, work, name):
 
     try:
         rep = subprocess.run(
-            list(dealer3.command) + ["-p", str(max(n_deals, args.produce)),
+            list(dealer3.command) + ["-p", str(max(n_deals, produce)),
                                      "--input-deals", str(pbn), str(staged)],
             capture_output=True, text=True, timeout=300)
     except subprocess.TimeoutExpired:

--- a/scripts/benchlib.py
+++ b/scripts/benchlib.py
@@ -49,6 +49,7 @@ originals.
 generate the number of deals asked for. A short run means something overrode
 the limit and the timing describes a different amount of work.
 """
+import hashlib
 import json
 import os
 import re
@@ -519,6 +520,29 @@ def load_corpus():
     for e in entries:
         e["path"] = CORPUS_DIR / e["file"]
     return entries
+
+
+def corpus_fingerprint(entries):
+    """A short hash of what the corpus actually is.
+
+    Results are keyed to this rather than to a git revision. A revision is the
+    wrong identity for two reasons: it changes when anything in the repo
+    changes, so reference numbers would look stale after an unrelated commit;
+    and it cannot be written into the corpus before the commit that contains
+    the corpus exists, which is a regress with no fixed point.
+
+    A content hash has neither problem. It is stable across unrelated commits
+    and changes exactly when the scripts or their calibrated deal counts do --
+    which is precisely when a measurement stops being comparable.
+    """
+    h = hashlib.sha256()
+    for e in sorted(entries, key=lambda e: e["name"]):
+        h.update(e["name"].encode())
+        h.update(str(e["deals"]).encode())
+        path = CORPUS_DIR / e["file"]
+        if path.exists():
+            h.update(path.read_bytes())
+    return h.hexdigest()[:12]
 
 
 def representative(corpus):

--- a/scripts/benchlib.py
+++ b/scripts/benchlib.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""
+benchlib.py - Shared machinery for the three-way performance comparison.
+
+Used by bench-corpus.py, bench-reference.py, bench-dealer3.py and
+bench-report.py. Nothing here runs on its own.
+
+Why the numbers are measured the way they are
+---------------------------------------------
+
+**Timing prefers the program's own clock, and falls back when it lies.**
+dealer3 and DealerV2_4 print a truthful `Time needed %.3f sec` covering the
+generate loop and nothing else, which is the number to compare: it excludes
+process startup, and for a target reached over SSH it excludes the round trip
+too.
+
+dealer.exe on the Windows VM prints `Time needed 0.000 sec` no matter how long
+it ran -- its gettimeofday() does not work there. So a target may be timed by
+wall clock instead, with a per-target overhead (SSH round trip plus process
+startup, measured by calibrate_overhead() against a near-zero-work run)
+subtracted. That overhead is small and steady -- about 0.28s for the VM -- but
+it is a tenth of a three-second run, so it is measured rather than ignored, and
+bench-reference.py sizes runs long enough for the residual to be noise.
+
+Sample.timing records which clock was used, so a report never silently mixes
+the two without saying so.
+
+**Do not pass `-v` to dealer.exe.** Its verbose flag defaults to *on* and the
+switch XORs it (dealer.c:1608), so `-v` turns the trailer off and the run looks
+like it printed nothing. The VM's build is older than the local source and has
+no `-X` to force it on either. It also has a known `-v` bug tied to whether an
+odd or even number of PBN rows were written. Verbose_flag is therefore None for
+that target: take the default and touch nothing.
+
+**Work is fixed by `-g`, not by `-p`.** The three programs do not deal the same
+boards, so "produce 40 matches" is a different amount of work for each of them:
+whoever's shuffle happens to hit the condition sooner does less. `-g N` makes
+all three evaluate exactly N deals against the condition, which is the thing
+being compared. `-p` is then set high enough never to bind.
+
+**The script's own `produce`/`generate` must be stripped first.** In dealer.c
+`yyparse()` runs *after* `getopt()`, and `maxgenerate`/`maxproduce` are only
+defaulted if still zero, so a `generate 100000` line inside a script silently
+beats `-g` on the command line. 120 of the 347 PBS scripts carry one. See
+normalize_script(); this is why the corpus is a rewritten copy rather than the
+originals.
+
+**Every sample is validated.** run_once() checks that the run really did
+generate the number of deals asked for. A short run means something overrode
+the limit and the timing describes a different amount of work.
+"""
+import json
+import os
+import re
+import shutil
+import statistics
+import subprocess
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CORPUS_DIR = REPO / "bench" / "corpus"
+RESULTS_DIR = REPO / "bench" / "results"
+CORPUS_INDEX = REPO / "bench" / "corpus.json"
+
+# `-p` is set to this so the produce limit never binds and `-g` alone decides
+# how much work happens. Comfortably inside a 32-bit int, which dealer.exe's
+# atoi() lands in.
+NO_PRODUCE_LIMIT = 100_000_000
+
+# A synthetic corpus entry that isolates deal generation.
+#
+# dealer3 rewrote the RNG and the shuffle, and dealer.exe's were notably slow,
+# so a large part of any measured gap is generation rather than condition
+# evaluation. Total deals/sec cannot separate the two: it is
+# (shuffle + evaluate) per deal, and for a cheap condition the shuffle
+# dominates. This script makes the condition as close to free as the language
+# allows -- one hcp() call and a comparison -- so its throughput is essentially
+# generation alone. Subtracting its per-deal cost from a real script's leaves
+# the evaluation cost, and the two can then be compared separately.
+#
+# The threshold is chosen to be rare but not impossible. A condition nothing
+# ever satisfies would leave `average` with no samples, and it costs nothing to
+# avoid finding out what each program prints in that case.
+BASELINE_NAME = "_shuffle_baseline"
+BASELINE_SCRIPT = """# Synthetic. Not from Practice-Bidding-Scenarios.
+#
+# Measures deal generation -- RNG plus shuffle -- with as little condition
+# evaluation as the language permits, so the generation half of the comparison
+# can be read on its own. See BASELINE_NAME in scripts/benchlib.py.
+hcp(north) >= 24
+action average "bench" hcp(north)
+"""
+
+# The action every corpus script gets, replacing whatever it had. Cheap, runs
+# only on produced deals, and prints one line regardless of hit rate -- so the
+# measurement is condition-evaluation throughput and not output I/O.
+BENCH_ACTION = 'action average "bench" hcp(north)'
+
+TIME_RE = re.compile(r"Time needed\s+([0-9.]+)\s*sec")
+GENERATED_RE = re.compile(r"Generated\s+(\d+)\s+hands")
+PRODUCED_RE = re.compile(r"Produced\s+(\d+)\s+hands")
+
+BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+LIMIT_LINE_RE = re.compile(r"^\s*(produce|generate)\s+\d+\s*$", re.IGNORECASE)
+ACTION_LINE_RE = re.compile(r"^\s*action\b", re.IGNORECASE)
+
+
+class BenchError(RuntimeError):
+    """A run that cannot be trusted as a measurement."""
+
+
+# OpenSSH prints a post-quantum key-exchange advisory on every connection to
+# the VM. It is the first thing on stderr, so without this an SSH target's
+# error messages would all read as that banner instead of the real failure.
+SSH_NOISE = ("WARNING: connection is not using", "store now, decrypt later",
+             "may need to be upgraded", "openssh.com/pq")
+
+
+def _first_real_line(out):
+    for ln in out.splitlines():
+        ln = ln.strip()
+        if ln and not any(n in ln for n in SSH_NOISE):
+            return ln
+    return "no output"
+
+
+# --------------------------------------------------------------------------
+# Script normalization
+# --------------------------------------------------------------------------
+
+def normalize_script(text):
+    """Rewrite a PBS script into one that measures condition throughput.
+
+    Three changes, all of them needed for the number to mean anything:
+
+      - Block comments go. dealer.exe has a parsing bug that echoes stray
+        characters out of `/* */` (docs/original-dealer-errata.md); harmless
+        for output, but noise in a corpus meant to run clean on all three.
+      - `produce`/`generate` lines go, because they would override `-g`.
+      - The `action` block is replaced with BENCH_ACTION, so the run is not
+        also measuring printall or a frequency table.
+
+    Everything else -- `dealer`, `predeal`, `vulnerable`, the variable
+    assignments and the condition itself -- is left exactly as written. That
+    is the part being benchmarked.
+
+    Returns (normalized_text, notes) where notes records what was dropped.
+    """
+    notes = []
+
+    if BLOCK_COMMENT_RE.search(text):
+        text = BLOCK_COMMENT_RE.sub("", text)
+        notes.append("stripped block comments")
+
+    lines = text.splitlines()
+
+    kept = [ln for ln in lines if not LIMIT_LINE_RE.match(ln)]
+    if len(kept) != len(lines):
+        notes.append(f"dropped {len(lines) - len(kept)} produce/generate line(s)")
+    lines = kept
+
+    # Truncate at the last `action`. In the dealer grammar the action list is
+    # the final statement, so everything after it belongs to it. One PBS
+    # script (Bergen_Thrump_X_after_Preempt) breaks that rule; bench-corpus.py
+    # rejects any script where truncating would drop a real statement.
+    action_at = None
+    for i, ln in enumerate(lines):
+        if ACTION_LINE_RE.match(ln):
+            action_at = i
+    if action_at is not None:
+        lines = lines[:action_at]
+        notes.append("replaced action block")
+    else:
+        notes.append("added action block (script had none)")
+
+    while lines and not lines[-1].strip():
+        lines.pop()
+    lines.append(BENCH_ACTION)
+
+    return "\n".join(lines) + "\n", notes
+
+
+def statements_after_action(text):
+    """True if a real statement follows the last `action`, so truncating loses it.
+
+    Used by bench-corpus.py to reject a script rather than silently benchmark
+    a different condition than the one that was written.
+    """
+    lines = BLOCK_COMMENT_RE.sub("", text).splitlines()
+    action_at = None
+    for i, ln in enumerate(lines):
+        if ACTION_LINE_RE.match(ln):
+            action_at = i
+    if action_at is None:
+        return False
+    tail = re.compile(
+        r"^\s*(dealer|predeal|vulnerable|condition|produce|generate)\b", re.IGNORECASE
+    )
+    return any(tail.match(ln) for ln in lines[action_at + 1:])
+
+
+# --------------------------------------------------------------------------
+# Redundancy: imports and body signatures
+# --------------------------------------------------------------------------
+
+# The PBS `.dlr` files are generated: a precompiler expands shared fragments
+# inline and brackets each one with markers. Two spellings are in use, and the
+# closing marker is not always spelled the same as its opener
+# ("1-Bid North" opens, "1-Bid-North" closes), so only openers are matched.
+IMPORT_OPEN_RE = re.compile(
+    r"^#{3,}\s*Imported Script\s*(?::|--)\s*(.*?)\s*#{3,}\s*$", re.MULTILINE)
+IMPORT_ANY_RE = re.compile(
+    r"^#{3,}\s*(?:End of\s+)?Imported Script\s*(?::|--)\s*.*?#{3,}\s*$", re.MULTILINE)
+
+
+def imported_fragments(text):
+    """Names of the shared fragments a generated script pulled in."""
+    return sorted({n for n in IMPORT_OPEN_RE.findall(text) if n})
+
+
+def body_signature(text):
+    """A key that is equal for two scripts doing the same evaluation work.
+
+    Expects text that has already been through normalize_script(): the
+    signature has to describe what will actually be *run*, and normalization
+    removes the `produce`/`generate` lines and the action block, which vary
+    across otherwise-identical family members and would otherwise make them
+    look distinct.
+
+    Comments and blank lines go, and every integer is masked. The masking is
+    what matters: the PBS corpus is full of families that differ only in a
+    threshold -- Weak_NT_09-12, _10-13, _13-15 and four more -- and as
+    benchmarks those are the same script. Measured across the real corpus,
+    members of such a family score 1.000 against each other while genuinely
+    different scripts score 0.04-0.22, so the two populations do not overlap
+    anywhere near the 0.85 threshold bench-corpus.py uses.
+    """
+    stripped = IMPORT_ANY_RE.sub("", BLOCK_COMMENT_RE.sub("", text))
+    lines = [ln.strip() for ln in stripped.splitlines()
+             if ln.strip() and not ln.strip().startswith("#")]
+    return re.sub(r"\d+", "N", " ".join(lines))
+
+
+# --------------------------------------------------------------------------
+# Targets
+# --------------------------------------------------------------------------
+
+@dataclass
+class Target:
+    """One program under test, and how to invoke it."""
+    name: str
+    kind: str                      # "local" or "ssh"
+    command: list = field(default_factory=list)
+    threaded: bool = False         # accepts -R for worker threads
+    note: str = ""
+    # Switch that asks for the run trailer carrying `Time needed`, or None to
+    # pass nothing because the program is already verbose by default. See the
+    # module docstring on why dealer.exe must be left alone here.
+    verbose_flag: object = "-v"
+    # "self"  - trust the program's own `Time needed`.
+    # "wall"  - time the process and subtract calibrated overhead.
+    # "auto"  - prefer self-reported, fall back to wall if it reports zero.
+    timing: str = "self"
+    # Filled in by calibrate_overhead(); seconds of startup/SSH to subtract
+    # from wall-clock measurements.
+    overhead: float = 0.0
+
+    def available(self):
+        if self.kind == "ssh":
+            missing = [v for v in ("WINDOWS_HOST", "WINDOWS_USER", "WINDOWS_GITHUB_HOME")
+                       if not os.environ.get(v)]
+            if missing:
+                return False, "unset: " + ", ".join(missing)
+            if not (REPO / "scripts" / "win-dealer.sh").exists():
+                return False, "scripts/win-dealer.sh missing"
+            return True, ""
+        exe = Path(self.command[0])
+        if not exe.exists():
+            return False, f"not found: {exe}"
+        if not os.access(exe, os.X_OK):
+            return False, f"not executable: {exe}"
+        return True, ""
+
+
+def dealer3_target(binary=None):
+    binary = Path(binary) if binary else REPO / "target" / "release" / "dealer"
+    return Target(
+        name="dealer3",
+        kind="local",
+        command=[str(binary)],
+        threaded=True,
+        note="built from this repo",
+        verbose_flag="-v",
+        timing="self",
+    )
+
+
+def dealer_exe_target(timeout=600):
+    """dealer.exe on the Windows VM, through scripts/win-dealer.sh.
+
+    The wrapper owns the host, the login and the drive mapping -- none of which
+    belong in this repository. Its default timeout is 10s, far too short for a
+    calibrated benchmark run, so it is raised here.
+    """
+    return Target(
+        name="dealer.exe",
+        kind="ssh",
+        command=[str(REPO / "scripts" / "win-dealer.sh"), "-t", str(timeout)],
+        threaded=False,
+        note="Windows VM via SSH; wall-clocked with SSH overhead calibrated out, "
+             "because dealer.exe reports Time needed 0.000 there",
+        verbose_flag=None,
+        timing="wall",
+    )
+
+
+def dealer_c_target(binary=None):
+    """The original C dealer, built natively for this machine.
+
+    The point of it is to take emulation out of the comparison. dealer.exe runs
+    x86-emulated on an ARM64 VM, so its throughput cannot be read as the C
+    implementation's speed; this is the same source compiled for the same
+    silicon dealer3 runs on. Built by scripts/build-dealer-c-macos.sh.
+
+    Verbose defaults on in this source too, and -v XORs it, so nothing is
+    passed. This source is newer than the VM's and does have -X, but there is
+    no reason to use it.
+    """
+    if binary:
+        path = str(binary)
+    elif os.environ.get("DEALER_C_BIN"):
+        path = os.environ["DEALER_C_BIN"]
+    else:
+        path = str(REPO.parent / "Dealer-cleanup" / "dealer")
+    return Target(
+        name="dealer-c",
+        kind="local",
+        command=[path],
+        threaded=False,
+        note="original C dealer, built natively -- the emulation-free reference "
+             "for dealer.exe's lineage",
+        verbose_flag=None,
+        timing="auto",
+    )
+
+
+def dealerv2_target(binary=None):
+    """DealerV2_4.
+
+    Resolved from --dealerv2, then $DEALERV2_BIN, then PATH. The upstream repo
+    ships only a Linux x86-64 build, so this is expected to be a local build;
+    bench-reference.py reports it as unavailable rather than failing if it is
+    not there yet.
+    """
+    if binary:
+        path = str(binary)
+    elif os.environ.get("DEALERV2_BIN"):
+        path = os.environ["DEALERV2_BIN"]
+    else:
+        path = shutil.which("dealerv2") or "/usr/local/bin/dealerv2"
+    return Target(
+        name="dealerv2_4",
+        kind="local",
+        command=[path],
+        threaded=False,
+        note="DealerV2_4",
+        # Same lineage as dealer.exe, so assume verbose-by-default and let the
+        # timing mode work out for itself whether its clock is trustworthy.
+        verbose_flag=None,
+        timing="auto",
+    )
+
+
+# --------------------------------------------------------------------------
+# Running
+# --------------------------------------------------------------------------
+
+@dataclass
+class Sample:
+    seconds: float          # the number to compare
+    wall: float             # process wall clock, including startup/SSH
+    generated: int
+    produced: int
+    timing: str = "self"    # which clock `seconds` came from
+
+    @property
+    def deals_per_sec(self):
+        return self.generated / self.seconds if self.seconds > 0 else float("nan")
+
+
+def run_once(target, script, deals, seed=1, threads=None, timeout=900):
+    """Run one script once and return a validated Sample.
+
+    Raises BenchError if the run failed, printed no timing, or generated a
+    different number of deals than asked for.
+    """
+    argv = list(target.command)
+    if target.verbose_flag:
+        argv.append(target.verbose_flag)
+    argv += ["-g", str(deals), "-p", str(NO_PRODUCE_LIMIT), "-s", str(seed)]
+    if threads is not None and target.threaded:
+        argv += ["-R", str(threads)]
+    argv.append(str(script))
+
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        raise BenchError(f"{target.name}: timed out after {timeout}s on {Path(script).name}")
+    wall = time.monotonic() - started
+
+    out = proc.stdout + proc.stderr
+    if proc.returncode != 0:
+        raise BenchError(f"{target.name}: exit {proc.returncode} on "
+                         f"{Path(script).name}: {_first_real_line(out)}")
+
+    m = TIME_RE.search(out)
+    reported = float(m.group(1)) if m else 0.0
+
+    # Which clock to believe. A self-reported zero is not a fast run, it is a
+    # broken timer (dealer.exe on Windows does this unconditionally), so "auto"
+    # treats it as absent rather than as 0.000 seconds.
+    if target.timing == "wall" or (target.timing == "auto" and reported <= 0.0):
+        seconds = max(wall - target.overhead, 1e-6)
+        timing = "wall"
+    else:
+        if not m:
+            raise BenchError(
+                f"{target.name}: no 'Time needed' line on {Path(script).name} "
+                "-- wrong verbose flag, or the run trailer is switched off"
+            )
+        seconds = reported
+        timing = "self"
+
+    g = GENERATED_RE.search(out)
+    p = PRODUCED_RE.search(out)
+    if not g:
+        raise BenchError(f"{target.name}: no 'Generated' line on {Path(script).name}")
+    generated = int(g.group(1))
+    produced = int(p.group(1)) if p else 0
+
+    # The whole point of fixing work with -g. A short run means a produce
+    # limit or a stray script statement bound first, and the timing describes
+    # a different amount of work than every other target's.
+    if generated != deals:
+        raise BenchError(
+            f"{target.name}: asked for {deals} deals, generated {generated} "
+            f"on {Path(script).name} -- something overrode -g"
+        )
+
+    return Sample(seconds=seconds, wall=wall, generated=generated,
+                  produced=produced, timing=timing)
+
+
+def run_repeated(target, script, deals, seed=1, threads=None, repeats=3, timeout=900):
+    """Run repeatedly and summarise.
+
+    `best` is the headline number. The fastest of several runs is the least
+    contaminated by whatever else the machine was doing; the median and the
+    spread are kept so a noisy result is visible rather than averaged in.
+    """
+    samples = [run_once(target, script, deals, seed, threads, timeout)
+               for _ in range(repeats)]
+    times = sorted(s.seconds for s in samples)
+    best = times[0]
+    return {
+        "seconds_best": best,
+        "seconds_median": statistics.median(times),
+        "seconds_all": times,
+        "spread_pct": (times[-1] - best) / best * 100 if best > 0 else 0.0,
+        "deals": deals,
+        "deals_per_sec": deals / best if best > 0 else float("nan"),
+        "produced": samples[0].produced,
+        "wall_best": min(s.wall for s in samples),
+        "timing": samples[0].timing,
+        "overhead_subtracted": target.overhead if samples[0].timing == "wall" else 0.0,
+    }
+
+
+def calibrate_overhead(target, script, repeats=3, deals=1000):
+    """Measure and store what a run costs before any dealing happens.
+
+    Only matters for wall-clocked targets. A run of `deals` deals is small
+    enough that its generate loop is a rounding error, so what is left is
+    process startup plus -- for the Windows VM -- the SSH round trip and the
+    drive mapping. The fastest of several attempts is used, on the same
+    reasoning as everywhere else here: the floor is the honest estimate of
+    fixed cost, and anything above it was the network having a bad moment.
+
+    Under-subtracting is the safe direction. It makes a target look slower than
+    it is, never faster, so a favourable comparison is never an artefact of
+    this number.
+    """
+    if target.timing == "self":
+        return 0.0
+    target.overhead = 0.0
+    walls = []
+    for _ in range(repeats):
+        try:
+            walls.append(run_once(target, script, deals).wall)
+        except BenchError:
+            continue
+    target.overhead = min(walls) if walls else 0.0
+    return target.overhead
+
+
+# --------------------------------------------------------------------------
+# Corpus + results I/O
+# --------------------------------------------------------------------------
+
+def load_corpus():
+    if not CORPUS_INDEX.exists():
+        raise BenchError(
+            f"no corpus at {CORPUS_INDEX.relative_to(REPO)} -- run scripts/bench-corpus.py first"
+        )
+    entries = json.loads(CORPUS_INDEX.read_text())["scripts"]
+    for e in entries:
+        e["path"] = CORPUS_DIR / e["file"]
+    return entries
+
+
+def representative(corpus):
+    """The single script to use when one has to stand for the corpus.
+
+    The median cost per deal, so it is neither the cheapest condition (where
+    dealing dominates and evaluation changes barely show) nor the most
+    expensive outlier. Deterministic, so two runs of --quick are comparable to
+    each other -- which is the whole point when iterating on a change.
+    """
+    ranked = sorted(corpus, key=lambda e: e.get("seconds_per_deal_r1", 0))
+    return ranked[len(ranked) // 2]
+
+
+def git_describe():
+    for args in (["git", "describe", "--always", "--dirty"], ["git", "rev-parse", "--short", "HEAD"]):
+        try:
+            out = subprocess.run(args, cwd=REPO, capture_output=True, text=True, timeout=10)
+            if out.returncode == 0 and out.stdout.strip():
+                return out.stdout.strip()
+        except (OSError, subprocess.SubprocessError):
+            pass
+    return "unknown"
+
+
+def machine_info():
+    def sysctl(key):
+        try:
+            out = subprocess.run(["sysctl", "-n", key], capture_output=True, text=True, timeout=5)
+            return out.stdout.strip() if out.returncode == 0 else ""
+        except (OSError, subprocess.SubprocessError):
+            return ""
+    return {
+        "model": sysctl("hw.model"),
+        "cpu": sysctl("machdep.cpu.brand_string"),
+        "logical_cpus": sysctl("hw.ncpu"),
+        "performance_cpus": sysctl("hw.perflevel0.logicalcpu"),
+        "efficiency_cpus": sysctl("hw.perflevel1.logicalcpu"),
+    }
+
+
+def windows_vm_info():
+    """What the VM actually is, recorded so the dealer.exe number can be read right.
+
+    It matters more than it looks. dealer.exe is a PE32/i386 binary, and if the
+    VM is ARM64 Windows -- which it is on an Apple Silicon host -- then it runs
+    under x86 emulation. Its throughput then describes "dealer.exe as run on
+    this VM", which is a real thing to know, but not the speed of the C
+    implementation. DealerV2_4 built natively is the like-for-like reference.
+
+    Host and login come from the environment, never from a file in this repo.
+    """
+    host, user = os.environ.get("WINDOWS_HOST"), os.environ.get("WINDOWS_USER")
+    if not host or not user:
+        return {}
+    try:
+        out = subprocess.run(
+            ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=8", f"{user}@{host}",
+             "echo %PROCESSOR_ARCHITECTURE% & echo %PROCESSOR_IDENTIFIER% "
+             "& echo %NUMBER_OF_PROCESSORS%"],
+            capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    lines = [ln.strip() for ln in out.stdout.splitlines() if ln.strip()]
+    if len(lines) < 3:
+        return {}
+    return {"architecture": lines[0], "identifier": lines[1], "cpus": lines[2],
+            "note": "dealer.exe is PE32/i386; on an ARM64 VM it runs emulated"}
+
+
+def write_results(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload.setdefault("written", time.strftime("%Y-%m-%d %H:%M:%S"))
+    payload.setdefault("machine", machine_info())
+    path.write_text(json.dumps(payload, indent=2, default=_json_default) + "\n")
+    return path
+
+
+def _json_default(obj):
+    if isinstance(obj, Path):
+        return str(obj)
+    if hasattr(obj, "__dataclass_fields__"):
+        return asdict(obj)
+    raise TypeError(f"not JSON serialisable: {type(obj)}")

--- a/scripts/benchlib.py
+++ b/scripts/benchlib.py
@@ -556,6 +556,36 @@ def load_corpus():
     return entries
 
 
+def source_fingerprint():
+    """A short hash of the Rust source that produces the dealer3 binary.
+
+    `git describe` is the wrong key for a dealer3 measurement. It reports the
+    state of the whole repository, so editing this harness marks a result
+    "-dirty" even though the binary is byte-identical, and two results taken
+    from the same code can end up labelled differently. What a performance
+    number is about is the code that ran.
+
+    Hashes every crate's Rust sources and manifests. `wasm/` is excluded: it is
+    its own workspace and is not part of the CLI binary.
+
+    Limitation worth knowing: the sibling crates patched in through
+    .cargo/config.toml (bridge-types, bridge-solver, bridge-encodings) live
+    outside this repository and are not covered. A change there moves the
+    numbers without moving this hash.
+    """
+    h = hashlib.sha256()
+    files = sorted(
+        [p for p in REPO.glob("*/src/**/*.rs") if "wasm/" not in str(p.relative_to(REPO))]
+        + [p for p in REPO.glob("*/Cargo.toml") if "wasm/" not in str(p.relative_to(REPO))]
+        + [REPO / "Cargo.toml"]
+    )
+    for path in files:
+        if path.exists():
+            h.update(str(path.relative_to(REPO)).encode())
+            h.update(path.read_bytes())
+    return h.hexdigest()[:12]
+
+
 def corpus_fingerprint(entries):
     """A short hash of what the corpus actually is.
 

--- a/scripts/benchlib.py
+++ b/scripts/benchlib.py
@@ -600,7 +600,12 @@ def corpus_fingerprint(entries):
     which is precisely when a measurement stops being comparable.
     """
     h = hashlib.sha256()
-    for e in sorted(entries, key=lambda e: e["name"]):
+    # Verify-only entries are deliberately excluded. They are never timed, so
+    # adding or changing one cannot make an existing measurement incomparable
+    # -- and if they counted, adding a correctness check would invalidate a set
+    # of reference numbers that took minutes of SSH round trips to produce.
+    for e in sorted((e for e in entries if not e.get("verify_only")),
+                    key=lambda e: e["name"]):
         h.update(e["name"].encode())
         h.update(str(e["deals"]).encode())
         path = CORPUS_DIR / e["file"]

--- a/scripts/benchlib.py
+++ b/scripts/benchlib.py
@@ -94,6 +94,40 @@ hcp(north) >= 24
 action average "bench" hcp(north)
 """
 
+# A synthetic entry that checks dealer3 and DealerV2_4 agree about
+# double-dummy results, over identical deals.
+#
+# dealer.exe and dealer-c have no solver at all -- they answer `dds` with a
+# syntax error -- so this entry names the targets it applies to and is skipped
+# elsewhere. It is verify-only: its cost is dominated by solving the deals it
+# produces rather than by filtering the ones it generates, and the two programs
+# do not produce the same *number* of deals from a fixed -g, so it would not be
+# a comparable throughput measurement.
+#
+# Every token here has to parse in both. DealerV2_4's lexer is case-sensitive
+# and disagrees with itself about case: compasses are lowercase (`north`) but
+# sides are uppercase (`NS`). dealer3 accepts that spelling too, so `par(NS)`
+# and `dds(north, ...)` is the combination that runs on both unchanged.
+#
+# `par` is the strongest check available: it is derived from all twenty
+# double-dummy results, so agreeing on it means agreeing on the whole table,
+# not on one search that happened to match.
+SOLVER_NAME = "_solver_agreement"
+SOLVER_TARGETS = ["dealer3", "dealerv2_4"]
+SOLVER_SCRIPT = """# Synthetic. Not from Practice-Bidding-Scenarios.
+#
+# Checks that dealer3 and DealerV2_4 return the same double-dummy results for
+# the same cards. dealer.exe and dealer-c have no solver and are excluded.
+#
+# Spellings are the intersection of the two languages: `north` lowercase,
+# `NS` uppercase. See SOLVER_NAME in scripts/benchlib.py.
+condition hcp(north) + hcp(south) >= 26
+action
+    average "dds north notrump" dds(north, notrump),
+    average "dds south spades" dds(south, spades),
+    average "par NS" par(NS)
+"""
+
 # The action every corpus script gets, replacing whatever it had. Cheap, runs
 # only on produced deals, and prints one line regardless of hit rate -- so the
 # measurement is condition-evaluation throughput and not output I/O.

--- a/scripts/build-dealer-c-macos.sh
+++ b/scripts/build-dealer-c-macos.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# build-dealer-c-macos.sh - Build the original C dealer natively on macOS.
+#
+# Why this is worth having: the benchmark's dealer.exe leg runs on an ARM64
+# Windows VM, and dealer.exe is a PE32/i386 binary, so it goes through x86
+# emulation. That number is honest about what running dealer.exe costs in
+# practice, but it says nothing about how fast the original C implementation
+# is. Built natively here, the same source becomes a like-for-like opponent for
+# a native dealer3 -- same silicon, no emulation, no VM.
+#
+#   scripts/build-dealer-c-macos.sh
+#   scripts/bench-reference.py            # picks it up automatically
+#
+# The source list mirrors upstream's make.bat. Everything needed is already in
+# the checkout, including __random.c -- the GNU random() port -- so the RNG is
+# the original's rather than a substitute. scan.c and y.tab.c are committed
+# pre-generated, so flex and bison are only run if they are missing.
+#
+# A note on that RNG. Built as a 64-bit Mach-O, __random.c does 64-bit
+# arithmetic, whereas dealer.exe is 32-bit and Windows is LLP64. The two data
+# models differ only in bit 31, and dealer indexes its card table from bits
+# 15..=30 -- so this binary deals *the same boards as dealer.exe*, which was
+# checked directly: byte-identical PBN over 400 deals at seed 1 and 200 each at
+# seeds 42 and 12345, modulo CRLF.
+#
+# That makes it a local stand-in for dealer.exe wherever the deals themselves
+# matter, at roughly six times the speed and with no SSH round trip. See
+# dealer-legacy-shuffle's PROVENANCE.md for the disassembly and the captured
+# vectors, and do not re-derive any of it.
+set -euo pipefail
+
+SRC="${DEALER_C_SRC:-$(cd "$(dirname "$0")/../.." && pwd)/Dealer-cleanup}"
+
+if [[ ! -f "$SRC/dealer.c" ]]; then
+    echo "error: no C dealer source at $SRC" >&2
+    exit 1
+fi
+cd "$SRC"
+
+if [[ ! -f y.tab.c ]]; then
+    echo "==> bison defs.y"
+    bison -y -d defs.y
+fi
+if [[ ! -f scan.c ]]; then
+    echo "==> flex scan.l"
+    flex -o scan.c scan.l          # included by y.tab.c, not compiled on its own
+fi
+
+# The source list is upstream's make.bat, and scan.c is deliberately absent
+# from it: defs.y ends with `#include "scan.c"`, so the scanner is compiled as
+# part of y.tab.c. Passing it separately instead fails with every token
+# undeclared, because scan.l has no prologue including y.tab.h -- it relies on
+# being textually inside the parser.
+#
+# -Wno-everything: this is 2003-era C compiled by a 2020s clang, and the
+# warnings are all about the era rather than anything worth fixing here.
+# -O2 because an unoptimized build would make the comparison meaningless.
+echo "==> clang -O2"
+clang -O2 -Wno-everything -o dealer \
+    dealer.c pbn.c c4.c getopt.c pointcount.c \
+    __random.c rand.c srand.c y.tab.c -lm
+
+echo
+echo "Built $SRC/dealer  ($(lipo -archs dealer))"
+./dealer -V 2>&1 | head -2 || true

--- a/scripts/build-dealerv2-macos.sh
+++ b/scripts/build-dealerv2-macos.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# build-dealerv2-macos.sh - Build DealerV2_4 natively on macOS/arm64.
+#
+# The upstream repo ships a Linux x86-64 binary and a Linux libdds.a, neither
+# of which runs here, so the third leg of the performance comparison has to be
+# built. Everything this needs is in the upstream tree already -- including the
+# DDS 2.9.0 source tarball -- so there is nothing to fetch beyond the clone.
+#
+#   git clone https://github.com/dealerv2/Dealer-Version-2-.git ../Dealer-Version-2-
+#   scripts/build-dealerv2-macos.sh
+#   export DEALERV2_BIN=../Dealer-Version-2-/macos-build/dealerv2
+#
+# Four things upstream assumes that macOS does not provide, and what is done
+# about each:
+#
+#   1. DDS is built with -Werror and trips over deprecated sprintf() and a
+#      non-UTF-8 comment. -Werror is dropped; both warnings are cosmetic.
+#   2. DDS's Mac makefile wants Boost for threading. DDS supports several
+#      backends, so it is built with GCD + STL instead. Irrelevant to the
+#      benchmark either way, which calls no double-dummy functions.
+#   3. -mtune=corei7 is x86-only, and -fopenmp needs libomp. Both are dropped;
+#      DealerV2_4 contains no OpenMP pragmas or API calls at all, so the flag
+#      was vestigial. (Which also confirms it is single-threaded.)
+#   4. <malloc.h> and getrandom() are glibc-isms. Both get a shim in
+#      macos-build/include/. getrandom() is reached only when no -s seed is
+#      given, which the benchmark never does.
+#
+# The result is a native arm64 binary that is a fair opponent for a native
+# arm64 dealer3. A cross-architecture or emulated build would not be.
+set -euo pipefail
+
+V2="${DEALERV2_SRC:-$(cd "$(dirname "$0")/../.." && pwd)/Dealer-Version-2-}"
+OUT="$V2/macos-build"
+
+if [[ ! -d "$V2/src" ]]; then
+    echo "error: no DealerV2 checkout at $V2" >&2
+    echo "  git clone https://github.com/dealerv2/Dealer-Version-2-.git \"$V2\"" >&2
+    exit 1
+fi
+
+# Homebrew bison; Apple's is 2.3 and too old for dealyacc.y.
+export PATH="/opt/homebrew/opt/bison/bin:${PATH}"
+if ! bison --version 2>/dev/null | head -1 | grep -qE '3\.[0-9]+'; then
+    echo "error: need bison 3.x (brew install bison)" >&2
+    exit 1
+fi
+
+echo "==> Preparing $OUT"
+rm -rf "$OUT"
+mkdir -p "$OUT/lib"
+cp -R "$V2/src" "$V2/include" "$V2/Prod" "$OUT/"
+rm -f "$OUT/Prod/dealerv2" "$OUT/Prod"/*.o          # upstream's Linux artifacts
+
+echo "==> Building DDS 2.9.0 for arm64"
+tar xzf "$V2/lib/dds290-src_2022.tar.gz" -C "$OUT"
+DDS="$OUT/dds290-src/src"
+rm -f "$DDS"/*.o "$DDS/libdds.a"                     # ditto, the tarball ships Linux .o
+cp "$DDS/Makefiles/Makefile_Mac_clang_static" "$DDS/Makefile.mac"
+sed -i '' \
+    -e 's/-Werror//g' \
+    -e 's/-mtune=[a-z0-9]*//g; s/-march=[a-z0-9]*//g' \
+    -e 's/^THREADING	= .*/THREADING	= $(THR_GCD) $(THR_STL)/' \
+    -e 's/^THREAD_LINK	= .*/THREAD_LINK	=/' \
+    "$DDS/Makefile.mac"
+make -C "$DDS" -f Makefile.mac -j"$(sysctl -n hw.ncpu)" >/dev/null
+cp "$DDS/libdds.a" "$OUT/lib/"
+cp "$OUT/dds290-src/include/"*.h "$OUT/include/" 2>/dev/null || true
+echo "    libdds.a: $(lipo -archs "$OUT/lib/libdds.a")"
+
+echo "==> Writing glibc shims"
+printf '#pragma once\n#include <stdlib.h>\n#include <malloc/malloc.h>\n' \
+    > "$OUT/include/malloc.h"
+cat > "$OUT/include/macos_compat.h" <<'EOF'
+/* macOS shims for DealerV2_4, which is written against glibc.
+ *
+ * getrandom(2) is Linux-only. DealerV2_4 calls it in one place, init_rand48(),
+ * and only when no -s seed was supplied. getentropy(3) has the same contract
+ * for buffers up to 256 bytes; the call site asks for 6.
+ */
+#pragma once
+#if defined(__APPLE__)
+#include <sys/random.h>
+#include <sys/types.h>
+static inline ssize_t getrandom(void *buf, size_t len, unsigned int flags) {
+    (void)flags;
+    return getentropy(buf, len) == 0 ? (ssize_t)len : -1;
+}
+#endif
+EOF
+
+echo "==> Building dealerv2"
+sed -i '' \
+    -e 's/^CC      = gcc/CC      = clang/' \
+    -e 's/^CXX = g++/CXX = clang++/' \
+    -e 's/-mtune=corei7//g; s/-flto//g; s/-fopenmp//g' \
+    -e 's/-Wall -pedantic/-Wall -Wno-everything/' \
+    -e 's|-I\.\./include|-I../include -include macos_compat.h|g' \
+    "$OUT/Prod/Makefile"
+make -C "$OUT/Prod" >/dev/null
+cp "$OUT/Prod/dealerv2" "$OUT/dealerv2"
+
+echo
+echo "Built $OUT/dealerv2  ($(lipo -archs "$OUT/dealerv2"))"
+"$OUT/dealerv2" -h 2>&1 | head -3 || true
+echo
+echo "Point the benchmark at it with:"
+echo "  export DEALERV2_BIN=\"$OUT/dealerv2\""

--- a/scripts/build-dealerv2-macos.sh
+++ b/scripts/build-dealerv2-macos.sh
@@ -21,7 +21,16 @@
 #      benchmark either way, which calls no double-dummy functions.
 #   3. -mtune=corei7 is x86-only, and -fopenmp needs libomp. Both are dropped;
 #      DealerV2_4 contains no OpenMP pragmas or API calls at all, so the flag
-#      was vestigial. (Which also confirms it is single-threaded.)
+#      is vestigial.
+#
+#      That is *not* the same as DealerV2_4 being single-threaded. Its own
+#      deal-and-filter loop is single-threaded, but its double-dummy solving is
+#      not: -R sets nThreads, which is handed to the DDS library through
+#      SetResources(maxMemoryMB, maxThreads), and table mode (-M 2) silently
+#      defaults it if you did not ask. So the benchmark corpus -- which calls
+#      no solver function -- measures it single-threaded, while anything using
+#      dds() or par() does not. Which is why DDS is built here with a real
+#      threading backend rather than none.
 #   4. <malloc.h> and getrandom() are glibc-isms. Both get a shim in
 #      macos-build/include/. getrandom() is reached only when no -s seed is
 #      given, which the benchmark never does.

--- a/scripts/win-dealer.sh
+++ b/scripts/win-dealer.sh
@@ -93,9 +93,15 @@ SSH_OPTS="-o ConnectTimeout=5 -o BatchMode=yes"
 
 # Map G: drive to GitHub folder (must be done each SSH session)
 # Parallels maps \\Mac\Home to macOS $HOME, so strip $HOME prefix
+#
+# /y matters: if the VM has a *different* path remembered for G: -- which it
+# will if $WINDOWS_GITHUB_HOME ever changed -- `net use` stops to ask whether
+# to overwrite it. An SSH session has nobody to answer, so the mapping is left
+# as it was and every path built below resolves against the wrong root. The
+# failure reads as "No such file or directory" for files that plainly exist.
 _REL="${WINDOWS_GITHUB_HOME#$HOME}"
 _UNC="\\\\Mac\\Home${_REL//\//\\}"
-DRIVE_MAP="net use G: \"${_UNC}\" >nul 2>&1 & "
+DRIVE_MAP="net use G: \"${_UNC}\" /y >nul 2>&1 & "
 SSH_TARGET="${WINDOWS_USER}@${WINDOWS_HOST}"
 
 # Run command with timeout (kills if exceeded)


### PR DESCRIPTION
Builds a performance comparison between `dealer.exe`, the original C dealer,
DealerV2_4 and dealer3 — and then acts on what it measured.

## The harness

Five scripts in `scripts/`, split so the expensive half is rarely run.
`bench-reference.py` measures the three reference programs and only needs
re-running when the corpus or one of those builds changes; `bench-dealer3.py`
runs whenever dealer3 does. `bench-report.py` joins them, `bench-verify.py`
checks the two agree about what a script *means*, and `bench-dds.py` compares
double-dummy throughput. `bench/README.md` explains how to read the numbers.

Two reference binaries had to be built, and both build scripts are here.
DealerV2_4 ships only a Linux x86-64 binary and libdds.a; four glibc-isms need
shimming. The original C dealer is built natively because the Windows VM is
ARM64 while `dealer.exe` is PE32/i386 — it runs x86-emulated, so its throughput
cannot be read as the C implementation's speed. That native build **deals the
same boards as dealer.exe**, verified byte-identical over 400 deals at seed 1
and 200 each at seeds 42 and 12345, so it is also a local stand-in wherever the
deals themselves matter — six times faster and no SSH.

The corpus is ten scripts from Practice-Bidding-Scenarios, vendored, verified to
run on all four programs, deduplicated, and calibrated so each contributes a
comparable measurement. 286 of 347 candidates run everywhere; 202 are distinct.
Deduplication matters because the `.dlr` files are generated — a precompiler
expands shared fragments inline, 155 scripts pull in at least one of ten, and
whole families differ only in a threshold. One synthetic entry isolates deal
generation so the RNG and shuffle can be read separately from filtering.

Four traps it exists to avoid, each of which quietly produces a plausible wrong
number: a script's own `produce`/`generate` beats the command line (`yyparse()`
runs after `getopt()`); `-v` turns dealer.exe's timing *off*, because its
verbose flag defaults on and the switch XORs it; dealer.exe's clock is stubbed
on Windows and always prints `0.000`; and work has to be fixed with `-g`, not
`-p`, since the programs do not deal alike.

## What it found, and what was done

**Single-threaded, dealer3 was slower than both native C dealers** — 0.6x the
original and 0.9x DealerV2_4. Splitting generation from evaluation showed why:
evaluation was competitive, generation was three times slower and 38% of the
per-deal cost.

The cause was `sort_all_hands()` on every deal generated, costing two thirds of
generation, while a run keeps well under 1% of the deals it makes. Nothing
needed it — counting functions are order-blind, the three that care about rank
position sort their own copies, every formatter re-sorts, the double-dummy memo
key is a bitmask. `Hand`'s equality did depend on it, so that now compares a
card mask instead, which is correct without the invariant and cheaper.

**Result: 1.60x faster single-threaded across the corpus, generation 2.84x.**
Generation is now at parity with the 2003 C dealer (188ns against 176), and
dealer3 runs 0.9x it and 1.3x DealerV2_4 — beating the modern fork outright.
Threaded it is about 4.4x the C dealer.

Also fixes a bug found while reading that code: `losers_in_suit`,
`suit_quality` and `cccc` read the raw thirteen-slot array rather than the
length-bounded slice, so a partial hand had its filler counted — and the filler
is a club two, so a void reported three losers. The test fails without the fix.

## Corrections in the history

Two claims I got wrong and fixed in place rather than leaving to mislead:

- DealerV2_4 is **not** simply single-threaded. Its deal loop is, but `-R` sets
  DDS's thread count. The corpus calls no solver function so the measurements
  stand, but the claim did not.
- The first double-dummy comparison reported a ratio between one thread and
  four. `bench-dds.py` now measures CPU with `getrusage` instead of trusting a
  thread switch — needed, because DealerV2_4 cannot be run single-threaded in
  table mode at all.

## Results, and what is not fixed

`bench/results/` carries the before and after, keyed by a hash of the Rust
source and of the corpus content rather than by `git describe`, so a result
names the code that produced it.

Two findings are filed rather than fixed:

- bridge-craftwork/bridge-solver#13 — the solver is single-threaded everywhere.
  3.24x slower on wall clock than DDS 2.9, of which 2.17x is parallelism and
  1.50x is per-core cost.
- #54 — `par()` ignores vulnerability entirely, returning the same score for
  None, NS, EW and All.

Verified beyond the unit tests: every corpus script still accepts every deal
dealer.exe and DealerV2_4 produced for it, with matching statistics, and
dealer3 and DealerV2_4 agree on double-dummy results over identical cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)