### PR TITLE
Emit the reference as plain text, and serve real 404s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ bench/.staging/
 bench/.verify/
 bench/.dds/
 scripts/__pycache__/
+
+# Generated at build time by web/scripts/emit-reference.mjs
+web/public/reference.txt

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,9 @@
     "build:all": "npm run wasm && vite build",
     "build:threaded": "npm run wasm:threaded && vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "reference": "node scripts/emit-reference.mjs",
+    "prebuild": "npm run reference"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/web/public/404.html
+++ b/web/public/404.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Not found — dealer3</title>
+
+<!--
+  Cloudflare Pages serves this file, with a 404 status, for any path that does
+  not match a real asset. Without it Pages falls back to index.html at 200, so
+  every guessed URL looked like a page that existed: /docs, /help and
+  /reference.md all returned the app shell. A client fetching URLs could not
+  tell "missing" from "present but empty", which is worse than a plain 404 —
+  especially for an assistant trying to find the language reference.
+
+  The real routes are unaffected: /reference and /leveling are actual files
+  (reference.html, leveling.html) and are matched before this is reached.
+-->
+
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+         max-width: 34rem; margin: 18vh auto 0; padding: 0 1.5rem; line-height: 1.6; color: #1a1a1a }
+  h1 { font-size: 1.25rem; font-weight: 500; margin: 0 0 .5rem }
+  p { color: #6b7280; margin: 0 0 1rem }
+  a { color: #334155 }
+  ul { color: #6b7280; padding-left: 1.1rem }
+</style>
+</head>
+<body>
+  <h1>Not found</h1>
+  <p>There is no page at that address.</p>
+  <ul>
+    <li><a href="/">The generator</a></li>
+    <li><a href="/reference">Language reference</a> — also as
+        <a href="/reference.txt">plain text</a></li>
+    <li><a href="/leveling">Levelling guide</a></li>
+  </ul>
+</body>
+</html>

--- a/web/scripts/emit-reference.mjs
+++ b/web/scripts/emit-reference.mjs
@@ -1,0 +1,62 @@
+/**
+ * Emits `public/reference.txt` — the language reference as plain text.
+ *
+ * Runs before `vite build` (see the `prebuild` script), so Vite copies the
+ * result out of `public/` verbatim and it lands at the root of the deploy,
+ * reachable at /reference.txt on this project's own domain and at
+ * /dealer3/reference.txt through the site mount.
+ *
+ * It loads the SAME wasm engine the page loads and calls the SAME
+ * `language_info()`, so the text and the page cannot drift into describing
+ * different languages. Requires `npm run wasm` to have run first; the module
+ * will not be there otherwise, and failing loudly here beats shipping a site
+ * whose reference is silently a build old.
+ */
+import { readFile, writeFile } from 'node:fs/promises'
+import { renderReferenceText, expectedNames } from '../src/lib/referenceText.js'
+
+const WASM_JS = new URL('../src/wasm/dealer3_wasm.js', import.meta.url)
+const WASM_BIN = new URL('../src/wasm/dealer3_wasm_bg.wasm', import.meta.url)
+const OUT = new URL('../public/reference.txt', import.meta.url)
+
+let engine
+try {
+  engine = await import(WASM_JS.href)
+} catch {
+  console.error('The wasm engine is not built. Run `npm run wasm` first.')
+  process.exit(1)
+}
+
+// The `--target web` build expects to fetch its own binary; in Node we hand it
+// the bytes directly.
+await engine.default({ module_or_path: await readFile(WASM_BIN) })
+
+const info = JSON.parse(engine.language_info())
+const version = engine.version()
+const text = renderReferenceText(info, version)
+
+// A dropped section is the failure worth guarding against: the file would still
+// look like a reference while missing a third of the language, and nothing
+// downstream would notice. Cheap to check, so check.
+const missing = expectedNames(info).filter((name) => !text.includes(name))
+if (missing.length) {
+  console.error(
+    `reference.txt is missing ${missing.length} entr${missing.length === 1 ? 'y' : 'ies'} ` +
+      `the engine declares: ${missing.slice(0, 12).join(', ')}${missing.length > 12 ? ' …' : ''}`,
+  )
+  process.exit(1)
+}
+
+// #2 asks for >20000 characters as the acceptance test for this being real
+// content rather than a shell. Assert it here so the build catches it, not a
+// curl three deploys later.
+if (text.length < 20000) {
+  console.error(`reference.txt is only ${text.length} characters — expected well over 20000.`)
+  process.exit(1)
+}
+
+await writeFile(OUT, text, 'utf8')
+console.log(
+  `reference.txt: ${text.length} characters, ` +
+    `${expectedNames(info).length} entries, engine ${version}`,
+)

--- a/web/src/lib/referenceText.js
+++ b/web/src/lib/referenceText.js
@@ -1,0 +1,153 @@
+/**
+ * The language reference as plain text.
+ *
+ * The reference page is rendered by Vue from `language_info()`, which means it
+ * does not exist until the page has loaded and hydrated. Anything that fetches
+ * a URL without running JavaScript — which is most assistants, and every
+ * search engine's cheap path — sees 28 characters of shell where ~25,000
+ * characters of reference should be.
+ *
+ * This renders the same data to text at build time, so `/dealer3/reference.txt`
+ * carries the whole thing with no JavaScript. It takes the SAME `info` object
+ * the page renders and reuses the SAME grouping helpers, so the two cannot
+ * describe different languages.
+ *
+ * Deliberately no timestamp: the output must be a pure function of the engine,
+ * or every build would produce a diff and the coverage check below would be
+ * comparing against noise.
+ */
+import { functionSections, operatorLevels, statementSections, wordLists } from './reference.js'
+
+const WIDTH = 78
+
+/** Wrap prose to WIDTH, indented, leaving existing line breaks alone. */
+function wrap(text, indent = '    ') {
+  const out = []
+  for (const para of String(text).split('\n')) {
+    let line = indent
+    for (const word of para.split(/\s+/).filter(Boolean)) {
+      if (line.length + word.length + 1 > WIDTH && line.trim()) {
+        out.push(line)
+        line = indent + word
+      } else {
+        line = line.trim() ? `${line} ${word}` : indent + word
+      }
+    }
+    out.push(line)
+  }
+  return out.join('\n')
+}
+
+// Wide enough for the longest label ("Signature") plus a space. Too narrow and
+// the longest labels run straight into their value with no separator.
+const LABEL_WIDTH = 15
+
+function field(label, value, out) {
+  if (!value) return
+  const head = `    ${label}:`.padEnd(LABEL_WIDTH)
+  const body = wrap(value, ' '.repeat(LABEL_WIDTH)).slice(LABEL_WIDTH)
+  out.push(head + body)
+}
+
+function entryBlock(heading, doc, out) {
+  out.push(`  ${heading}`)
+  field('Signature', doc.signature, out)
+  field('Form', doc.form, out)
+  if (doc.alias_of) field('Alias of', doc.alias_of, out)
+  field('Summary', doc.summary, out)
+  field('Example', doc.example, out)
+  field('Note', doc.note, out)
+  out.push('')
+}
+
+/**
+ * Every name the reference is expected to mention, for the emitter's coverage
+ * check. A silently dropped section is the failure this guards against — the
+ * text would still look plausible while missing a third of the language.
+ */
+export function expectedNames(info) {
+  return [
+    ...(info.function_docs ?? []).map((d) => d.name),
+    ...(info.operator_docs ?? []).map((d) => d.symbol),
+    ...(info.statement_docs ?? []).map((d) => d.keyword || d.form),
+    ...(info.action_docs ?? []).map((d) => d.name),
+    ...(info.not_supported ?? []).map((d) => d.name),
+  ].filter(Boolean)
+}
+
+export function renderReferenceText(info, version = '') {
+  const out = []
+  const rule = (t) => { out.push(t); out.push('='.repeat(t.length)); out.push('') }
+
+  rule(`dealer3 language reference${version ? ` — engine ${version}` : ''}`)
+  out.push(wrap(
+    'Every function, operator and statement dealer3 accepts. Generated from the ' +
+    "engine's own vocabulary, so it cannot list something the parser rejects, or " +
+    'leave out something it accepts.', '')
+  )
+  out.push('')
+  out.push('  Run it:  https://bridge-craftwork.com/dealer3/')
+  out.push('  Source:  https://github.com/bridge-craftwork/dealer3')
+  out.push('  Same content as https://bridge-craftwork.com/dealer3/reference')
+  out.push('')
+
+  const statements = statementSections(info)
+
+  out.push('STATEMENTS')
+  out.push('-'.repeat(10))
+  out.push('')
+  for (const doc of [...statements.keyword, ...statements.other]) {
+    entryBlock(doc.keyword || doc.form, doc, out)
+  }
+
+  out.push('FUNCTIONS')
+  out.push('-'.repeat(9))
+  out.push('')
+  for (const section of functionSections(info)) {
+    out.push(`  [${section.group}]`)
+    out.push('')
+    for (const doc of section.entries) entryBlock(doc.name, doc, out)
+  }
+
+  out.push('OPERATORS')
+  out.push('-'.repeat(9))
+  out.push('')
+  out.push(wrap('Grouped by precedence, tightest binding first.', '  '))
+  out.push('')
+  for (const level of operatorLevels(info)) {
+    out.push(`  [precedence ${level.precedence}]`)
+    out.push('')
+    for (const doc of level.entries) {
+      entryBlock(doc.word ? `${doc.symbol}   (${doc.word})` : doc.symbol, doc, out)
+    }
+  }
+
+  out.push('ACTIONS')
+  out.push('-'.repeat(7))
+  out.push('')
+  for (const doc of info.action_docs ?? []) entryBlock(doc.name, doc, out)
+
+  out.push('WORDS')
+  out.push('-'.repeat(5))
+  out.push('')
+  for (const list of wordLists(info)) {
+    out.push(`  ${list.title}`)
+    out.push(wrap((list.words ?? []).join(', ')))
+    if (list.note) out.push(wrap(list.note))
+    out.push('')
+  }
+
+  const unsupported = info.not_supported ?? []
+  if (unsupported.length) {
+    out.push('NOT SUPPORTED')
+    out.push('-'.repeat(13))
+    out.push('')
+    for (const doc of unsupported) {
+      out.push(`  ${doc.name}`)
+      field('Instead', doc.instead, out)
+      out.push('')
+    }
+  }
+
+  return out.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n'
+}

--- a/web/src/lib/referenceText.test.js
+++ b/web/src/lib/referenceText.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { renderReferenceText, expectedNames } from './referenceText.js'
+
+/** A miniature `language_info()`, shaped exactly like the engine's. */
+const info = {
+  function_groups: ['Hand evaluation'],
+  function_docs: [
+    {
+      name: 'hcp',
+      group: 'Hand evaluation',
+      signature: 'hcp(compass)',
+      summary: 'High card points.',
+      example: 'hcp(north) >= 12',
+      alias_of: null,
+      note: 'A `pointcount` statement replaces the scale.',
+    },
+    { name: 'hcps', group: 'Hand evaluation', summary: 'Alias.', alias_of: 'hcp', note: null },
+    { name: 'stray', group: 'Undeclared group', summary: 'Orphan.', alias_of: null, note: null },
+  ],
+  operator_docs: [
+    { symbol: '!', word: 'not', precedence: 1, summary: 'Negation.', example: 'not x', note: null },
+    { symbol: '+', word: null, precedence: 2, summary: 'Addition.', example: 'a + b', note: null },
+  ],
+  statement_docs: [
+    { keyword: 'condition', form: 'condition <expr>', summary: 'Keep a deal.', example: 'condition x', note: null },
+    { keyword: null, form: 'x = <expr>', summary: 'Assignment.', example: 'x = 1', note: null },
+  ],
+  action_docs: [{ name: 'printall', summary: 'All four hands.', note: null }],
+  positions: ['north', 'east', 'n', 'e'],
+  vulnerabilities: ['none', 'all'],
+  other_keywords: ['spades'],
+  not_supported: [{ name: 'evalcontract', instead: 'Use `score`.' }],
+}
+
+describe('renderReferenceText', () => {
+  const text = renderReferenceText(info, '9.9.9')
+
+  it('names every entry the engine declares', () => {
+    for (const name of expectedNames(info)) expect(text).toContain(name)
+  })
+
+  it('keeps a function whose group was never declared', () => {
+    // functionSections() collects these into an "Other" section rather than
+    // dropping them; losing one silently is the failure worth a test.
+    expect(text).toContain('stray')
+  })
+
+  it('carries the engine version', () => {
+    expect(text).toContain('9.9.9')
+  })
+
+  it('renders every section heading', () => {
+    for (const h of ['STATEMENTS', 'FUNCTIONS', 'OPERATORS', 'ACTIONS', 'WORDS', 'NOT SUPPORTED']) {
+      expect(text).toContain(h)
+    }
+  })
+
+  it('shows an operator word alongside its symbol', () => {
+    expect(text).toMatch(/!\s+\(not\)/)
+  })
+
+  it('labels an alias rather than presenting it as its own function', () => {
+    expect(text).toMatch(/Alias of:\s+hcp/)
+  })
+
+  it('is deterministic — no timestamp, so builds do not churn', () => {
+    expect(renderReferenceText(info, '9.9.9')).toBe(text)
+  })
+
+  it('wraps prose rather than emitting one long line', () => {
+    for (const line of text.split('\n')) expect(line.length).toBeLessThanOrEqual(80)
+  })
+
+  it('survives an engine that declares nothing', () => {
+    expect(() => renderReferenceText({}, '')).not.toThrow()
+  })
+})


### PR DESCRIPTION
Implements A1 and A3 from
[bridge-craftwork-site#2](https://github.com/bridge-craftwork/bridge-craftwork-site/issues/2),
under the cross-tool contract agreed in
[#3](https://github.com/bridge-craftwork/bridge-craftwork-site/issues/3).

## A1 — the reference was invisible without JavaScript

`/dealer3/reference` is **841 bytes, 28 characters of visible text**. The
~29,000-character reference only exists after hydration, so anything that fetches
a URL without running JS — most assistants, and every search engine's cheap path
— sees an empty shell.

That is the worst possible split, because the 347-file `.dlr` corpus *is* fully
fetchable from `raw.githubusercontent.com`. A model then pattern-matches hundreds
of examples with no grammar and invents syntax around the edges.

`public/reference.txt` now carries the whole thing as `text/plain`:

```
$ node scripts/emit-reference.mjs
reference.txt: 29081 characters, 96 entries, engine 1.0.0
```

It loads the **same wasm engine** the page loads, calls the **same
`language_info()`**, and reuses the **same grouping helpers** from
`lib/reference.js` — so the text and the page cannot drift into describing
different languages. No timestamp, so the output is a pure function of the
engine and builds do not churn.

**The emitter fails the build** if any entry the engine declares is missing from
the text, or if the result comes in under 20,000 characters (#2's acceptance
threshold). A dropped section is the failure worth guarding against: the file
would still look like a reference while missing a third of the language.

## A3 — unknown paths returned the app shell at 200

There is no `_redirects` and no `404.html`, so Pages falls back to `index.html`.
`/bogus` came back **byte-identical to `/`**. A client fetching URLs could not
tell "missing" from "present but empty" — `/docs`, `/help` and `/reference.md`
all looked like real pages.

`public/404.html` gives Pages something to serve.

**The real routes are untouched.** `/reference` (841b) and `/leveling` (692b) are
actual files and differ from the shell (883b) — I checked that before changing
anything, because a blanket 404 would have taken both out.

## Wiring

`prebuild`, so every build path emits it — CI included, with **no workflow
change** (npm runs `prebuild` before `build`, and the Pages job already runs
`npm run wasm` then `npm run build`).

`web/public/reference.txt` is gitignored, like `web/src/wasm/`.

## Verified

- All **156** tests pass, including 9 new ones covering the renderer: every
  declared entry present, the orphaned-group case, determinism, line wrapping,
  and an engine that declares nothing
- Full build run; both `dist/reference.txt` (29,156b) and `dist/404.html` land
- Fixed a formatting bug the tests caught: labels of 13+ characters
  (`Signature:`, `Alias of:`) ran into their values with no separator

**Not verifiable locally:** Pages' `404.html` behaviour. `/bogus` returning 404
and `/reference` still returning 200 need checking after deploy.
