### PR TITLE
Solve a batch's produced deals on the pool, not one at a time

### DIFF
--- a/dealer-dds/src/memo.rs
+++ b/dealer-dds/src/memo.rs
@@ -141,19 +141,29 @@ pub fn tricks(deal: &Deal, denomination: Denomination, declarer: Position) -> u8
 ///
 /// Laid out as `bridge_solver` wants it: seats N, E, S, W and strains C, D, H,
 /// S, NT, which is dealer's own strain numbering too.
-pub fn table(deal: &Deal) -> bridge_solver::DdTricks {
-    let mut tricks = [[0u8; 5]; 4];
+pub fn table(deal: &Deal) -> bridge_solver::DdTable {
+    let mut table = bridge_solver::DdTable::new();
     // Denomination outermost, so the four declarers share one pair of solver
     // caches — `DealAnalysis` keeps them per denomination and throws them away
     // when the denomination changes. Seat-outermost asks for a different
     // denomination on every call and so rebuilds the caches twenty times
     // instead of five, which costs about a third of the run.
     for denomination in Denomination::ALL {
-        for (seat, row) in Position::ALL.iter().zip(tricks.iter_mut()) {
-            row[denomination as usize] = self::tricks(deal, denomination, *seat);
+        for seat in Position::ALL {
+            let tricks = self::tricks(deal, denomination, seat);
+            // Both axes are converted rather than indexed. `DdTable` is keyed
+            // by `Direction` and `Strain`, and this crate counts seats and
+            // denominations its own way; the two happen to agree today, and
+            // writing the cells by name means it does not matter if they stop.
+            // Getting an axis wrong here does not fail, it negates par.
+            table.set(
+                bridge_solver::seat_to_direction(bridge_solver::direction_to_seat(seat)),
+                bridge_solver::STRAINS[denomination as usize],
+                tricks,
+            );
         }
     }
-    bridge_solver::DdTricks { tricks }
+    table
 }
 
 /// The par score, to North-South, at the given vulnerability.

--- a/dealer-run/src/dd_demand.rs
+++ b/dealer-run/src/dd_demand.rs
@@ -1,0 +1,219 @@
+//! What double-dummy work a script's `action` will ask for, per produced deal.
+//!
+//! The point is to know it *before* the deals arrive, so the batch can be
+//! solved on the worker pool instead of one cell at a time on the main thread.
+//!
+//! Why this is worth doing
+//! ----------------------
+//!
+//! Workers deal and test the condition; the main thread evaluates the action.
+//! A condition that calls `tricks()` therefore already solves in parallel —
+//! measured at 4.5 cores busy — while the same call in an action solves on one
+//! core with the pool idle. Same work, same `-R`, and on one measurement 12.1s
+//! against 1.9s.
+//!
+//! Nothing needs to move to fix that. `dealer_dds` shares a solved cell across
+//! threads the moment it is worked out, precisely so "a worker thread may only
+//! see one deal calling `tricks()` in a whole batch, and the main thread needs
+//! the answer". So the batch's deals are solved on the pool first, and the main
+//! thread's evaluation then finds every answer already there. Evaluation order,
+//! `rnd()` streams and output all stay exactly as they were.
+//!
+//! Why the demand is analysed rather than just solving whole tables
+//! ---------------------------------------------------------------
+//!
+//! A table is twenty searches and a single `tricks()` is one. `action average
+//! "x" tricks(south, spades)` asked for as a table would be twenty times the
+//! work — so the cells are read off the script where they can be, and only a
+//! genuinely table-shaped demand (`par`, `trix`, or an argument that is not a
+//! literal) asks for all twenty.
+
+use dealer_core::Position;
+use dealer_dds::Denomination;
+use dealer_parser::{CsvTerm, EsTerm, Expr, Function, Program, Statement};
+use std::collections::HashSet;
+
+/// The double-dummy cells one deal's action will need.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DdDemand {
+    /// No action expression reaches the solver. Nothing to warm.
+    None,
+    /// These (denomination, declarer) cells, and no others.
+    Cells(Vec<(Denomination, Position)>),
+    /// All twenty. `par` needs the whole table by definition, and so does a
+    /// `tricks()` whose arguments cannot be read off the script.
+    Table,
+}
+
+impl DdDemand {
+    fn add_cell(&mut self, cell: (Denomination, Position)) {
+        match self {
+            DdDemand::Table => {}
+            DdDemand::None => *self = DdDemand::Cells(vec![cell]),
+            DdDemand::Cells(cells) => {
+                if !cells.contains(&cell) {
+                    cells.push(cell);
+                }
+            }
+        }
+    }
+
+    fn widen_to_table(&mut self) {
+        *self = DdDemand::Table;
+    }
+
+    /// Solve what this demand names, so a later evaluation finds it remembered.
+    ///
+    /// Errors are not reported: this is a cache warm, and the real evaluation
+    /// that follows will raise anything genuinely wrong with its own message
+    /// and position. Failing quietly here costs a solve, not an answer.
+    pub fn warm(&self, deal: &dealer_core::Deal) {
+        match self {
+            DdDemand::None => {}
+            DdDemand::Table => {
+                dealer_dds::table(deal);
+            }
+            DdDemand::Cells(cells) => {
+                for (denomination, declarer) in cells {
+                    dealer_dds::tricks(deal, *denomination, *declarer);
+                }
+            }
+        }
+    }
+
+    pub fn is_none(&self) -> bool {
+        matches!(self, DdDemand::None)
+    }
+}
+
+/// Read the double-dummy demand off a program's `action` statements.
+///
+/// The condition is deliberately not looked at: it is evaluated by the workers
+/// already, so anything it asks for is solved in parallel and remembered before
+/// the action ever runs. Warming it again would be pure waste.
+pub fn of_program(program: &Program) -> DdDemand {
+    let mut demand = DdDemand::None;
+    for statement in &program.statements {
+        if let Statement::Action {
+            averages,
+            frequencies,
+            printes,
+            print_reports,
+            ..
+        } = statement
+        {
+            for spec in averages {
+                walk(&spec.expr, program, &mut demand, &mut HashSet::new());
+            }
+            for spec in frequencies {
+                walk(&spec.expr, program, &mut demand, &mut HashSet::new());
+                if let Some((second, _)) = &spec.second {
+                    walk(second, program, &mut demand, &mut HashSet::new());
+                }
+            }
+            for terms in printes {
+                for term in terms {
+                    if let EsTerm::Expression(expr) = term {
+                        walk(expr, program, &mut demand, &mut HashSet::new());
+                    }
+                }
+            }
+            for terms in print_reports {
+                walk_csv(terms, program, &mut demand);
+            }
+        }
+        // `csvrpt` as a bare statement, which DealerV2_4's scripts also write.
+        if let Statement::CsvReport(terms) = statement {
+            walk_csv(terms, program, &mut demand);
+        }
+    }
+    demand
+}
+
+fn walk_csv(terms: &[CsvTerm], program: &Program, demand: &mut DdDemand) {
+    for term in terms {
+        match term {
+            CsvTerm::Expression(expr) => walk(expr, program, demand, &mut HashSet::new()),
+            // `trix` is the whole table for every seat it names.
+            CsvTerm::Trix(_) => demand.widen_to_table(),
+            _ => {}
+        }
+    }
+}
+
+/// Walk one expression, following variables.
+///
+/// `seen` guards against a variable that refers to itself, directly or through
+/// others. The evaluator has its own answer for that; this only has to avoid
+/// looping while looking.
+fn walk(expr: &Expr, program: &Program, demand: &mut DdDemand, seen: &mut HashSet<String>) {
+    match expr {
+        Expr::FunctionCall { func, args } => {
+            match func {
+                // Every spelling of the single-cell question.
+                Function::Tricks => match cell_of(args) {
+                    Some(cell) => demand.add_cell(cell),
+                    // Arguments that are not literals cannot be read here, and
+                    // guessing would warm the wrong cell and solve the right
+                    // one later anyway. The whole table is the honest answer.
+                    None => demand.widen_to_table(),
+                },
+                // Par is derived from all twenty.
+                Function::Par => demand.widen_to_table(),
+                _ => {}
+            }
+            for arg in args {
+                walk(arg, program, demand, seen);
+            }
+        }
+        Expr::BinaryOp { left, right, .. } => {
+            walk(left, program, demand, seen);
+            walk(right, program, demand, seen);
+        }
+        Expr::UnaryOp { expr, .. } => walk(expr, program, demand, seen),
+        Expr::Ternary {
+            condition,
+            true_expr,
+            false_expr,
+        } => {
+            walk(condition, program, demand, seen);
+            walk(true_expr, program, demand, seen);
+            walk(false_expr, program, demand, seen);
+        }
+        Expr::Variable(name) => {
+            if !seen.insert(name.clone()) {
+                return;
+            }
+            for statement in &program.statements {
+                if let Statement::Assignment {
+                    name: assigned,
+                    expr,
+                } = statement
+                {
+                    if assigned == name {
+                        walk(expr, program, demand, seen);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// The (denomination, declarer) a `tricks(position, denomination)` names, when
+/// both are written as literals — which is how scripts write them.
+fn cell_of(args: &[Expr]) -> Option<(Denomination, Position)> {
+    if args.len() != 2 {
+        return None;
+    }
+    let declarer = match &args[0] {
+        Expr::Position(position) => *position,
+        _ => return None,
+    };
+    let denomination = match &args[1] {
+        Expr::Suit(suit) => Denomination::from_suit(*suit),
+        Expr::Literal(n) => Denomination::from_index(*n)?,
+        _ => return None,
+    };
+    Some((denomination, declarer))
+}

--- a/dealer-run/src/lib.rs
+++ b/dealer-run/src/lib.rs
@@ -32,6 +32,7 @@
 //! its own. The condition and `printes` stay with the caller, which builds its
 //! own for those.
 
+pub mod dd_demand;
 pub mod run;
 pub use run::{
     run, Deals, LevelingOptions, LevelingReport, Phase, Produced, Rows, RunHost, RunOptions,

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -338,6 +338,30 @@ impl Workers {
         }
         (0..count).map(one).collect()
     }
+
+    /// Run `warm` over every deal, on the pool.
+    ///
+    /// Used to solve a batch's produced deals before the main thread evaluates
+    /// their action. No results come back: what it leaves behind is the solved
+    /// cells in `dealer_dds`'s shared memo, which the evaluation then finds
+    /// already worked out. See `crate::dd_demand`.
+    fn warm_each(&self, deals: &[&Deal], warm: &(dyn Fn(&Deal) + Sync)) {
+        #[cfg(feature = "parallel")]
+        {
+            use rayon::prelude::*;
+            if let Some(pool) = &self.pool {
+                pool.install(|| deals.par_iter().for_each(|deal| warm(deal)));
+                return;
+            }
+            if self.global {
+                deals.par_iter().for_each(|deal| warm(deal));
+                return;
+            }
+        }
+        for deal in deals {
+            warm(deal);
+        }
+    }
 }
 
 /// A deal the producing pass has produced.
@@ -754,6 +778,9 @@ fn run_pass(
     let point_counts = point_counts.as_ref();
     let mut accumulator =
         RunAccumulator::new(&program, MeasureStop::standard(), opts.vulnerability)?;
+    // What the action will ask the solver for, per produced deal. Worked out
+    // once: it is a property of the script, not of a deal.
+    let dd_demand = crate::dd_demand::of_program(&program);
     if let Some(plan) = opts.round_robin {
         accumulator = accumulator.with_round_robin(plan.clone());
     }
@@ -832,6 +859,23 @@ fn run_pass(
         // Where the last of these sits in the stream, so a kept deal's position
         // is known without threading one through every deal.
         let batch_end = source.position;
+
+        // Solve this batch's matched deals on the pool, before the main thread
+        // starts evaluating their actions one at a time. The workers are idle
+        // at this point and the answers are shared, so the loop below finds
+        // every cell already worked out. Nothing else changes: the deals are
+        // still observed in order, and no expression is evaluated here.
+        if !dd_demand.is_none() {
+            let matched_deals: Vec<&Deal> = built
+                .iter()
+                .filter(|(_, matched)| matches!(matched, Ok(true)))
+                .map(|(deal, _)| deal)
+                .collect();
+            if matched_deals.len() > 1 {
+                workers.warm_each(&matched_deals, &|deal| dd_demand.warm(deal));
+            }
+        }
+
         for (index, (deal, matched)) in built.iter().enumerate() {
             if from_stream {
                 generated += 1;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -110,6 +110,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which has nothing to walk through.
 
 ### Changed
+- **Double-dummy in an `action` now uses every core.** A script calling
+  `tricks()`, `dds()` or `par()` from its *condition* already solved in
+  parallel, because the workers evaluate the condition; the same call in an
+  *action* solved on one core while the pool sat idle, because the main thread
+  evaluates actions. Each batch's matching deals are now solved on that pool
+  before their actions are evaluated, and the evaluation finds the answers
+  already worked out. On one script `par` in an action went from 12.1s on one
+  core to 2.4s on six, at the same `-R`. No threads were added; deals are still
+  observed in order, and `rnd()` streams and output are unchanged. What gets
+  solved is read off the script, so `average "x" tricks(south, spades)` still
+  costs one search per deal rather than a whole twenty-cell table.
+
 - **Dealing is about 1.6x faster, and generating a deal nearly 3x.** Every deal
   generated had all four of its hands sorted on the way out, which cost about
   two thirds of the time to produce one — and was paid on every deal, while a


### PR DESCRIPTION
Closes the dealer3 half of bridge-craftwork/bridge-solver#13.

## The gap

dealer3's workers deal and test the condition; the main thread evaluates the
action. So the same double-dummy call costs wildly different wall time
depending on which half of the script it sits in:

| where the solve is | wall | cpu | cores busy |
|---|---|---|---|
| in the **condition** | 0.29s | 1.30s | 4.5 |
| in the **action** | 1.11s | 1.11s | 1.0 |

Identical work, identical `-R 8`. The pool was idle for the whole of the second
one.

## The fix

Each batch's matching deals are solved on that same pool before the main thread
begins evaluating their actions. `dealer_dds` already shares a solved cell
across threads the moment it is worked out — its comment says so explicitly, "a
worker thread may only see one deal calling `tricks()` in a whole batch, and the
main thread needs the answer" — so the evaluation then finds every cell already
there.

**No threads are added.** This is the pool that already existed. Deals are still
observed in order, no expression is evaluated while warming, and `rnd()` streams
and output are untouched.

`par` in an action, `-R 8`: **12.10s on 1.0 cores → 2.38s on 6.0**.

## Not solving blindly

A table is twenty searches and a single `tricks()` is one, so warming whole
tables would make `action average "x" tricks(south, spades)` twenty times
dearer. `dealer-run/src/dd_demand.rs` reads the demand off the script once:
literal-argument `tricks()` calls name their cell, while `par`, `trix` and
arguments that cannot be read statically ask for all twenty. Variables are
followed, with a cycle guard. The condition is deliberately not analysed —
anything it asks for is already solved and remembered before the action runs.

Confirmed: a single-cell action runs 0.28s at 4.8 cores, so it is warming one
cell, not a table.

## Also: dealer-dds migrated to DdTable

Not optional any more. bridge-solver deleted `par`'s private `DdTricks` (their
\#31), so **dealer3 did not compile against its sibling at all** until this.

Worth a word, because the first attempt was wrong in exactly the way
`dealer-dds` warns about. Transcribing the local array into a `DdTable`
conflated solver *seat* numbering with `Direction` index, and par came out
**negated** — `-645.96` where it should read `645.96`. Everything still ran;
only the sign was wrong. `table()` now sets each cell by name, through
`seat_to_direction` and `STRAINS`, so an axis that changes cannot silently
negate par again.

## Verification

- `cargo fmt`, clippy `-D warnings`, 43 test binaries — clean.
- `par` identical at `-R 1` and `-R 8` (645.96), and the known-good deal's table
  is byte-identical with South/notrump = 8.
- `scripts/bench-verify.py` over the whole corpus: all 12 scripts accept every
  deal `dealer.exe` and DealerV2_4 produced for them, with matching statistics —
  including `_solver_agreement`, where `dds()` and `par()` agree with DDS 2.9
  over identical cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)