### PR TITLE
The threaded wasm build is faster now, not slower

### DIFF
--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -10,12 +10,32 @@
 #   threaded  the same ES module built for wasm threads       -> pkg/
 #
 # `threaded` needs a pinned nightly and rust-src, and the page must be served
-# with COOP/COEP. It works and it is correct — the same deals, whatever the
-# thread count — but it is **not** what the site ships, because today it is
-# slower: 4M deals in six seconds on one thread against 290K on twelve, getting
-# worse with every thread added. That shape is lock contention, and the lock is
-# almost certainly the allocator: a `Deal` is four `Vec<Card>` allocations and
-# wasm's dlmalloc serialises them all. Allocation-free dealing comes first.
+# with COOP/COEP. It works, it is correct — the same deals, whatever the thread
+# count — and since `Hand` became an inline `[Card; 13]` it is also faster.
+#
+# It used to be slower, and dramatically: 4M deals in six seconds on one thread
+# against 290K on twelve, getting worse with every thread added. That was the
+# allocator. A `Deal` was four `Vec<Card>` allocations and wasm's dlmalloc
+# serialises them, so every worker queued on the same lock. This comment used
+# to end "Allocation-free dealing comes first"; that landed, and the shape
+# reversed.
+#
+# Re-measured 2026-09-05 in Chromium on an M4 Pro (8 performance + 4 efficiency
+# cores), `condition hcp(north) >= 20`, 16M-deal budget, median of three:
+#
+#     threads   1      2      4      8     12
+#     M deals/s 2.86   4.77   7.84  11.13  11.41
+#     vs one    1.00x  1.67x  2.74x  3.89x  3.99x
+#
+# Sublinear, and flat between eight and twelve — four of the cores are
+# efficiency cores and some contention remains — but rising throughout, where it
+# used to collapse. The atomics build costs nothing at one thread (2.86 against
+# the shipped build's 2.73, inside the noise), so threads would not penalise a
+# browser that cannot spawn workers.
+#
+# It is still not what the site ships. That is now a deployment question — a
+# second build to produce and COOP/COEP headers to serve — and no longer a
+# performance one.
 #
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -285,9 +285,16 @@ fn now_ms() -> f64 {
 /// deals exactly the same deals, which is the property that makes any of this
 /// safe.
 ///
-/// **The site does not ship a threaded build**, because more threads currently
-/// make it slower rather than faster — see `build.sh`. This is the groundwork
-/// and the proof that the engine's side is right, not a switch to flip.
+/// **The site does not ship a threaded build**, but that is a deployment
+/// decision rather than a performance one: a second build to produce, and
+/// COOP/COEP headers to serve.
+///
+/// It used to be a performance one. Threads made the browser slower — 4M deals
+/// in six seconds on one against 290K on twelve — because a `Deal` was four
+/// `Vec<Card>` allocations and wasm's dlmalloc serialises them, so every worker
+/// queued on the same lock. `Hand` is an inline `[Card; 13]` now, and the shape
+/// reversed: measured 2026-09-05, about 4x on twelve threads, and no cost at
+/// one. `build.sh` carries the numbers.
 #[cfg(feature = "parallel")]
 #[wasm_bindgen]
 pub fn start_threads(threads: usize) -> js_sys::Promise {


### PR DESCRIPTION
Comment-only. Two places in the repo state a performance finding that has been
overturned, and both are the reason someone would not look again.

`wasm/build.sh` said the threaded build is *"not what the site ships, because
today it is slower: 4M deals in six seconds on one thread against 290K on
twelve"*, diagnosed it as allocator contention — a `Deal` was four `Vec<Card>`
allocations and wasm's dlmalloc serialises them — and ended **"Allocation-free
dealing comes first."**

That landed. `Hand` is an inline `[Card; 13]` now, and the shape reversed.

## Re-measured

Chromium on an M4 Pro (8 performance + 4 efficiency cores),
`condition hcp(north) >= 20`, 16M-deal budget, median of three, page
COOP/COEP-isolated:

| threads | M deals/sec | vs one |
|---|---|---|
| shipped single-threaded build | 2.73 | 0.96x |
| 1 | 2.86 | 1.00x |
| 2 | 4.77 | 1.67x |
| 4 | 7.84 | 2.74x |
| 8 | 11.13 | 3.89x |
| 12 | 11.41 | **3.99x** |

Rising throughout, where it used to collapse.

Two results that matter as much as the headline: the atomics build **costs
nothing at one thread** (2.86 against 2.73, inside the noise), so threads would
not penalise a browser that cannot spawn workers; and `produced` was
**byte-identical at every thread count** and against the Node build, so "the
same deals, whatever the thread count" still holds.

Caveats kept in the comment: scaling is sublinear and flat between 8 and 12 —
four efficiency cores plus some remaining contention. The old "4M / 290K"
figures have no recorded script, host or budget, so that comparison is
indicative; the number to trust is threaded/1 against threaded/12 in one
session.

## What changes

Nothing in behaviour. The site still does not ship a threaded build — but that
is now a **deployment** question (a second build to produce, COOP/COEP headers
to serve) rather than a performance one, and saying so is the point: the next
person to read this should be weighing build complexity, not re-deriving a
claim that is no longer true.

Issue #20 has been rewritten to match — its "the browser characterizes on one
thread" item was resting on the same stale finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)