### PR TITLE
DealerV2_4 has no -l, and never exported "DL52 format"

### DIFF
--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -982,12 +982,12 @@ fn main() {
     if args.library {
         eprintln!("Error: Switch '-l' (library mode) is not supported in dealer3.");
         eprintln!();
-        eprintln!("Reason: The '-l' switch has conflicting meanings:");
-        eprintln!("        - In dealer.exe: Read deals from library.dat");
-        eprintln!("        - In DealerV2_4: Export to DL52 format");
+        eprintln!("In dealer.exe, '-l N' reads deals from Ginsberg's library.dat,");
+        eprintln!("starting at index N. Those deals carry pre-solved double-dummy");
+        eprintln!("tricks, which is what made the switch worth having.");
         eprintln!();
-        eprintln!("Suggestion: Remove the '-l' switch from your command.");
-        eprintln!("            Future versions may add library support with a different switch.");
+        eprintln!("Suggestion: use '--input-deals' to filter deals from a file.");
+        eprintln!("            Reading a solved library is tracked as issue #61.");
         std::process::exit(1);
     }
 

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -197,22 +197,16 @@ pub const REMAINING: &[WorkItem] = &[
         note: Some("`--input-deals` already covers the common case in dealer3's own way."),
     },
     WorkItem {
-        what: "Export in RP zrd format",
+        what: "Read and write RP ZRD, Pavlicek's solved-deal library",
         done_when: Some(DoneWhen::Switch("-Z")),
-        issue: None,
+        issue: Some(61),
         effort: Effort::Medium,
-        value: Value::Low,
-        note: None,
-    },
-    WorkItem {
-        what: "Export in DL52 format",
-        done_when: None,
-        issue: None,
-        effort: Effort::Medium,
-        value: Value::Low,
+        value: Value::Medium,
         note: Some(
-            "DealerV2_4 spells it `-l`, which is dealer.exe's library switch — so as with \
-             the script parameters, the spelling here would have to differ.",
+            "Reading is the valuable half: a ZRD record carries a deal *and* its twenty \
+             double-dummy results, so `tricks()`, `dds()` and `par()` become lookups rather \
+             than hundred-millisecond searches — which is also what would make them usable \
+             in the browser. The format work is bridge-encodings#20.",
         ),
     },
     WorkItem {

--- a/dealer/src/switches.rs
+++ b/dealer/src/switches.rs
@@ -531,7 +531,7 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
         group: "Reading deals in",
         what: "Filter deals from a file instead of generating",
         dealer_exe: Origin::Differs("-l replays from a library file by index"),
-        dealer_v2: Origin::Differs("-L names a library path, -l exports DL52"),
+        dealer_v2: Origin::Differs("-L names a library path: Pavlicek's solved-deal library, in ZRD format"),
         note: Some(
             "Reads PBN or one-line, auto-detected, `-` for stdin. Unrecognised lines are \
              skipped, so check the reported count.",
@@ -556,7 +556,7 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
         group: "Recognised but not supported",
         what: "Replay deals from a library file",
         dealer_exe: Origin::Same,
-        dealer_v2: Origin::Differs("-l exports DL52"),
+        dealer_v2: Origin::Absent,
         note: Some("`--input-deals` covers this use case in dealer3's own way."),
     },
     SwitchRow {
@@ -623,8 +623,7 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
         dealer_exe: Origin::Absent,
         dealer_v2: Origin::Same,
         note: Some(
-            "The companion to DealerV2_4's `-l`; it was mentioned only in the note on \
-             `--input-deals`, which left it the one V2_4 switch with no row of its own.",
+            "DealerV2_4's own library switch, and the same idea as dealer.exe's `-l`: deals that arrive with their double-dummy results already worked out, so `tricks()` is a lookup rather than a search. Different libraries — Pavlicek's ZRD here, Ginsberg's `library.dat` there. DealerV2_4 has no `-l`.",
         ),
     },
 ];

--- a/docs/DEPRECATED_SWITCHES.md
+++ b/docs/DEPRECATED_SWITCHES.md
@@ -78,28 +78,42 @@ already, so `-u` changes nothing here either — which is the compatible answer.
 ```
 Error: Switch '-l' (library mode) is not supported in dealer3.
 
-Reason: The '-l' switch has conflicting meanings:
-        - In dealer.exe: Read deals from library.dat
-        - In DealerV2_4: Export to DL52 format
+In dealer.exe, '-l N' reads deals from Ginsberg's library.dat,
+starting at index N. Those deals carry pre-solved double-dummy
+tricks, which is what made the switch worth having.
 
-Suggestion: Remove the '-l' switch from your command.
-            Future versions may add library support with a different switch.
+Suggestion: use '--input-deals' to filter deals from a file.
+            Reading a solved library is tracked as issue #61.
 ```
 
 **What it did in dealer.exe**:
-- Read pre-generated deals from `library.dat` (M. Ginsberg's library)
-- Used with bridge.exe from GIB for fast tricks() evaluation
-- INPUT mode (reads deals from file)
+- `-l N` set `loading = 1` and `loadindex = N`, reading pre-generated deals from
+  M. Ginsberg's `library.dat` from that index onward
+- Those records carry pre-solved double-dummy results — `dealer.c` reads
+  `libdeal.tricks[dn]` rather than searching — which is the point of the switch:
+  `tricks()` becomes a lookup
 
-**What it does in DealerV2_4**:
-- Export deals to DL52 format file
-- OUTPUT mode (writes deals to file)
+**What it does in DealerV2_4**: nothing. **There is no `-l`.**
 
-**Why not supported**:
-- **Conflicting purposes**: INPUT in dealer.exe, OUTPUT in DealerV2_4
-- Implementing either version would break compatibility with the other
-- Better to wait for user feedback on which is more important
-- Could add `--library-input` and `--dl52-output` in future
+This page used to say it exported "DL52 format". That was wrong, and wrong in a
+way worth recording, because it drove a roadmap item and a message dealer3
+printed at users. DealerV2_4's option string is
+`hmquvVg:p:s:x:C:D:L:M:O:P:R:T:N:E:S:W:X:U:0-9` — no lowercase `l` — and the
+binary answers `-l` with its usage message. "DL52" appears nowhere in
+DealerV2_4's source, headers or user guide; the only occurrences anywhere were
+in dealer3's own documentation, citing each other.
+
+What DealerV2_4 does have is **`-L`**, naming a path to Richard Pavlicek's
+solved-deal library in ZRD format — the same idea as dealer.exe's `-l`, a
+different file. That is worth having, and is tracked as
+[#61](https://github.com/bridge-craftwork/Dealer3/issues/61) with the format
+work in bridge-encodings#20.
+
+**Why `-l` is still not supported**:
+- `--input-deals` already covers filtering deals from a file, in dealer3's own
+  way and without an index
+- A library's value is its pre-solved tricks, which `--input-deals` cannot carry
+  today — that is what #61 adds
 
 ---
 
@@ -189,8 +203,11 @@ Error: Switch '-l' (library mode) is not supported in dealer3.
 
 ### Could Be Added Later
 1. ~~**Upper/lowercase toggle (`-u`)**~~: accepted and ignored; it is a no-op in dealer.exe too
-2. **Library input (`--library-input`)**: If there's demand for library.dat support
-3. **DL52 export (`--dl52-output`)**: If there's demand for DealerV2_4 compatibility
+2. **Solved-deal libraries**: reading deals *and* their double-dummy tables, so
+   `tricks()` becomes a lookup. Tracked as
+   [#61](https://github.com/bridge-craftwork/Dealer3/issues/61), against
+   Pavlicek's ZRD format rather than Ginsberg's `library.dat`, because ZRD is
+   specified, downloadable and has a reference decoder.
 
 ### Will NOT Be Added
 1. **Swapping modes (`-2`, `-3`)**: Fundamentally incompatible with predeal

--- a/docs/command_line_comparison.md
+++ b/docs/command_line_comparison.md
@@ -96,14 +96,14 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 
 | Switch | What it does | dealer3 | dealer.exe | DealerV2_4 | Notes |
 |---|---|---|---|---|---|
-| `--input-deals` | Filter deals from a file instead of generating | ✅ | ⚠️ -l replays from a library file by index | ⚠️ -L names a library path, -l exports DL52 | Reads PBN or one-line, auto-detected, `-` for stdin. Unrecognised lines are skipped, so check the reported count. |
+| `--input-deals` | Filter deals from a file instead of generating | ✅ | ⚠️ -l replays from a library file by index | ⚠️ -L names a library path: Pavlicek's solved-deal library, in ZRD format | Reads PBN or one-line, auto-detected, `-` for stdin. Unrecognised lines are skipped, so check the reported count. |
 
 ### Recognised but not supported
 
 | Switch | What it does | dealer3 | dealer.exe | DealerV2_4 | Notes |
 |---|---|---|---|---|---|
 | `-e` | Exhaust mode | ⚠️ rejected with a message | ⚠️ compiled out; prints "not included" | — | Never finished in the original either. |
-| `-l` | Replay deals from a library file | ⚠️ rejected with a message | ✅ | ⚠️ -l exports DL52 | `--input-deals` covers this use case in dealer3's own way. |
+| `-l` | Replay deals from a library file | ⚠️ rejected with a message | ✅ | — | `--input-deals` covers this use case in dealer3's own way. |
 | `--legacy` | The old single-threaded RNG mode | ⚠️ rejected with a message | — | — | Removed in 0.5.0; still parsed so a script using it gets an explanation. |
 
 ### Not implemented
@@ -115,7 +115,7 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 | `-U` | DealerServer path | ❌ | — | ✅ |  |
 | `-O` | OPC evaluation for the opener | ❌ | — | ✅ |  |
 | `-D` | Debug verbosity 0-9 | ❌ | — | ✅ |  |
-| `-L` | Path to the RP library the deals are read from | ❌ | — | ✅ | The companion to DealerV2_4's `-l`; it was mentioned only in the note on `--input-deals`, which left it the one V2_4 switch with no row of its own. |
+| `-L` | Path to the RP library the deals are read from | ❌ | — | ✅ | DealerV2_4's own library switch, and the same idea as dealer.exe's `-l`: deals that arrive with their double-dummy results already worked out, so `tricks()` is a lookup rather than a search. Different libraries — Pavlicek's ZRD here, Ginsberg's `library.dat` there. DealerV2_4 has no `-l`. |
 <!-- END GENERATED: switches -->
 
 ## Sources
@@ -148,7 +148,8 @@ the table marks them ⚠️ rather than ✅:
 
 - `-X` — force statistics on (dealer.exe, dealer3) vs export predeal holdings
   (V2_4).
-- `-l` — replay from a library by index (dealer.exe) vs export DL52 (V2_4).
+- `-l` — replay from a library by index (dealer.exe). DealerV2_4 has no `-l`;
+  its library switch is `-L`, naming a Pavlicek ZRD library.
   dealer3 does neither; `--input-deals` covers the first use case in its own
   way.
 - `-P` — vulnerability for par in V2_4; dealer3 uses `--vulnerable`.

--- a/docs/command_line_switch_requirements.md
+++ b/docs/command_line_switch_requirements.md
@@ -482,9 +482,9 @@ Keep `docs/implementation_roadmap.md` updated with:
 
 **Options**:
 - A) Support neither dealer.exe nor V2_4 version (current plan - RECOMMENDED)
-- B) Support V2_4 version only (DL52 export)
+- B) ~~Support V2_4 version only (DL52 export)~~ — there is no such switch; DealerV2_4 has no `-l`
 - C) Support dealer.exe version only (library input)
-- D) Add `--library-input` and `--dl52-output` to avoid conflict
+- D) ~~Add `--library-input` and `--dl52-output` to avoid conflict~~ — there was no conflict to avoid
 
 **Recommendation**: Option A - avoid the conflict entirely until user demand clarifies which is needed
 

--- a/docs/dealer_vs_dealer2_switches.md
+++ b/docs/dealer_vs_dealer2_switches.md
@@ -92,7 +92,7 @@ These switches are new features added in DealerV2_4:
 **V2_4 Focus Areas**:
 - Predeal via command-line (4 switches)
 - Double-dummy analysis with DDS library
-- Multiple export formats (CSV, RP zrd, DL52)
+- Export formats: CSV, and reading Pavlicek's RP ZRD library (`-L`)
 - Advanced evaluation (OPC, Par)
 - Multi-threading support
 - Scripting support with parameters
@@ -106,15 +106,25 @@ These switches exist in both versions but have **different meanings or behavior*
 
 | Switch | dealer.exe Meaning | DealerV2_4 Meaning | Compatibility |
 |--------|-------------------|-------------------|---------------|
-| `-l PATH` | **Read from library.dat** (M. Ginsberg's pre-generated deals for fast tricks() evaluation) | **DL52 format export** (write deals to file in DL52 format) | ⚠️ **INCOMPATIBLE** - Completely different purposes |
+| `-l N` | **Read from library.dat** (M. Ginsberg's pre-generated deals, carrying pre-solved tricks, from index N) | **Not a switch.** `-l` is rejected with the usage message | No conflict — one program has it, the other does not |
 
-**Total: 1 switch with conflict**
+**Total: 0 switches with a conflicting meaning**
 
-**Critical Note**: The `-l` switch has a fundamental incompatibility:
-- **dealer.exe**: INPUT mode - reads pre-generated deals from library.dat for fast bridge.exe/GIB integration
-- **DealerV2_4**: OUTPUT mode - writes deals to file in DL52 format for export
+**This table used to claim a conflict, and there is none.** It said DealerV2_4's
+`-l` exported "DL52 format", making `-l` INPUT in one program and OUTPUT in the
+other. DealerV2_4 has no `-l`: its option string is
+`hmquvVg:p:s:x:C:D:L:M:O:P:R:T:N:E:S:W:X:U:0-9`, and the binary answers `-l`
+with usage. "DL52" appears nowhere in its source, headers or user guide.
 
-This is a **breaking change** between versions that could cause confusion or errors if scripts are ported from dealer.exe to DealerV2_4.
+The two programs do both have a library idea, and it is the same idea rather
+than opposite ones — deals that arrive with their double-dummy results already
+worked out, so `tricks()` is a lookup:
+
+- **dealer.exe** `-l N`: Ginsberg's `library.dat`, reading `libdeal.tricks[dn]`
+- **DealerV2_4** `-L path`: Richard Pavlicek's solved-deal library, ZRD format
+
+dealer3 has neither yet; [#61](https://github.com/bridge-craftwork/Dealer3/issues/61)
+tracks ZRD, which is the one with a published spec and a reference decoder.
 
 ---
 
@@ -142,7 +152,7 @@ This is a **breaking change** between versions that could cause confusion or err
 DealerV2_4 represents a **major enhancement** with:
 1. **Command-line predeal**: 4 new switches (`-N`, `-E`, `-S`, `-W`) for convenience
 2. **DDS integration**: Double-dummy solver with multi-threading
-3. **Export formats**: CSV, RP zrd, DL52 for interoperability
+3. **Export formats**: CSV, and RP ZRD for interoperability
 4. **Advanced evaluation**: OPC, Par calculations
 5. **Scripting support**: Parameters `$0`-`$9` for flexible scripts
 6. **Server mode**: Integration with DealerServer
@@ -177,7 +187,7 @@ Based on this analysis, dealer3 should:
 ### Low Priority (Advanced Features)
 9. ~~Swapping modes~~ - done, using dealer.exe's `-0`/`-2`/`-3` rather than V2_4's `-x MODE`
 10. DDS integration (`-M`, `-R`) - High effort, requires external library
-11. Export formats (`-Z` RP zrd, `-l` DL52) - Niche use cases
+11. Export formats (`-Z` RP ZRD) - niche, but reading ZRD is not: see #61
 
 ### Avoid Conflicts
 - **DO NOT** implement dealer.exe's `-l` (library.dat reader) to avoid confusion with V2_4
@@ -201,7 +211,7 @@ Based on this analysis, dealer3 should:
 | 3-way swap (`-3`) | ✅ Yes | dealer3 keeps `-3`; V2_4 spells it `-x 3` |
 | Upper/lowercase (`-u`) | ❌ No | Cosmetic, dropped |
 | Exhaust mode (`-e`) | ❌ No | Experimental, never finished |
-| Library mode (`-l`) | ⚠️ Different | Now means DL52 export, not input |
+| Library mode (`-l`) | ✅ dealer.exe only | DealerV2_4 has no `-l`; its library switch is `-L` (ZRD) |
 
 **Coverage: 9/13 (69%) of dealer.exe switches work identically in V2_4**
 

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -159,7 +159,7 @@ letters are dealer.exe's swapping switches and already taken.
 
 So what remains of it is in **What is left** below, which is generated from
 `dealer/src/roadmap.rs` and checked against the argument parser — `-M`, `-Z`,
-DL52 and library mode are all rows in that table, with the switch collisions
+Library mode is a row in that table, with the switch collisions
 written down where they belong. Script parameters used to be a row there too,
 and are now finished: `--param` fills one, a `# param 0 = west` comment declares
 what it should be when nothing does, and `--params` lists what a script wants.
@@ -209,7 +209,7 @@ See `CHANGELOG.md` for the migration note.
 - [x] DDS integration - **COMPLETED** via `tricks()`, `score()`, `imps()`,
       solved by `bridge-solver` and remembered per deal (#14)
 - [ ] Library mode - `--input-deals` covers the common case; `-l` is rejected
-- [ ] Export formats (`-Z` zrd, DL52)
+- [ ] ZRD: read a solved library, and write one ([#61](https://github.com/bridge-craftwork/Dealer3/issues/61))
 - [x] Script parameters (`$0`-`$9`) - **COMPLETED**. `--param 1=west` rather than
       DealerV2_4's `-1`, which is dealer.exe's swapping switch; a script declares
       its own defaults in a `# param 1 = 15` comment, which the original's lexer
@@ -265,8 +265,7 @@ Priority is derived from effort and value rather than written down beside them.
 
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
-| 🔵 Unlikely | Export in DL52 format | Medium | Low |  | DealerV2_4 spells it `-l`, which is dealer.exe's library switch — so as with the script parameters, the spelling here would have to differ. |
-| 🔵 Unlikely | Export in RP zrd format | Medium | Low |  |  |
+| 🟢 Someday | Read and write RP ZRD, Pavlicek's solved-deal library | Medium | Medium | [#61](https://github.com/bridge-craftwork/Dealer3/issues/61) | Reading is the valuable half: a ZRD record carries a deal *and* its twenty double-dummy results, so `tricks()`, `dds()` and `par()` become lookups rather than hundred-millisecond searches — which is also what would make them usable in the browser. The format work is bridge-encodings#20. |
 | 🔵 Unlikely | The length-bias form of `predeal`, `spades(north) == 5` — which the original ignores | Medium | Low |  | **The original accepts it and does nothing with it.** `predealarg : SUIT '(' COMPASS ')' CMPEQ NUMBER` in `defs.y` calls `bias_deal`, which writes `biasdeal[compass][suit]` — and nothing ever reads that array; `dealer.c` contains its declaration and no other mention. Measured rather than inferred: `predeal spades(north) == 5` over 200 deals gives North an average of 3.285 spades, the natural 3.25, on the macOS build and on the Windows one BBO's lineage comes from. So there is no behaviour to be compatible with. dealer3 rejects it loudly, which is the better of the two; implementing it would make dealer3 differ from the original rather than match it. |
 | 🔵 Unlikely | `--bbo-strict`: warn when a script will behave differently on BBO | Medium | Low | [#13](https://github.com/bridge-craftwork/Dealer3/issues/13) | Rick judged it unlikely to bite. |
 | 🔵 Unlikely | `bktfreq`: frequency in buckets, one and two dimensional | Medium | Low |  | Adjacent to the two-dimensional `frequency` below but not the same thing: that one is the original's, this one groups a range into buckets. |


### PR DESCRIPTION
Documentation and one error message. No behaviour changes.

## The claim

That DealerV2_4's `-l` exports "DL52 format" — making `-l` mean opposite things
in the two reference programs, INPUT in dealer.exe and OUTPUT in DealerV2_4.

It is not true:

- DealerV2_4's option string is
  `hmquvVg:p:s:x:C:D:L:M:O:P:R:T:N:E:S:W:X:U:0-9` — **no lowercase `l`**
- The binary answers `-l` with its usage message
- **"DL52" appears nowhere** in DealerV2_4's source, headers or 50-page user
  guide. Every occurrence anywhere was in dealer3's own docs, citing each other

## What it reached

One unsourced assertion, **nine places**:

| where | what it did |
|---|---|
| `dealer/src/switches.rs` (x3) | fed the *generated* comparison table |
| `dealer/src/roadmap.rs` | carried a work item |
| `dealer/src/main.rs` | **printed at users** who typed `-l` |
| 6 documents | cited each other |

## What is true instead

More useful than what it replaced. The two library switches are not opposites,
they are **the same idea**: deals that arrive with their double-dummy results
already worked out, so `tricks()` is a lookup rather than a search.

- **dealer.exe** `-l N` — Ginsberg's `library.dat`, consulting `libdeal.tricks[dn]`
- **DealerV2_4** `-L path` — Pavlicek's solved-deal library, ZRD format

Neither is an export.

## Changes

- **DL52 roadmap row deleted** — it described work against a format with no
  established existence
- **RP ZRD row rewritten**, re-rated Low → **Medium** value, pointing at #61.
  Reading such a library is not an export nicety: it is what makes double-dummy
  affordable, including in the browser
- **The `-l` error message** now says what dealer.exe's switch did, and points at
  `--input-deals` and #61
- **The `-L` note** said it was "the companion to DealerV2_4's `-l`" — the same
  error one layer down. Regenerating the table is what surfaced it

Corrected pages say what they used to claim and why it was wrong, rather than
quietly dropping it — this drifted for months precisely because each document
could cite another.

## Follow-up

#62 proposes the check that would have caught this on day one: assert every
switch we credit to a reference program against that program's own option
string. Generation keeps the table honest about *dealer3* and can say nothing
about anyone else's binary — which is the gap this fell through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)