### PR TITLE
Read a solved-deal library from a pipe (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ echo "hcp(north) >= 0" | dealer -E S8743,HA9,D642,CQT64 -W SQ965,HK63,DAQJT,CA5 
 ## Filtering Existing Deals
 
 `--input-deals` reads deals from a file instead of generating them, then applies the
-script's constraints as usual. PBN and oneline formats are auto-detected.
+script's constraints as usual. The format is detected from the content: a Pavlicek
+`.zrd` library, PBN, oneline or printall, whatever the file is called.
 
 ```bash
 # Filter an existing PBN file
@@ -87,6 +88,9 @@ dealer filter.dlr --input-deals hands.pbn -f pbn
 
 # Read deals from stdin (script must be a file argument, since stdin is taken)
 cat hands.pbn | dealer filter.dlr --input-deals - -f oneline
+
+# A binary library reads the same way, so fetching one needs no HTTP client here
+curl -s https://example.org/deals.zrd | dealer filter.dlr --input-deals -
 
 # Check how many deals in a file satisfy a constraint
 echo "hcp(north) >= 15" > strong.dlr
@@ -105,6 +109,8 @@ Notes:
 - Lines that are not recognised as deals are ignored, so PBN metadata and previous
   stats output can be piped straight in. Check the reported `Generated N hands` count
   to confirm every deal you expected was actually read.
+- A file whose name disagrees with its content — a `.zrd` holding PBN, or the reverse
+  — is read for what it holds, and the disagreement is reported.
 
 ## Constraint Language
 

--- a/dealer-run/src/deal_input.rs
+++ b/dealer-run/src/deal_input.rs
@@ -24,9 +24,26 @@
 //! ZRD says "not solved" with an all-zero table, which is unreachable for a
 //! real deal. `bridge_encodings` reports that as `None` too, so an unsolved
 //! record and a one-line deal arrive here indistinguishable, as they should.
+//!
+//! ## Two sources, one decoder
+//!
+//! [`read`] takes somewhere to read from; [`read_bytes`] takes the bytes. The
+//! second is the whole of the decoding, so a browser handed a file by the page
+//! and a terminal handed a pipe reach the same reader rather than each growing
+//! one of their own.
 
+use bridge_encodings::zrd::{read_record, Record, ZrdReader, RECORD_LEN};
 use bridge_types::DdTable;
 use dealer_core::Deal;
+
+/// How many records the format sniff decodes before it is satisfied.
+///
+/// Bounded because sniffing is decoding, and the published library is ten
+/// million records: checking every one of them would double the cost of
+/// reading it. Sixty-four is far past the point of doubt — arbitrary bytes
+/// split thirteen cards to a seat about once in four hundred, and would have to
+/// do it sixty-four times running with twenty legal trick counts each time.
+const SNIFF_RECORDS: usize = 64;
 
 /// A deal from a file, and the table that came with it.
 #[derive(Debug, Clone)]
@@ -56,13 +73,34 @@ pub struct InputReport {
     /// Records that could not be read or did not make a whole deal, with the
     /// reason. The deals around them are still returned.
     pub skipped: Vec<String>,
+    /// What a caller may want to say about the input that was not a failure —
+    /// chiefly a file whose name disagrees with what is inside it.
+    pub notes: Vec<String>,
 }
 
 /// Read deals from `source`, keeping any double-dummy tables they carry.
 ///
-/// `-` reads standard input. A `.zrd` path is a Pavlicek library; anything else
-/// is text, and is tried as PBN first so that a board's tags are kept, falling
-/// back to the line-oriented reader for one-line and printall.
+/// `-` reads standard input; anything else is a path.
+///
+/// ## The format is what the bytes are, not what they are called
+///
+/// It used to be the extension, and standard input has none — so a piped
+/// library was read as text and died on `stream did not contain valid UTF-8`
+/// before anything else got a look at it. A pipe is the whole point here:
+/// `curl -s .../deals.zrd | dealer script.dlr --input-deals -` is how a library
+/// arrives without this program growing an HTTP client to fetch it.
+///
+/// So the content decides. A ZRD file is a whole number of 23-byte records,
+/// every one of which decodes to four hands of thirteen; anything else is text.
+/// The old objection to sniffing was that a record is twenty-three arbitrary
+/// bytes with no header to recognise — true of the *record*, and beside the
+/// point: a deal is a strong constraint, and text does not satisfy it by
+/// accident.
+///
+/// A name that disagrees with the content is read as the content says, and
+/// noted. Refusing would help nobody — a renamed or half-downloaded file still
+/// holds what it holds — but a `.zrd` full of PBN used to be spent on garbage
+/// records and come back as no deals at all, with nothing said.
 ///
 /// ## Why PBN is tried first rather than detected
 ///
@@ -86,26 +124,142 @@ pub fn read(source: &str) -> Result<(Vec<InputDeal>, InputReport), String> {
             source
         ));
     }
-    if is_library_path(source) {
-        return read_library(source);
+
+    if source == "-" {
+        use std::io::Read;
+        let mut bytes = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut bytes)
+            .map_err(|e| format!("reading deals from standard input: {}", e))?;
+        return read_named(&bytes, "standard input");
     }
 
-    let text = if source == "-" {
-        use std::io::Read;
-        let mut text = String::new();
-        std::io::stdin()
-            .read_to_string(&mut text)
-            .map_err(|e| format!("reading deals from standard input: {}", e))?;
-        text
+    // A named library is streamed rather than read into memory to be sniffed:
+    // the published one is 241 MB, and its head settles the question.
+    let library = path_holds_library(source)?;
+    let mut read = if library {
+        read_library(source)?
     } else {
-        std::fs::read_to_string(source)
-            .map_err(|e| format!("opening input deals file '{}': {}", source, e))?
+        let bytes = std::fs::read(source)
+            .map_err(|e| format!("opening input deals file '{}': {}", source, e))?;
+        read_named(&bytes, &format!("'{}'", source))?
     };
+    if let Some(note) = name_disagrees(source, library) {
+        read.1.notes.push(note);
+    }
+    Ok(read)
+}
 
-    if let Some(read) = read_pbn(&text) {
+/// Read deals from bytes already in hand: a pipe, a download, a dropped file.
+///
+/// The whole of the decoding with no filesystem in it — [`read`] is this plus
+/// somewhere to read from. A browser handed a file by the page reads it here,
+/// so that a supplied library behaves the same in a tab as at a terminal rather
+/// than through a second decoder that drifts from this one.
+pub fn read_bytes(bytes: &[u8]) -> Result<(Vec<InputDeal>, InputReport), String> {
+    read_named(bytes, "the supplied deals")
+}
+
+/// [`read_bytes`], with a name for the bytes so an error can say where they came
+/// from. Nothing else differs between the two, and nothing else may.
+fn read_named(bytes: &[u8], what: &str) -> Result<(Vec<InputDeal>, InputReport), String> {
+    if looks_like_library(bytes) {
+        // `Cursor` is `Read + Seek`, which is all `ZrdReader` ever wanted, so a
+        // library that came down a pipe needs no decoding of its own.
+        let reader = ZrdReader::new(std::io::Cursor::new(bytes))
+            .map_err(|e| format!("reading {} as a library: {}", what, e))?;
+        return Ok(read_records(reader));
+    }
+
+    let text = std::str::from_utf8(bytes).map_err(|e| {
+        // Neither format: worth saying which two were ruled out, because the
+        // likely cause is a library that arrived short and a caller staring at
+        // a UTF-8 complaint has no way to guess that.
+        let leftover = bytes.len() % RECORD_LEN;
+        let hint = if leftover == 0 {
+            String::new()
+        } else {
+            format!(
+                " A library is a whole number of {}-byte records, and this is {} bytes with \
+                 {} left over — which is what a download cut short looks like.",
+                RECORD_LEN,
+                bytes.len(),
+                leftover
+            )
+        };
+        format!(
+            "{} is neither a Pavlicek library nor text: {}.{}",
+            what, e, hint
+        )
+    })?;
+
+    if let Some(read) = read_pbn(text) {
         return Ok(read);
     }
-    Ok(read_lines(&text))
+    Ok(read_lines(text))
+}
+
+/// Do these bytes hold a Pavlicek library?
+///
+/// A whole number of 23-byte records, of which the first [`SNIFF_RECORDS`] all
+/// decode. Empty is not a library: it is nothing, and answering yes would send
+/// an empty file to the reader least able to say what was wrong with it.
+pub fn looks_like_library(bytes: &[u8]) -> bool {
+    if bytes.is_empty() || !bytes.len().is_multiple_of(RECORD_LEN) {
+        return false;
+    }
+    records_decode(&bytes[..bytes.len().min(RECORD_LEN * SNIFF_RECORDS)])
+}
+
+/// Does every whole record in `head` decode? The one place that test lives, so
+/// a file on disk and a pipe cannot come to different conclusions about the
+/// same bytes.
+fn records_decode(head: &[u8]) -> bool {
+    head.chunks_exact(RECORD_LEN)
+        .all(|record| read_record(record).is_ok())
+}
+
+/// Does the file at `path` hold a library? Reads its head, not the whole file.
+fn path_holds_library(path: &str) -> Result<bool, String> {
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| format!("opening input deals file '{}': {}", path, e))?;
+    let len = file
+        .metadata()
+        .map_err(|e| format!("opening input deals file '{}': {}", path, e))?
+        .len();
+    if len == 0 || !len.is_multiple_of(RECORD_LEN as u64) {
+        return Ok(false);
+    }
+    let head_len = len.min((RECORD_LEN * SNIFF_RECORDS) as u64) as usize;
+    let mut head = vec![0u8; head_len];
+    file.read_exact(&mut head)
+        .map_err(|e| format!("reading input deals file '{}': {}", path, e))?;
+    Ok(records_decode(&head))
+}
+
+/// A note for a file whose name says one format and whose content says another.
+///
+/// Said rather than refused: the content is what gets read either way, and a
+/// file renamed on its way through a browser or a shared drive still holds what
+/// it holds. But a `.zrd` that is really PBN used to be spent on garbage records
+/// and come back as no deals with no complaint, and a `.pbn` that is really a
+/// library used to fail on `stream did not contain valid UTF-8`, which named
+/// neither the file nor the reason.
+fn name_disagrees(path: &str, holds_library: bool) -> Option<String> {
+    let named_library = path.to_ascii_lowercase().ends_with(".zrd");
+    match (named_library, holds_library) {
+        (true, false) => Some(format!(
+            "'{}' is named as a Pavlicek library but does not hold one; reading it as text.",
+            path
+        )),
+        (false, true) => Some(format!(
+            "'{}' holds a Pavlicek library whatever its name says; reading it as one.",
+            path
+        )),
+        _ => None,
+    }
 }
 
 /// Deals from PBN, with each board's table, or `None` if this is not PBN.
@@ -188,18 +342,30 @@ fn read_lines(text: &str) -> (Vec<InputDeal>, InputReport) {
     (deals, report)
 }
 
-/// Read a ZRD library: every deal, and the table that came with it.
+/// Read a ZRD library from a path: every deal, and the table that came with it.
 ///
-/// Returns the deals in file order, each with its table or `None`, and a report
-/// of what else was in there. Unreadable records are skipped rather than fatal
-/// — a library is millions of records and one bad one should not cost the rest
-/// — but they are all named in the report so a caller can decide.
+/// Streamed, because the published library is 241 MB and a path is the one
+/// source that need not be held in memory to be read.
 pub fn read_library(path: &str) -> Result<(Vec<InputDeal>, InputReport), String> {
-    use bridge_encodings::zrd::{Record, ZrdReader};
-
-    let mut reader =
+    let reader =
         ZrdReader::open(path).map_err(|e| format!("opening input deals file '{}': {}", path, e))?;
+    Ok(read_records(reader))
+}
 
+/// Every record of an open library, in file order.
+///
+/// Returns the deals with their tables or `None`, and a report of what else was
+/// in there. Unreadable records are skipped rather than fatal — a library is
+/// millions of records and one bad one should not cost the rest — but they are
+/// all named in the report so a caller can decide.
+///
+/// Generic over the source because that is the only difference between a
+/// library on disk and one that came down a pipe: the pipe's bytes arrive in a
+/// `Cursor`, and everything after that is the same decoding. Two copies of this
+/// loop would be two answers to what a separator is.
+fn read_records<R: std::io::Read + std::io::Seek>(
+    mut reader: ZrdReader<R>,
+) -> (Vec<InputDeal>, InputReport) {
     let mut deals = Vec::new();
     let mut report = InputReport {
         format: "zrd",
@@ -228,18 +394,7 @@ pub fn read_library(path: &str) -> Result<(Vec<InputDeal>, InputReport), String>
         }
     }
 
-    Ok((deals, report))
-}
-
-/// Does this `--input-deals` source name a library rather than a text file?
-///
-/// By extension, because the caller names the file and the two extensions mean
-/// different things. Sniffing the content would be worse than it sounds: a ZRD
-/// record is twenty-three arbitrary bytes, so there is no header to recognise,
-/// and a short text file can be a multiple of twenty-three by accident.
-pub fn is_library_path(source: &str) -> bool {
-    let lower = source.to_ascii_lowercase();
-    lower.ends_with(".zrd") || lower.ends_with(".zdd")
+    (deals, report)
 }
 
 /// Is this the tables-only companion format, which has no deals in it?
@@ -248,6 +403,196 @@ pub fn is_library_path(source: &str) -> bool {
 /// Pavlicek distributes, with the deals regenerated locally into a `.zrd`. A
 /// caller asking to read deals from one has the wrong file, and saying so beats
 /// reading twenty-three-byte records out of ten-byte ones.
+///
+/// By name, unlike the library check, because there is nothing to sniff: a
+/// `.zdd` record is ten bytes of trick counts, which is not a constraint any
+/// text would struggle to meet.
 pub fn is_tables_only_path(source: &str) -> bool {
     source.to_ascii_lowercase().ends_with(".zdd")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ten records of Pavlicek's library, all solved, no separators.
+    ///
+    /// A real file rather than records written here: what is under test is
+    /// reading something this code did not write, and a round trip cannot tell
+    /// that apart from agreeing with itself.
+    const LIBRARY: &[u8] = include_bytes!("../tests/fixtures/rpdd_10First.zrd");
+
+    /// The first record of the fixture, as `bridge_encodings`' own tests have
+    /// it. Pins the order as well as the count: ten deals in the wrong order,
+    /// or ten copies of one, would satisfy a count.
+    const FIRST_DEAL: &str =
+        "N:J873.J42.Q65.KT2 AT652.A976.AJ82. Q4.85.KT9.A87643 K9.KQT3.743.QJ95";
+
+    const ONELINE: &str =
+        "n J873.J42.Q65.KT2 e AT652.A976.AJ82. s Q4.85.KT9.A87643 w K9.KQT3.743.QJ95\n";
+
+    /// A path in the temporary directory, unique to this process and thread.
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "dealer3-deal-input-{}-{:?}-{}",
+            std::process::id(),
+            std::thread::current().id(),
+            name
+        ));
+        path
+    }
+
+    /// The deals as PBN, for comparing two readings of the same bytes.
+    fn as_pbn(deals: &[InputDeal]) -> Vec<String> {
+        deals
+            .iter()
+            .map(|read| bridge_types::Deal::from(&read.deal).to_pbn(bridge_types::Direction::North))
+            .collect()
+    }
+
+    #[test]
+    fn a_library_in_memory_is_recognised_and_read() {
+        assert!(looks_like_library(LIBRARY));
+
+        let (deals, report) = read_bytes(LIBRARY).expect("a library should read from bytes");
+
+        assert_eq!(report.format, "zrd");
+        assert_eq!(deals.len(), 10, "the fixture holds ten records");
+        assert_eq!(report.solved, 10, "every record of it is solved");
+        assert_eq!(report.unsolved, 0);
+        assert_eq!(report.separators, 0);
+        assert!(report.skipped.is_empty(), "skipped: {:?}", report.skipped);
+        assert!(
+            report.notes.is_empty(),
+            "bytes have no name to disagree with: {:?}",
+            report.notes
+        );
+        assert_eq!(as_pbn(&deals)[0], FIRST_DEAL);
+        assert!(
+            deals.iter().all(|read| read.table.is_some()),
+            "every deal should have brought its table through"
+        );
+    }
+
+    #[test]
+    fn text_whose_length_is_a_multiple_of_a_record_is_still_text() {
+        // The length test alone would let this through, so it is the record
+        // decoding that has to refuse it — which is the whole claim the sniff
+        // makes.
+        let mut text = ONELINE.to_string();
+        while !text.len().is_multiple_of(RECORD_LEN) {
+            text.push('\n');
+        }
+        assert!(
+            text.len().is_multiple_of(RECORD_LEN),
+            "this test is pointless unless the length is a whole number of records"
+        );
+
+        assert!(!looks_like_library(text.as_bytes()));
+
+        let (deals, report) = read_bytes(text.as_bytes()).expect("text should read as text");
+        assert_eq!(report.format, "lines");
+        assert_eq!(deals.len(), 1);
+        assert_eq!(report.unsolved, 1);
+        assert!(report.skipped.is_empty(), "skipped: {:?}", report.skipped);
+    }
+
+    #[test]
+    fn a_pbn_board_read_from_bytes_still_arrives_with_its_table() {
+        let pbn = "[Board \"1\"]\n\
+                   [Deal \"N:QJ3.A93.K4.KT875 A98.QJT2.97653.2 T76.K65.AQJ8.J43 K542.874.T2.AQ96\"]\n\
+                   [DoubleDummyTricks \"87879878793555345564\"]\n";
+
+        let (deals, report) = read_bytes(pbn.as_bytes()).expect("PBN should read from bytes");
+        assert_eq!(report.format, "pbn");
+        assert_eq!(deals.len(), 1);
+        assert_eq!(report.solved, 1);
+        assert!(deals[0].table.is_some());
+    }
+
+    #[test]
+    fn a_library_cut_short_says_so_rather_than_complaining_about_utf8() {
+        // What a `curl` that lost its connection leaves behind. It used to
+        // arrive as "stream did not contain valid UTF-8", which names neither
+        // the format that was expected nor the reason it was not found.
+        let truncated = &LIBRARY[..LIBRARY.len() - 5];
+        assert!(!looks_like_library(truncated));
+
+        let error = read_bytes(truncated).expect_err("a part-record library cannot be read");
+        assert!(
+            error.contains("neither a Pavlicek library nor text"),
+            "should rule out both formats: {}",
+            error
+        );
+        assert!(
+            error.contains("left over"),
+            "should say the records do not come out whole: {}",
+            error
+        );
+    }
+
+    #[test]
+    fn a_library_under_a_text_name_is_read_as_a_library_and_noted() {
+        let path = temp_path("named.pbn");
+        std::fs::write(&path, LIBRARY).expect("write fixture");
+        let source = path.to_str().expect("utf-8 path");
+
+        let (deals, report) = read(source).expect("the content is a library whatever the name");
+        assert_eq!(report.format, "zrd");
+        assert_eq!(deals.len(), 10);
+        assert_eq!(report.solved, 10);
+        assert!(
+            report.notes.iter().any(|n| n.contains("whatever its name")),
+            "the disagreement should be said out loud: {:?}",
+            report.notes
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn text_under_a_library_name_is_read_as_text_and_noted() {
+        let path = temp_path("named.zrd");
+        std::fs::write(&path, ONELINE).expect("write fixture");
+        let source = path.to_str().expect("utf-8 path");
+
+        let (deals, report) = read(source).expect("the content is text whatever the name");
+        assert_eq!(report.format, "lines");
+        assert_eq!(deals.len(), 1, "it used to come back as no deals at all");
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|n| n.contains("named as a Pavlicek library")),
+            "the disagreement should be said out loud: {:?}",
+            report.notes
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn a_library_reads_the_same_from_a_path_as_from_a_pipe() {
+        // The two sources may differ in where the bytes come from and nowhere
+        // else; a streaming reader and a `Cursor` that disagreed about a record
+        // would be invisible from either side alone.
+        let path = temp_path("same.zrd");
+        std::fs::write(&path, LIBRARY).expect("write fixture");
+        let source = path.to_str().expect("utf-8 path");
+
+        let (from_path, path_report) = read(source).expect("read from a path");
+        let (from_bytes, bytes_report) = read_bytes(LIBRARY).expect("read from bytes");
+
+        assert_eq!(path_report, bytes_report);
+        assert_eq!(as_pbn(&from_path), as_pbn(&from_bytes));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn a_tables_only_file_is_still_refused_by_name() {
+        let error = read("deals.zdd").expect_err(".zdd holds no deals");
+        assert!(error.contains("no deals in it"), "{}", error);
+    }
 }

--- a/dealer-run/src/deal_input.rs
+++ b/dealer-run/src/deal_input.rs
@@ -215,8 +215,8 @@ pub fn looks_like_library(bytes: &[u8]) -> bool {
 /// a file on disk and a pipe cannot come to different conclusions about the
 /// same bytes.
 fn records_decode(head: &[u8]) -> bool {
-    head.chunks_exact(RECORD_LEN)
-        .all(|record| read_record(record).is_ok())
+    let (records, _) = head.as_chunks::<RECORD_LEN>();
+    records.iter().all(|record| read_record(record).is_ok())
 }
 
 /// Does the file at `path` hold a library? Reads its head, not the whole file.

--- a/dealer-run/src/lib.rs
+++ b/dealer-run/src/lib.rs
@@ -49,7 +49,25 @@ pub fn deals_from_file(
     path: &str,
 ) -> Result<(Vec<run::SolvedDeal>, deal_input::InputReport), String> {
     let (records, report) = deal_input::read(path)?;
-    let deals = records
+    Ok((to_solved(records), report))
+}
+
+/// The same, from bytes a caller already holds.
+///
+/// What a front end without a filesystem needs: a page handed a file, or a
+/// library fetched over the network. It reaches the same reader as
+/// [`deals_from_file`] — the difference between the two is where the bytes came
+/// from, and it stops there.
+pub fn deals_from_bytes(
+    bytes: &[u8],
+) -> Result<(Vec<run::SolvedDeal>, deal_input::InputReport), String> {
+    let (records, report) = deal_input::read_bytes(bytes)?;
+    Ok((to_solved(records), report))
+}
+
+/// Pair each deal with what is already known of its double-dummy answers.
+fn to_solved(records: Vec<deal_input::InputDeal>) -> Vec<run::SolvedDeal> {
+    records
         .into_iter()
         .map(|record| {
             let known = match &record.table {
@@ -58,8 +76,7 @@ pub fn deals_from_file(
             };
             (record.deal, known)
         })
-        .collect();
-    Ok((deals, report))
+        .collect()
 }
 
 pub use run::{

--- a/dealer-run/tests/fixtures/README.md
+++ b/dealer-run/tests/fixtures/README.md
@@ -1,0 +1,13 @@
+# Input fixtures
+
+`rpdd_10First.zrd` — the first ten records of Richard Pavlicek's solved-deal
+library, as shipped with DealerV2_4. 230 bytes, ten 23-byte records, every one
+of them solved and none of them a separator.
+
+Copied from `bridge-encodings`' own fixture rather than read from that checkout:
+a test that reaches outside this repository passes or fails on what is beside
+it, which is not a property of this code.
+
+It is the only input that can tell the format sniff from a lucky guess. Bytes
+written here by a test would be bytes this code both wrote and read, and the
+whole question is whether it reads a file it did not write.

--- a/dealer-run/tests/fixtures/rpdd_10First.zrd
+++ b/dealer-run/tests/fixtures/rpdd_10First.zrd
@@ -1,0 +1,2 @@
+rRz
+ázäùRàAü|IIII+*99gg¯þV#i—EŒ p} ¾77££uu99……ÔQŒDrNöz,-8ª¢¢²²““££„„U<9j°^xŒø4¨vv££gg„„uu¸ÈSíÙiw”à²uuXX¢¢²²XX¿$5FÒBæ.øTs©ÁÁÁÁ££²²ÁÁcn¢‡sK1B7=ˆgg::::IIHH::q–&œàôX»žOÞIIIH99IIgg$ö~ˆ°'läßiå„„ggIIvv””KÒ$D©j†Ðìw¿££XXIIHI²¢

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -460,6 +460,12 @@ fn read_input_deals(source: &str) -> Vec<dealer_run::run::SolvedDeal> {
         std::process::exit(1);
     });
 
+    // A name that disagreed with the content is worth a line: the file was read
+    // as what it holds, which is not what the caller asked for by name.
+    for note in &report.notes {
+        eprintln!("Note: {}", note);
+    }
+
     // Unreadable content is indistinguishable from metadata in a text file, so
     // a caller that needs to know every deal arrived should compare the count
     // against what it expected. Named individually up to a limit, then counted.

--- a/dealer/tests/input_deals.rs
+++ b/dealer/tests/input_deals.rs
@@ -42,6 +42,21 @@ fn temp_file(tag: &str, contents: &str) -> PathBuf {
     path
 }
 
+/// The same for bytes, and with an extension, so a name can be made to
+/// disagree with what the file holds.
+fn temp_binary(tag: &str, extension: &str, contents: &[u8]) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "dealer3-test-{}-{}-{:?}.{}",
+        tag,
+        std::process::id(),
+        std::thread::current().id(),
+        extension
+    ));
+    std::fs::write(&path, contents).expect("failed to write temp file");
+    path
+}
+
 struct Output {
     stdout: String,
     stderr: String,
@@ -50,6 +65,12 @@ struct Output {
 
 /// Run the binary with `args`, optionally piping `stdin_data` in.
 fn run(args: &[&str], stdin_data: Option<&str>) -> Output {
+    run_bytes(args, stdin_data.map(|data| data.as_bytes()))
+}
+
+/// The same, for input that is not text: a ZRD library is binary, and it is
+/// exactly the case that used to die before the reader saw it.
+fn run_bytes(args: &[&str], stdin_data: Option<&[u8]>) -> Output {
     let mut child = Command::new(bin())
         .args(args)
         .stdin(Stdio::piped())
@@ -61,7 +82,7 @@ fn run(args: &[&str], stdin_data: Option<&str>) -> Output {
     {
         let stdin = child.stdin.as_mut().expect("stdin unavailable");
         if let Some(data) = stdin_data {
-            stdin.write_all(data.as_bytes()).expect("write to stdin");
+            stdin.write_all(data).expect("write to stdin");
         }
     }
     // Dropping stdin closes it, so the child sees EOF.
@@ -562,5 +583,144 @@ fn a_pbn_table_is_used_rather_than_solved_again() {
         "solving anyway would give 8 for North notrump, and would mean the tag was \
          ignored:\n{}",
         out.stdout
+    );
+}
+
+/// Ten records of Pavlicek's solved-deal library: binary, and not valid UTF-8,
+/// which is what used to stop it at the door.
+const LIBRARY: &[u8] = include_bytes!("../../dealer-run/tests/fixtures/rpdd_10First.zrd");
+
+/// A library arriving down a pipe is read as a library.
+///
+/// The point of the pipe is `curl -s https://…/deals.zrd | dealer script.dlr
+/// --input-deals -`, which is how a library reaches this program without it
+/// growing an HTTP client. It used to fail on "stream did not contain valid
+/// UTF-8": stdin was read into a `String`, and the format was decided by the
+/// filename, which `-` does not have.
+#[test]
+fn a_library_piped_in_is_read_as_one() {
+    let script = temp_file("script-piped-library", "condition 1\n");
+
+    let out = run_bytes(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            "-",
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        Some(LIBRARY),
+    );
+
+    assert!(out.success, "stderr:\n{}", out.stderr);
+    assert!(
+        out.stdout.contains("Generated 10 hands"),
+        "all ten records should have been read:\n{}",
+        out.stdout
+    );
+    assert_eq!(count_deals(&out.stdout), 10, "stdout:\n{}", out.stdout);
+    // The records are solved, so their tables came through the pipe too. A
+    // reader that recovered the deals and dropped the tables would produce the
+    // same ten deals and say nothing here.
+    assert!(
+        out.stderr.contains("10 of 10 deals"),
+        "the tables should have arrived with the deals:\n{}",
+        out.stderr
+    );
+}
+
+/// A library under a name that says otherwise is read for what it holds.
+#[test]
+fn a_library_named_as_pbn_is_read_and_the_mismatch_reported() {
+    let corpus = temp_binary("library-as-pbn", "pbn", LIBRARY);
+    let script = temp_file("script-library-as-pbn", "condition 1\n");
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        None,
+    );
+
+    assert!(out.success, "stderr:\n{}", out.stderr);
+    assert!(
+        out.stdout.contains("Generated 10 hands"),
+        "stdout:\n{}",
+        out.stdout
+    );
+    assert!(
+        out.stderr.contains("whatever its name says"),
+        "the name and the content disagree, and that should be said:\n{}",
+        out.stderr
+    );
+}
+
+/// And text under a `.zrd` name, which is the half-download case.
+///
+/// It used to be read as twenty-three-byte records of nothing: no deals, no
+/// error, and no clue which of the two was wrong.
+#[test]
+fn text_named_as_a_library_is_read_and_the_mismatch_reported() {
+    let corpus = temp_binary("text-as-zrd", "zrd", ONELINE_CORPUS.as_bytes());
+    let script = temp_file("script-text-as-zrd", FILTER);
+
+    let out = run(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            corpus.to_str().unwrap(),
+            "-f",
+            "oneline",
+            "-X",
+        ],
+        None,
+    );
+
+    assert!(out.success, "stderr:\n{}", out.stderr);
+    assert!(
+        out.stdout.contains("Generated 6 hands"),
+        "the deals are there to be read:\n{}",
+        out.stdout
+    );
+    assert_eq!(count_deals(&out.stdout), 2, "stdout:\n{}", out.stdout);
+    assert!(
+        out.stderr.contains("named as a Pavlicek library"),
+        "the name and the content disagree, and that should be said:\n{}",
+        out.stderr
+    );
+}
+
+/// A library that arrived short is refused in terms of the library it is.
+#[test]
+fn a_library_cut_short_is_refused_with_a_reason() {
+    let script = temp_file("script-truncated", "condition 1\n");
+
+    let out = run_bytes(
+        &[
+            script.to_str().unwrap(),
+            "--input-deals",
+            "-",
+            "-f",
+            "oneline",
+        ],
+        Some(&LIBRARY[..LIBRARY.len() - 5]),
+    );
+
+    assert!(!out.success, "stdout:\n{}", out.stdout);
+    assert!(
+        out.stderr.contains("neither a Pavlicek library nor text"),
+        "should name both formats it ruled out:\n{}",
+        out.stderr
+    );
+    assert!(
+        !out.stderr.contains("stream did not contain valid UTF-8"),
+        "that message is what this replaced:\n{}",
+        out.stderr
     );
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`--input-deals` reads a solved-deal library from a pipe**, so a library can
+  be fetched by something that already knows how:
+
+  ```
+  curl -s https://.../deals.zrd | dealer script.dlr --input-deals -
+  ```
+
+  - The format is now decided by the content rather than the filename. Standard
+    input has no filename, so a piped library was read as text and died on
+    `stream did not contain valid UTF-8` before any reader saw it.
+  - A file whose name disagrees with what is in it — a `.zrd` holding PBN, or
+    the reverse — is read for what it holds and the disagreement reported. The
+    first of those used to come back as no deals at all, with nothing said.
+  - No HTTP client: `curl` is not being reimplemented here.
 - **Two-dimensional `frequency`.** A second expression and range turns the
   histogram into a cross-tabulation: the first expression down the rows, the
   second across the columns, a Low and a High on each axis, and marginal sums


### PR DESCRIPTION
Closes #69.

`curl -s https://.../deals.zrd | dealer script.dlr --input-deals -` failed with
"stream did not contain valid UTF-8". Two things compounded: the stdin branch
read to a `String`, so binary died before anything else got a chance, and format
detection came from the filename, so `-` was never a library however it decoded.

## Content, not filename

`read()` now reads stdin as bytes. `looks_like_library` asks whether the bytes
are a whole number of 23-byte records whose first 64 all decode through
`bridge_encodings::zrd::read_record` — bounded, because sniffing *is* decoding
and the published library is ten million records. Anything else is interpreted
as UTF-8 and takes the existing text path.

`records_decode` is the single place that decision lives, called by both the
in-memory sniff and the head-of-file sniff, so a pipe and a path cannot come to
different conclusions about the same bytes. A file still streams through
`ZrdReader::open`; bytes go through a `Cursor`, which needs no new decoding
because `ZrdReader::new` is generic over `Read + Seek`.

`is_library_path` is gone — it decided by extension and nothing else used it.
`is_tables_only_path` stays: there is nothing to sniff in ten bytes of trick
counts, so `.zdd` is still refused by name.

## A byte-oriented entry point, for #66

```rust
pub fn deal_input::read_bytes(&[u8]) -> Result<(Vec<InputDeal>, InputReport), String>
pub fn deals_from_bytes(&[u8])        -> Result<(Vec<run::SolvedDeal>, InputReport), String>
```

Both share one decoder with the path-taking versions; the only difference is the
name used in an error message. A wasm caller needs `deals_from_bytes` and
touches no filesystem — one decoder with two callers rather than two that drift.

## Diagnostics

A file whose name and content disagree is read for what it holds and says so,
through a new `InputReport::notes`. A ragged truncation names the remainder:

> standard input is neither a Pavlicek library nor text: invalid utf-8 sequence
> of 1 bytes from index 0. A library is a whole number of 23-byte records, and
> this is 2310 bytes with 10 left over — which is what a download cut short
> looks like.

## Verified by hand as well as by tests

A piped library produces output identical to reading the same file by path, bar
the source name in the note. Every new test was broken deliberately and
confirmed to fail: restoring `read_to_string` on the stdin branch reproduces the
issue's exact symptom, and removing the CLI's note loop fails the mislabelling
tests on stderr rather than only in the library.

Gate: `cargo fmt` and `cargo clippy -D warnings` clean, 44 test binaries green.
No HTTP client was added — `curl` already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)