### PR TITLE
Read a library from an offset, and only as far as needed (#65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,47 @@ jobs:
       if: runner.os == 'Linux'
       run: scripts/third-party-notices.py --check
 
+  wasm:
+    name: WebAssembly
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+        targets: wasm32-unknown-unknown
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: wasm
+
+    # `wasm/` is its own workspace, so nothing above builds it. That is how a
+    # change to `dealer-run`'s API reached `main` while the bindings that call
+    # it no longer compiled: the root gate was green and had no reason not to
+    # be. This job is what makes the two front ends fail together.
+    - name: Check formatting
+      working-directory: wasm
+      run: cargo fmt --all -- --check
+
+    - name: Run clippy
+      working-directory: wasm
+      run: cargo clippy --all-targets -- -D warnings
+
+    # Host target, so the tests actually run — the wasm ones would need a
+    # browser or Node, and these assert on what the engine did with the deals.
+    - name: Run tests
+      working-directory: wasm
+      run: cargo test
+
+    - name: Build for wasm32
+      working-directory: wasm
+      run: cargo build --target wasm32-unknown-unknown --release
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -198,7 +239,7 @@ jobs:
   build-summary:
     name: Build Summary
     runs-on: ubuntu-latest
-    needs: [test, lint, check-licenses, regression]
+    needs: [test, wasm, lint, check-licenses, regression]
 
     steps:
     - name: Summary

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ echo "hcp(north) >= 0" | dealer -E S8743,HA9,D642,CQT64 -W SQ965,HK63,DAQJT,CA5 
 
 ### Deal Input
 - `--input-deals SOURCE` - Read deals from a file instead of generating them; use `-` for stdin
+- `--input-offset N` - Start a solved-deal library at record N (records, separators included)
+- `--input-limit N` - Read this many deals from it, wrapping round the file when it runs short
 
 ### Export
 - `-C FILE, --CSV FILE` - CSV export file
@@ -92,6 +94,9 @@ cat hands.pbn | dealer filter.dlr --input-deals - -f oneline
 # A binary library reads the same way, so fetching one needs no HTTP client here
 curl -s https://example.org/deals.zrd | dealer filter.dlr --input-deals -
 
+# Forty deals out of a ten-million-record library, from a reproducible place in it
+dealer filter.dlr --input-deals rpdd.zrd -s 42 -g 5000
+
 # Check how many deals in a file satisfy a constraint
 echo "hcp(north) >= 15" > strong.dlr
 dealer strong.dlr --input-deals hands.pbn -q -X
@@ -102,7 +107,18 @@ dealer3's regression tests compare constraint evaluation against dealer.exe.
 
 Notes:
 
-- `--seed` is ignored — the deals are supplied, not generated.
+- `--seed` picks where in a **solved-deal library** to start reading, so the same
+  seed reads the same deals there, exactly as it deals the same deals when
+  generating. For PBN and one-line files it is ignored — those are read in the
+  order somebody wrote them.
+- `--input-offset` names a starting record outright instead. It counts *records*,
+  separators included, because that is what the file numbers; `--input-limit`
+  counts deals, because deals are what a run spends. Past the end of the file
+  wraps round to the beginning.
+- `--input-limit` larger than the library repeats deals, and `average` and
+  `frequency` then count each repeat — a sample with replacement rather than a
+  bigger sample. The run says so when it happens. `-g` on its own never repeats:
+  it is a ceiling on what gets read, not a demand.
 - It cannot be combined with predeal, since predeal only applies to generation.
 - `-p` and `-g` still apply: `-p` stops once that many deals match, `-g` caps how many
   are read. Running out of input before `-p` is satisfied is not an error.

--- a/dealer-run/src/deal_input.rs
+++ b/dealer-run/src/deal_input.rs
@@ -25,6 +25,15 @@
 //! real deal. `bridge_encodings` reports that as `None` too, so an unsolved
 //! record and a one-line deal arrive here indistinguishable, as they should.
 //!
+//! ## A window, not the whole file
+//!
+//! A library is not read from the front, and it is not read entire. The
+//! published one is ten million records, and a script asking for forty deals
+//! has no use for the other 9,999,960 of them. [`Window`] says where to start
+//! and how much to take; [`Start::Seed`] is what makes `-s` mean the same
+//! thing for a library as for a generated run, which is to say the same seed
+//! gives the same deals.
+//!
 //! ## Two sources, one decoder
 //!
 //! [`read`] takes somewhere to read from; [`read_bytes`] takes the bytes. The
@@ -34,6 +43,7 @@
 
 use bridge_encodings::zrd::{read_record, Record, ZrdReader, RECORD_LEN};
 use bridge_types::DdTable;
+use dealer_core::rng::Xoshiro256PlusPlus;
 use dealer_core::Deal;
 
 /// How many records the format sniff decodes before it is satisfied.
@@ -44,6 +54,133 @@ use dealer_core::Deal;
 /// split thirteen cards to a seat about once in four hundred, and would have to
 /// do it sixty-four times running with twenty legal trick counts each time.
 const SNIFF_RECORDS: usize = 64;
+
+/// Which part of a library to read: where to start, and how much to take.
+///
+/// A `.zrd` is fixed-length records, so a start is arithmetic and a seek
+/// rather than a scan. Nothing else here can be windowed — PBN and one-line
+/// have to be read to be counted — so a start given for text declines out
+/// loud rather than pretending, while a limit is honoured by taking the first
+/// deals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Window {
+    /// Which record to read first.
+    pub start: Start,
+    /// How many deals to take from there.
+    pub take: Take,
+}
+
+impl Default for Window {
+    fn default() -> Self {
+        Window {
+            start: Start::Record(0),
+            take: Take::Pass,
+        }
+    }
+}
+
+impl Window {
+    /// The whole library in file order: what a caller with no opinion wants.
+    pub fn all() -> Self {
+        Window::default()
+    }
+}
+
+/// Which record a read starts at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Start {
+    /// A record ordinal, counting from zero, and counting *records* — a
+    /// separator is a record and spends one of these, which is what makes an
+    /// offset arithmetic on a file position rather than a count of deals.
+    ///
+    /// Past the end wraps rather than failing: the library is a ring here, and
+    /// there is nothing at the end of it to fall off.
+    Record(u64),
+    /// The run's seed, which picks the record.
+    ///
+    /// This is what keeps `-s` meaning one thing across both deal sources: a
+    /// generated run reproduces from its seed, and so does a library run.
+    Seed(u32),
+}
+
+/// How much of a library to take.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Take {
+    /// One pass: every deal in the library, starting at [`Start`] and coming
+    /// round to it again.
+    Pass,
+    /// At most this many deals, and never more than the library holds. What a
+    /// run's `-g` amounts to — a ceiling on what will be looked at, not a
+    /// demand for that many.
+    AtMost(usize),
+    /// Exactly this many deals, repeating the library from the start when it
+    /// runs short. That repeats *deals*, and is reported when it happens.
+    Exactly(usize),
+}
+
+impl Take {
+    /// The most deals this will yield, or `None` for a whole pass.
+    fn limit(self) -> Option<usize> {
+        match self {
+            Take::Pass => None,
+            Take::AtMost(n) | Take::Exactly(n) => Some(n),
+        }
+    }
+}
+
+impl Start {
+    /// Which record to begin at, in a library of `records` records.
+    ///
+    /// `records` must not be zero: an empty library is turned away before this
+    /// is asked, because there is no record to name.
+    ///
+    /// ## Why the seed is mixed rather than used as it stands
+    ///
+    /// DealerV2_4 does the plainer thing — its `seek_rpdd_pos()` reads the
+    /// seed as a count of 1000-record blocks to skip, and refuses a seed past
+    /// the end of the file. Two reasons not to follow it. A seed would mean
+    /// different deals depending on how big the library is, and would be an
+    /// *error* for a small one, where dealer3's `-s` is a `u32` that always
+    /// stands for something. And seeds here are small integers far more often
+    /// than not — `-s 1`, `-s 2`, `-s 3` across a lesson set — which under a
+    /// block skip puts three runs in three adjacent blocks of a file whose
+    /// records are in generated order. Mixing decorrelates them and costs
+    /// nothing: one `SplitMix64` expansion and one draw.
+    ///
+    /// The RNG is dealer3's own, so a seed picks the same record in a browser
+    /// as at a terminal.
+    pub fn record(self, records: u64) -> u64 {
+        match self {
+            Start::Record(index) => index % records,
+            Start::Seed(seed) => {
+                Xoshiro256PlusPlus::seed_from_u64(seed as u64).next_u64() % records
+            }
+        }
+    }
+
+    /// What to say about starting there, if anything.
+    ///
+    /// Said for a seed always, because a run nobody can reproduce is worth a
+    /// line, and for an ordinal only when it moved — record 0 is where a file
+    /// starts anyway.
+    fn note(self, start: u64, records: u64) -> Option<String> {
+        match self {
+            Start::Seed(seed) => Some(format!(
+                "seed {} starts this library at record {} of {}; the same seed reads the same deals.",
+                seed, start, records
+            )),
+            Start::Record(index) if index >= records => Some(format!(
+                "record {} is past the end of a {}-record library; starting at record {}.",
+                index, records, start
+            )),
+            Start::Record(0) => None,
+            Start::Record(_) => Some(format!(
+                "starting this library at record {} of {}.",
+                start, records
+            )),
+        }
+    }
+}
 
 /// A deal from a file, and the table that came with it.
 #[derive(Debug, Clone)]
@@ -116,7 +253,11 @@ pub struct InputReport {
 /// `Generated/Produced/Time needed` trailer parses and keeps the trailer, and
 /// so does one whose first line begins with the stray `<EOF>` characters
 /// dealer.exe's block-comment bug emits.
-pub fn read(source: &str) -> Result<(Vec<InputDeal>, InputReport), String> {
+///
+/// `window` says which part of a library to read; it is [`Window::all`] for a
+/// caller that wants the file as it stands. Text is read entire whatever the
+/// window says, bar its limit — see [`Window`].
+pub fn read(source: &str, window: Window) -> Result<(Vec<InputDeal>, InputReport), String> {
     if is_tables_only_path(source) {
         return Err(format!(
             "'{}' holds double-dummy tables with no deals in it. Read the .zrd built \
@@ -131,18 +272,18 @@ pub fn read(source: &str) -> Result<(Vec<InputDeal>, InputReport), String> {
         std::io::stdin()
             .read_to_end(&mut bytes)
             .map_err(|e| format!("reading deals from standard input: {}", e))?;
-        return read_named(&bytes, "standard input");
+        return read_named(&bytes, "standard input", window);
     }
 
     // A named library is streamed rather than read into memory to be sniffed:
     // the published one is 241 MB, and its head settles the question.
     let library = path_holds_library(source)?;
     let mut read = if library {
-        read_library(source)?
+        read_library(source, window)?
     } else {
         let bytes = std::fs::read(source)
             .map_err(|e| format!("opening input deals file '{}': {}", source, e))?;
-        read_named(&bytes, &format!("'{}'", source))?
+        read_named(&bytes, &format!("'{}'", source), window)?
     };
     if let Some(note) = name_disagrees(source, library) {
         read.1.notes.push(note);
@@ -156,19 +297,23 @@ pub fn read(source: &str) -> Result<(Vec<InputDeal>, InputReport), String> {
 /// somewhere to read from. A browser handed a file by the page reads it here,
 /// so that a supplied library behaves the same in a tab as at a terminal rather
 /// than through a second decoder that drifts from this one.
-pub fn read_bytes(bytes: &[u8]) -> Result<(Vec<InputDeal>, InputReport), String> {
-    read_named(bytes, "the supplied deals")
+pub fn read_bytes(bytes: &[u8], window: Window) -> Result<(Vec<InputDeal>, InputReport), String> {
+    read_named(bytes, "the supplied deals", window)
 }
 
 /// [`read_bytes`], with a name for the bytes so an error can say where they came
 /// from. Nothing else differs between the two, and nothing else may.
-fn read_named(bytes: &[u8], what: &str) -> Result<(Vec<InputDeal>, InputReport), String> {
+fn read_named(
+    bytes: &[u8],
+    what: &str,
+    window: Window,
+) -> Result<(Vec<InputDeal>, InputReport), String> {
     if looks_like_library(bytes) {
         // `Cursor` is `Read + Seek`, which is all `ZrdReader` ever wanted, so a
         // library that came down a pipe needs no decoding of its own.
         let reader = ZrdReader::new(std::io::Cursor::new(bytes))
             .map_err(|e| format!("reading {} as a library: {}", what, e))?;
-        return Ok(read_records(reader));
+        return Ok(read_records(reader, window));
     }
 
     let text = std::str::from_utf8(bytes).map_err(|e| {
@@ -193,10 +338,49 @@ fn read_named(bytes: &[u8], what: &str) -> Result<(Vec<InputDeal>, InputReport),
         )
     })?;
 
-    if let Some(read) = read_pbn(text) {
-        return Ok(read);
+    let mut read = match read_pbn(text) {
+        Some(read) => read,
+        None => read_lines(text),
+    };
+    narrow_text(&mut read.0, &mut read.1, what, window);
+    Ok(read)
+}
+
+/// Apply what of a window a text file can honour, and say so about the rest.
+///
+/// A limit is honoured: the deals are in hand, and keeping only the first `n`
+/// is what "read only what the run will use" comes to for a format that has to
+/// be read to be counted. A start is not: there is no record to seek to, and a
+/// seed picking a starting board in a forty-board PBN file would rotate a file
+/// somebody assembled in the order they meant.
+///
+/// So a seed goes quietly — it is the run's seed, not something the caller
+/// asked of this file — and a named record says out loud that it did nothing.
+fn narrow_text(deals: &mut Vec<InputDeal>, report: &mut InputReport, what: &str, window: Window) {
+    if let Start::Record(index) = window.start {
+        if index > 0 {
+            report.notes.push(format!(
+                "{} is not a Pavlicek library, so there is no record {} to start at; \
+                 it was read from the beginning.",
+                what, index
+            ));
+        }
     }
-    Ok(read_lines(text))
+    if let Some(limit) = window.take.limit() {
+        if deals.len() > limit {
+            deals.truncate(limit);
+            recount(deals, report);
+        }
+    }
+}
+
+/// Put `solved` and `unsolved` back in step with the deals that survived.
+///
+/// The two counts describe what the caller is being handed, not what the file
+/// held, so anything that adds or removes deals owes them a recount.
+fn recount(deals: &[InputDeal], report: &mut InputReport) {
+    report.solved = deals.iter().filter(|read| read.table.is_some()).count();
+    report.unsolved = deals.len() - report.solved;
 }
 
 /// Do these bytes hold a Pavlicek library?
@@ -342,22 +526,36 @@ fn read_lines(text: &str) -> (Vec<InputDeal>, InputReport) {
     (deals, report)
 }
 
-/// Read a ZRD library from a path: every deal, and the table that came with it.
+/// Read `window` of a ZRD library at a path, with the tables that came along.
 ///
 /// Streamed, because the published library is 241 MB and a path is the one
-/// source that need not be held in memory to be read.
-pub fn read_library(path: &str) -> Result<(Vec<InputDeal>, InputReport), String> {
+/// source that need not be held in memory to be read. The window is why that
+/// matters: a run wanting forty deals out of ten million records now reads
+/// forty-odd records, not ten million.
+pub fn read_library(path: &str, window: Window) -> Result<(Vec<InputDeal>, InputReport), String> {
     let reader =
         ZrdReader::open(path).map_err(|e| format!("opening input deals file '{}': {}", path, e))?;
-    Ok(read_records(reader))
+    Ok(read_records(reader, window))
 }
 
-/// Every record of an open library, in file order.
+/// The window's records of an open library, in file order from its start.
 ///
 /// Returns the deals with their tables or `None`, and a report of what else was
 /// in there. Unreadable records are skipped rather than fatal — a library is
 /// millions of records and one bad one should not cost the rest — but they are
 /// all named in the report so a caller can decide.
+///
+/// ## The file is a ring
+///
+/// Reading runs from the window's first record to the end and then round to it
+/// again, so a start near the end of the file still yields a whole library
+/// rather than a tail. One pass at most: coming back to where it began is
+/// where a pass stops, whatever the limit says, because everything past that
+/// point is a deal this run has already seen.
+///
+/// [`Take::Exactly`] is the one caller that wants more than a pass, and it
+/// repeats what the pass found rather than reading the file again — the same
+/// records would come back, at the price of reading them twice.
 ///
 /// Generic over the source because that is the only difference between a
 /// library on disk and one that came down a pipe: the pipe's bytes arrive in a
@@ -365,6 +563,7 @@ pub fn read_library(path: &str) -> Result<(Vec<InputDeal>, InputReport), String>
 /// loop would be two answers to what a separator is.
 fn read_records<R: std::io::Read + std::io::Seek>(
     mut reader: ZrdReader<R>,
+    window: Window,
 ) -> (Vec<InputDeal>, InputReport) {
     let mut deals = Vec::new();
     let mut report = InputReport {
@@ -372,8 +571,26 @@ fn read_records<R: std::io::Read + std::io::Seek>(
         ..Default::default()
     };
 
-    for (index, record) in reader.records().enumerate() {
-        match record {
+    let records = reader.len();
+    if records == 0 {
+        return (deals, report);
+    }
+
+    let start = window.start.record(records);
+    if let Some(note) = window.start.note(start, records) {
+        report.notes.push(note);
+    }
+    let limit = window.take.limit();
+
+    for step in 0..records {
+        if limit.is_some_and(|want| deals.len() >= want) {
+            break;
+        }
+        // The offset counts records rather than deals, which is what makes it
+        // a seek: `index` is the ordinal the file itself numbers by, and a
+        // separator spends one of them.
+        let index = (start + step) % records;
+        match reader.record(index) {
             Ok(Record::Separator) => report.separators += 1,
             Ok(Record::Deal { deal, table }) => match Deal::try_from(&deal) {
                 Ok(deal) => {
@@ -394,7 +611,49 @@ fn read_records<R: std::io::Read + std::io::Seek>(
         }
     }
 
+    if let Take::Exactly(want) = window.take {
+        repeat_to(&mut deals, &mut report, want);
+    }
+
     (deals, report)
+}
+
+/// Go round the library again until `want` deals are in hand, and say so.
+///
+/// The repeats are the deals already read, in the order they were read: going
+/// back to the file would return the same records at the price of reading them
+/// twice.
+///
+/// ## Why this is worth a note
+///
+/// A run that wraps sees some deals more than once, and `average` and
+/// `frequency` count each sighting. That is a sample with replacement drawn in
+/// a correlated order — fine for "deal me hands to look at", misleading for
+/// "what fraction of deals are like this". Neither this module nor the run can
+/// tell which of the two the caller wanted, so it says what happened and lets
+/// them judge.
+///
+/// A library with no deals in it is left alone: repeating nothing yields
+/// nothing, and looping to find that out would never end.
+fn repeat_to(deals: &mut Vec<InputDeal>, report: &mut InputReport, want: usize) {
+    let pass = deals.len();
+    if pass == 0 || pass >= want {
+        return;
+    }
+
+    report.notes.push(format!(
+        "the library holds {} deals and the run asked for {}; deals repeat from the start \
+         after the first pass, so `average` and `frequency` count the repeats.",
+        pass, want
+    ));
+
+    while deals.len() < want {
+        // From the front each time, which is the same thing as carrying on
+        // round the ring: every copy but the last is a whole pass.
+        let more = (want - deals.len()).min(pass);
+        deals.extend_from_within(..more);
+    }
+    recount(deals, report);
 }
 
 /// Is this the tables-only companion format, which has no deals in it?
@@ -455,7 +714,8 @@ mod tests {
     fn a_library_in_memory_is_recognised_and_read() {
         assert!(looks_like_library(LIBRARY));
 
-        let (deals, report) = read_bytes(LIBRARY).expect("a library should read from bytes");
+        let (deals, report) =
+            read_bytes(LIBRARY, Window::all()).expect("a library should read from bytes");
 
         assert_eq!(report.format, "zrd");
         assert_eq!(deals.len(), 10, "the fixture holds ten records");
@@ -491,7 +751,8 @@ mod tests {
 
         assert!(!looks_like_library(text.as_bytes()));
 
-        let (deals, report) = read_bytes(text.as_bytes()).expect("text should read as text");
+        let (deals, report) =
+            read_bytes(text.as_bytes(), Window::all()).expect("text should read as text");
         assert_eq!(report.format, "lines");
         assert_eq!(deals.len(), 1);
         assert_eq!(report.unsolved, 1);
@@ -504,7 +765,8 @@ mod tests {
                    [Deal \"N:QJ3.A93.K4.KT875 A98.QJT2.97653.2 T76.K65.AQJ8.J43 K542.874.T2.AQ96\"]\n\
                    [DoubleDummyTricks \"87879878793555345564\"]\n";
 
-        let (deals, report) = read_bytes(pbn.as_bytes()).expect("PBN should read from bytes");
+        let (deals, report) =
+            read_bytes(pbn.as_bytes(), Window::all()).expect("PBN should read from bytes");
         assert_eq!(report.format, "pbn");
         assert_eq!(deals.len(), 1);
         assert_eq!(report.solved, 1);
@@ -519,7 +781,8 @@ mod tests {
         let truncated = &LIBRARY[..LIBRARY.len() - 5];
         assert!(!looks_like_library(truncated));
 
-        let error = read_bytes(truncated).expect_err("a part-record library cannot be read");
+        let error =
+            read_bytes(truncated, Window::all()).expect_err("a part-record library cannot be read");
         assert!(
             error.contains("neither a Pavlicek library nor text"),
             "should rule out both formats: {}",
@@ -538,7 +801,8 @@ mod tests {
         std::fs::write(&path, LIBRARY).expect("write fixture");
         let source = path.to_str().expect("utf-8 path");
 
-        let (deals, report) = read(source).expect("the content is a library whatever the name");
+        let (deals, report) =
+            read(source, Window::all()).expect("the content is a library whatever the name");
         assert_eq!(report.format, "zrd");
         assert_eq!(deals.len(), 10);
         assert_eq!(report.solved, 10);
@@ -557,7 +821,8 @@ mod tests {
         std::fs::write(&path, ONELINE).expect("write fixture");
         let source = path.to_str().expect("utf-8 path");
 
-        let (deals, report) = read(source).expect("the content is text whatever the name");
+        let (deals, report) =
+            read(source, Window::all()).expect("the content is text whatever the name");
         assert_eq!(report.format, "lines");
         assert_eq!(deals.len(), 1, "it used to come back as no deals at all");
         assert!(
@@ -581,8 +846,9 @@ mod tests {
         std::fs::write(&path, LIBRARY).expect("write fixture");
         let source = path.to_str().expect("utf-8 path");
 
-        let (from_path, path_report) = read(source).expect("read from a path");
-        let (from_bytes, bytes_report) = read_bytes(LIBRARY).expect("read from bytes");
+        let (from_path, path_report) = read(source, Window::all()).expect("read from a path");
+        let (from_bytes, bytes_report) =
+            read_bytes(LIBRARY, Window::all()).expect("read from bytes");
 
         assert_eq!(path_report, bytes_report);
         assert_eq!(as_pbn(&from_path), as_pbn(&from_bytes));
@@ -590,9 +856,244 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// The whole fixture in file order, as PBN: what a window is measured
+    /// against. Read through the same door as everything else, so a change to
+    /// the decoding moves the expectation with it rather than breaking it.
+    fn library_in_order() -> Vec<String> {
+        let (deals, _) = read_bytes(LIBRARY, Window::all()).expect("the fixture reads");
+        as_pbn(&deals)
+    }
+
+    /// One record with four zero bytes where the cards go: a separator.
+    ///
+    /// Synthesised rather than found, because Pavlicek's first ten records have
+    /// none in them, and what needs testing is a record that is not a deal
+    /// sitting between records that are.
+    const SEPARATOR: [u8; RECORD_LEN] = [0u8; RECORD_LEN];
+
+    #[test]
+    fn an_offset_starts_at_that_record_and_comes_round() {
+        let ordered = library_in_order();
+
+        let (deals, report) = read_bytes(
+            LIBRARY,
+            Window {
+                start: Start::Record(7),
+                take: Take::Pass,
+            },
+        )
+        .expect("a library reads from an offset");
+
+        assert_eq!(deals.len(), 10, "a pass is still the whole library");
+        let rotated: Vec<String> = ordered[7..]
+            .iter()
+            .chain(ordered[..7].iter())
+            .cloned()
+            .collect();
+        assert_eq!(
+            as_pbn(&deals),
+            rotated,
+            "reading should run from record 7 to the end and round to the start"
+        );
+        assert_eq!(report.solved, 10);
+        assert!(
+            report.notes.iter().any(|n| n.contains("record 7 of 10")),
+            "where it started is worth saying: {:?}",
+            report.notes
+        );
+    }
+
+    #[test]
+    fn a_limit_reads_only_the_deals_it_asks_for() {
+        let ordered = library_in_order();
+
+        let (deals, report) = read_bytes(
+            LIBRARY,
+            Window {
+                start: Start::Record(4),
+                take: Take::AtMost(3),
+            },
+        )
+        .expect("a library reads a window");
+
+        assert_eq!(as_pbn(&deals), ordered[4..7], "three deals from record 4");
+        assert_eq!(
+            report.solved, 3,
+            "the counts describe what was handed over, not what the file holds"
+        );
+        assert_eq!(report.unsolved, 0);
+    }
+
+    #[test]
+    fn a_ceiling_larger_than_the_library_stops_after_one_pass() {
+        // `-g` is a ceiling on what a run will look at, not a demand for that
+        // many deals — and it is ten million by default, which is no reason to
+        // repeat a ten-record library a million times.
+        let (deals, report) = read_bytes(
+            LIBRARY,
+            Window {
+                start: Start::Record(0),
+                take: Take::AtMost(25),
+            },
+        )
+        .expect("a library reads");
+
+        assert_eq!(deals.len(), 10, "one pass, and no deal read twice");
+        assert!(
+            !report.notes.iter().any(|note| note.contains("repeat")),
+            "nothing repeated, so nothing to report: {:?}",
+            report.notes
+        );
+    }
+
+    #[test]
+    fn asking_for_more_deals_than_the_library_holds_repeats_them_and_says_so() {
+        let ordered = library_in_order();
+
+        let (deals, report) = read_bytes(
+            LIBRARY,
+            Window {
+                start: Start::Record(0),
+                take: Take::Exactly(25),
+            },
+        )
+        .expect("a library reads");
+
+        assert_eq!(deals.len(), 25, "the run asked for 25 and gets 25");
+        let pbn = as_pbn(&deals);
+        assert_eq!(pbn[..10], ordered[..], "the first pass is the library");
+        assert_eq!(pbn[10..20], ordered[..], "and the second is the same again");
+        assert_eq!(pbn[20..], ordered[..5], "the last pass is a part of one");
+        assert_eq!(
+            report.solved, 25,
+            "the counts describe the deals handed over, repeats and all"
+        );
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|note| note.contains("holds 10 deals and the run asked for 25")),
+            "a run whose statistics count deals twice should say so: {:?}",
+            report.notes
+        );
+    }
+
+    #[test]
+    fn the_seed_picks_the_start_and_picks_the_same_one_every_time() {
+        let by_seed = |seed: u32| {
+            let (deals, _) = read_bytes(
+                LIBRARY,
+                Window {
+                    start: Start::Seed(seed),
+                    take: Take::Pass,
+                },
+            )
+            .expect("a library reads from a seed");
+            as_pbn(&deals)
+        };
+
+        assert_eq!(by_seed(1), by_seed(1), "the same seed reads the same deals");
+
+        // And the seed has to reach the offset at all: eight seeds that all
+        // started at the same record would satisfy the line above while
+        // ignoring the seed completely.
+        let starts: std::collections::BTreeSet<String> =
+            (1u32..=8).map(|seed| by_seed(seed)[0].clone()).collect();
+        assert!(
+            starts.len() > 1,
+            "different seeds should start in different places: {:?}",
+            starts
+        );
+    }
+
+    #[test]
+    fn an_offset_counts_records_and_a_limit_counts_deals() {
+        // The two count different things, which is the whole of the separator
+        // question: a separator is a record, so it spends an offset, and it is
+        // not a deal, so it does not spend a limit.
+        let ordered = library_in_order();
+        let mut spliced = SEPARATOR.to_vec();
+        spliced.extend_from_slice(LIBRARY);
+
+        let (deals, report) = read_bytes(
+            &spliced,
+            Window {
+                start: Start::Record(3),
+                take: Take::AtMost(2),
+            },
+        )
+        .expect("a library with a separator in it reads");
+        assert_eq!(
+            as_pbn(&deals),
+            ordered[2..4],
+            "record 3 is the third deal, because record 0 is the separator"
+        );
+        assert_eq!(report.separators, 0, "the separator is behind the start");
+
+        let (deals, report) = read_bytes(
+            &spliced,
+            Window {
+                start: Start::Record(0),
+                take: Take::AtMost(2),
+            },
+        )
+        .expect("a library with a separator in it reads");
+        assert_eq!(
+            as_pbn(&deals),
+            ordered[..2],
+            "a separator does not spend the limit"
+        );
+        assert_eq!(report.separators, 1, "but it is still counted");
+    }
+
+    #[test]
+    fn a_library_with_no_deals_in_it_is_not_repeated_for_ever() {
+        // Repeating nothing yields nothing, and a loop looking for the deals it
+        // was asked for would never come back.
+        let separators = SEPARATOR.repeat(3);
+
+        let (deals, report) = read_bytes(
+            &separators,
+            Window {
+                start: Start::Record(0),
+                take: Take::Exactly(100),
+            },
+        )
+        .expect("a library of separators is still a library");
+
+        assert!(deals.is_empty(), "there were no deals to read");
+        assert_eq!(report.separators, 3);
+    }
+
+    #[test]
+    fn text_honours_a_limit_and_says_a_start_did_nothing() {
+        let text = ONELINE.repeat(4);
+
+        let (deals, report) = read_bytes(
+            text.as_bytes(),
+            Window {
+                start: Start::Record(2),
+                take: Take::AtMost(3),
+            },
+        )
+        .expect("text reads");
+
+        assert_eq!(report.format, "lines");
+        assert_eq!(deals.len(), 3, "the limit is what a run will spend");
+        assert_eq!(report.unsolved, 3, "and the counts follow it");
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|note| note.contains("no record 2 to start at")),
+            "a start there is nothing to seek in should say so: {:?}",
+            report.notes
+        );
+    }
+
     #[test]
     fn a_tables_only_file_is_still_refused_by_name() {
-        let error = read("deals.zdd").expect_err(".zdd holds no deals");
+        let error = read("deals.zdd", Window::all()).expect_err(".zdd holds no deals");
         assert!(error.contains("no deals in it"), "{}", error);
     }
 }

--- a/dealer-run/src/lib.rs
+++ b/dealer-run/src/lib.rs
@@ -45,10 +45,14 @@ pub mod run;
 ///
 /// Nothing is put in a shared store. A table belongs to one deal, lives as long
 /// as that deal does, and goes with it when the filter throws it away.
+///
+/// `window` is which part of a solved-deal library to read — where to start and
+/// how much to take. [`deal_input::Window::all`] reads the file as it stands.
 pub fn deals_from_file(
     path: &str,
+    window: deal_input::Window,
 ) -> Result<(Vec<run::SolvedDeal>, deal_input::InputReport), String> {
-    let (records, report) = deal_input::read(path)?;
+    let (records, report) = deal_input::read(path, window)?;
     Ok((to_solved(records), report))
 }
 
@@ -60,8 +64,9 @@ pub fn deals_from_file(
 /// from, and it stops there.
 pub fn deals_from_bytes(
     bytes: &[u8],
+    window: deal_input::Window,
 ) -> Result<(Vec<run::SolvedDeal>, deal_input::InputReport), String> {
-    let (records, report) = deal_input::read_bytes(bytes)?;
+    let (records, report) = deal_input::read_bytes(bytes, window)?;
     Ok((to_solved(records), report))
 }
 

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -121,6 +121,37 @@ struct Args {
     #[arg(long = "input-deals", value_name = "SOURCE")]
     input_deals: Option<String>,
 
+    /// Start a solved-deal library at this record, counting from zero
+    ///
+    /// Counts *records*, not deals: a `.zrd` is fixed-length records, a section
+    /// separator is one of them, and record N is the one the file itself
+    /// numbers N. (`--input-limit` counts deals, because deals are what a run
+    /// spends.) Past the end of the file wraps round to the beginning.
+    ///
+    /// Without this, `-s` picks the starting record, so a seed means the same
+    /// thing for a library as for a generated run: the same seed reads the same
+    /// deals.
+    ///
+    /// Libraries only. A PBN or one-line file has no records to seek to and is
+    /// read from the beginning, which is said out loud.
+    #[arg(long = "input-offset", value_name = "N")]
+    input_offset: Option<u64>,
+
+    /// Read this many deals from a solved-deal library
+    ///
+    /// Counts deals: separators and unreadable records do not spend it. Only
+    /// this window is read, so a run wanting forty deals out of ten million
+    /// records reads forty-odd records rather than the file.
+    ///
+    /// More than the library holds wraps back to its first record and repeats
+    /// deals — `average` and `frequency` then count each repeat, which makes a
+    /// sample with replacement rather than a bigger sample. The run says so
+    /// when it happens.
+    ///
+    /// Without this the ceiling is `-g`, and the library is never repeated.
+    #[arg(long = "input-limit", value_name = "N")]
+    input_limit: Option<usize>,
+
     /// Level this scenario and run it, in one go
     ///
     /// Deals it once to find out what it does — how often each `HandType_*`
@@ -454,11 +485,23 @@ fn print_frequency_2d(grid: &dealer_run::FrequencyGrid) {
 /// `dealer_run`'s, so a browser reading the same file behaves the same without
 /// implementing it again. What is left here is what a terminal does with the
 /// report: write it to stderr.
-fn read_input_deals(source: &str) -> Vec<dealer_run::run::SolvedDeal> {
-    let (deals, report) = dealer_run::deals_from_file(source).unwrap_or_else(|e| {
+fn read_input_deals(
+    source: &str,
+    window: dealer_run::deal_input::Window,
+    seed_given: bool,
+) -> Vec<dealer_run::run::SolvedDeal> {
+    let (deals, report) = dealer_run::deals_from_file(source, window).unwrap_or_else(|e| {
         eprintln!("Error {}", e);
         std::process::exit(1);
     });
+
+    // `-s` used to be ignored by every kind of supplied deal, and for text it
+    // still is: a PBN file is read in the order somebody wrote it. A library is
+    // the exception — the seed picks where in it to start — and the report says
+    // which record it picked, so the warning would contradict it.
+    if seed_given && report.format != "zrd" {
+        eprintln!("Warning: --seed is ignored when using --input-deals");
+    }
 
     // A name that disagreed with the content is worth a line: the file was read
     // as what it holds, which is not what the caller asked for by name.
@@ -1588,8 +1631,24 @@ fn main() {
                 );
                 std::process::exit(1);
             }
-            if args.seed.is_some() {
-                eprintln!("Warning: --seed is ignored when using --input-deals");
+        }
+
+        // The window switches are about seeking within a library, so they need
+        // one to seek in. Said here rather than ignored quietly: a caller who
+        // asked for record 900,000 and got board 1 should hear about it.
+        if args.input_deals.is_none() {
+            for (switch, given) in [
+                ("--input-offset", args.input_offset.is_some()),
+                ("--input-limit", args.input_limit.is_some()),
+            ] {
+                if given {
+                    eprintln!(
+                        "Error: {} says where to read supplied deals from, so it needs \
+                         --input-deals.",
+                        switch
+                    );
+                    std::process::exit(1);
+                }
             }
         }
 
@@ -1608,12 +1667,32 @@ fn main() {
         // dealer.exe behavior: stats hidden by default, -v shows them
         let verbose_stats = args.force_verbose || args.verbose;
 
-        // `--input-deals` supplies the deals rather than the seed. Read in full
-        // rather than streamed, because a levelled run looks at them twice —
-        // once to characterize the scenario, once to apply the keeps — and the
-        // second pass has to be able to go back to the first one's deals.
-        let input_deals: Option<Vec<dealer_run::run::SolvedDeal>> =
-            args.input_deals.as_deref().map(read_input_deals);
+        // Which part of a supplied library to read. The window is read in full
+        // rather than streamed, because a levelled run looks at the deals twice
+        // — once to characterize the scenario, once to apply the keeps — and
+        // the second pass has to be able to go back to the first one's deals.
+        // What the window buys is not reading the rest of the file at all.
+        let input_window = dealer_run::deal_input::Window {
+            // `-s` picks the record unless a record was named outright, which
+            // is what makes a library run reproducible the way a generated one
+            // is: same seed, same deals, whichever source they come from.
+            start: match args.input_offset {
+                Some(record) => dealer_run::deal_input::Start::Record(record),
+                None => dealer_run::deal_input::Start::Seed(seed),
+            },
+            // `-g` is a ceiling on what a run will look at, so it is a ceiling
+            // on what is worth reading — but it is 10,000,000 by default, and a
+            // default is no reason to repeat a short library ten million times.
+            // Repeating is what `--input-limit` asks for, and only that.
+            take: match args.input_limit {
+                Some(limit) => dealer_run::deal_input::Take::Exactly(limit),
+                None => dealer_run::deal_input::Take::AtMost(max_generate),
+            },
+        };
+        let input_deals: Option<Vec<dealer_run::run::SolvedDeal>> = args
+            .input_deals
+            .as_deref()
+            .map(|source| read_input_deals(source, input_window, args.seed.is_some()));
 
         // The switch wins over the script, as `-s` does over `seed`. Without
         // either, the script's own `_Share` declarations answer — and those

--- a/dealer/src/switches.rs
+++ b/dealer/src/switches.rs
@@ -533,8 +533,36 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
         dealer_exe: Origin::Differs("-l replays from a library file by index"),
         dealer_v2: Origin::Differs("-L names a library path: Pavlicek's solved-deal library, in ZRD format"),
         note: Some(
-            "Reads PBN or one-line, auto-detected, `-` for stdin. Unrecognised lines are \
-             skipped, so check the reported count.",
+            "Reads a Pavlicek `.zrd` library, PBN or one-line, decided by the content, `-` \
+             for stdin. Unrecognised lines are skipped, so check the reported count.",
+        ),
+    },
+    SwitchRow {
+        short: "",
+        long: "--input-offset",
+        group: "Reading deals in",
+        what: "Start a solved-deal library at this record",
+        dealer_exe: Origin::Absent,
+        dealer_v2: Origin::Differs("`-s` doubles as the offset: it counts 1000-record blocks to skip"),
+        note: Some(
+            "Counts records, separators included, not deals. Without it the seed picks the \
+             starting record, so a library run reproduces from `-s` the way a generated one \
+             does. DealerV2_4's block skip is not followed: it makes a seed mean different \
+             deals in different libraries, an error in a small one, and adjacent seeds \
+             adjacent blocks.",
+        ),
+    },
+    SwitchRow {
+        short: "",
+        long: "--input-limit",
+        group: "Reading deals in",
+        what: "Read this many deals from a solved-deal library",
+        dealer_exe: Origin::Absent,
+        dealer_v2: Origin::Absent,
+        note: Some(
+            "Counts deals, so separators do not spend it. Only the window is read. More than \
+             the library holds wraps round and repeats deals, which `average` and `frequency` \
+             then count twice; the run says when that happened.",
         ),
     },
     // ---- Recognised but not supported -------------------------------------

--- a/dealer/tests/input_deals.rs
+++ b/dealer/tests/input_deals.rs
@@ -724,3 +724,187 @@ fn a_library_cut_short_is_refused_with_a_reason() {
         out.stderr
     );
 }
+
+// ---------------------------------------------------------------------------
+// The window: where in a library a run starts, and how much of it it reads.
+// ---------------------------------------------------------------------------
+
+/// The deal lines of a run over the fixture library, with `args` added.
+///
+/// Every window test compares one reading against another, so they all go
+/// through here: what is under test is which deals came back and in what
+/// order, not how a deal is rendered.
+fn library_run(path: &str, args: &[&str]) -> Output {
+    let script = temp_file("script-window", "condition 1\n");
+    let mut all = vec![
+        script.to_str().expect("utf-8 path").to_string(),
+        "--input-deals".to_string(),
+        path.to_string(),
+        "-f".to_string(),
+        "oneline".to_string(),
+        "-X".to_string(),
+    ];
+    all.extend(args.iter().map(|arg| arg.to_string()));
+    let borrowed: Vec<&str> = all.iter().map(String::as_str).collect();
+    let out = run(&borrowed, None);
+    assert!(out.success, "stderr:\n{}", out.stderr);
+    out
+}
+
+/// Just the deals, in the order they were produced.
+fn deal_lines(out: &Output) -> Vec<String> {
+    out.stdout
+        .lines()
+        .filter(|line| line.starts_with("n "))
+        .map(str::to_string)
+        .collect()
+}
+
+/// `--input-offset N` starts at record N, and record N is the file's own
+/// numbering.
+#[test]
+fn an_offset_names_the_record_a_library_starts_at() {
+    let library = temp_binary("window-offset", "zrd", LIBRARY);
+    let path = library.to_str().expect("utf-8 path");
+
+    let in_order = deal_lines(&library_run(path, &["--input-offset", "0"]));
+    assert_eq!(in_order.len(), 10, "the fixture holds ten deals");
+
+    let from_seven = deal_lines(&library_run(
+        path,
+        &["--input-offset", "7", "--input-limit", "1"],
+    ));
+    assert_eq!(
+        from_seven,
+        in_order[7..8],
+        "record 7 is the eighth deal of the file"
+    );
+
+    // And the rest of the file follows it, coming round to the start.
+    let whole_pass = deal_lines(&library_run(path, &["--input-offset", "7"]));
+    let rotated: Vec<String> = in_order[7..]
+        .iter()
+        .chain(in_order[..7].iter())
+        .cloned()
+        .collect();
+    assert_eq!(whole_pass, rotated, "a pass from an offset is still a pass");
+}
+
+/// `-s` picks the starting record, so it means for a library what it means for
+/// a generated run: the same seed reads the same deals.
+#[test]
+fn the_seed_picks_where_a_library_starts() {
+    let library = temp_binary("window-seed", "zrd", LIBRARY);
+    let path = library.to_str().expect("utf-8 path");
+
+    let once = deal_lines(&library_run(path, &["-s", "1"]));
+    let again = deal_lines(&library_run(path, &["-s", "1"]));
+    assert_eq!(once, again, "the same seed should read the same deals");
+
+    let elsewhere = deal_lines(&library_run(path, &["-s", "2"]));
+    assert_ne!(
+        once[0], elsewhere[0],
+        "a different seed should start somewhere else"
+    );
+    let mut sorted_once = once.clone();
+    let mut sorted_elsewhere = elsewhere.clone();
+    sorted_once.sort();
+    sorted_elsewhere.sort();
+    assert_eq!(
+        sorted_once, sorted_elsewhere,
+        "both are a pass over the same library, in a different order"
+    );
+
+    // The seed is doing something here, so the warning that it is ignored has
+    // no business being printed.
+    let out = library_run(path, &["-s", "1"]);
+    assert!(
+        !out.stderr.contains("--seed is ignored"),
+        "the seed is not ignored for a library:\n{}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("seed 1 starts this library at record"),
+        "which record it picked is worth saying:\n{}",
+        out.stderr
+    );
+}
+
+/// Asking for more deals than the library holds wraps round, and says what
+/// that does to the statistics.
+#[test]
+fn a_limit_past_the_end_of_the_library_repeats_deals_and_reports_it() {
+    let library = temp_binary("window-wrap", "zrd", LIBRARY);
+    let path = library.to_str().expect("utf-8 path");
+
+    let out = library_run(path, &["--input-offset", "0", "--input-limit", "25"]);
+    let deals = deal_lines(&out);
+
+    assert_eq!(
+        deals.len(),
+        25,
+        "the run asked for 25 deals:\n{}",
+        out.stdout
+    );
+    assert_eq!(
+        deals[..10],
+        deals[10..20],
+        "the second pass is the first one again"
+    );
+    assert!(
+        out.stderr
+            .contains("holds 10 deals and the run asked for 25"),
+        "the repeat should be reported:\n{}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("count the repeats"),
+        "and what it does to `average` and `frequency` said:\n{}",
+        out.stderr
+    );
+}
+
+/// `-g` bounds what is read without asking for the library to be repeated.
+#[test]
+fn the_generate_ceiling_does_not_repeat_the_library() {
+    let library = temp_binary("window-ceiling", "zrd", LIBRARY);
+    let path = library.to_str().expect("utf-8 path");
+
+    let out = library_run(path, &["--input-offset", "0", "-g", "25"]);
+
+    assert_eq!(
+        deal_lines(&out).len(),
+        10,
+        "a ceiling is not a demand:\n{}",
+        out.stdout
+    );
+    assert!(
+        !out.stderr.contains("repeat"),
+        "nothing repeated, so nothing to report:\n{}",
+        out.stderr
+    );
+
+    let short = library_run(path, &["--input-offset", "0", "-g", "4"]);
+    assert_eq!(
+        deal_lines(&short).len(),
+        4,
+        "and it does bound the reading:\n{}",
+        short.stdout
+    );
+}
+
+/// The window switches need a library to seek in.
+#[test]
+fn the_window_switches_need_input_deals() {
+    let script = temp_file("script-window-alone", "condition 1\n");
+
+    for switch in ["--input-offset", "--input-limit"] {
+        let out = run(&[script.to_str().expect("utf-8 path"), switch, "3"], None);
+        assert!(!out.success, "{} alone should be refused", switch);
+        assert!(
+            out.stderr.contains("needs --input-deals"),
+            "and say why:\n{}",
+            out.stderr
+        );
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **A solved-deal library is read from an offset, and only as far as the run
+  needs** (#65). It used to be read whole into memory before the run started,
+  which for the published 241 MB library is 10,485,760 deals whether the script
+  wanted forty of them or all of them.
+
+  ```
+  dealer filter.dlr --input-deals rpdd.zrd -s 42 -g 5000
+  ```
+
+  - **`-s` picks the starting record**, so a seed means the same thing for a
+    library as for a generated run: the same seed reads the same deals. It used
+    to be ignored outright, with a warning. It still is for PBN and one-line
+    files, which are read in the order somebody wrote them.
+  - `--input-offset N` names a record instead. It counts records, separators
+    included; `--input-limit N` counts deals. Past the end of the file wraps
+    round to the beginning, so a start near the end still reads a whole library.
+  - `--input-limit` past the end of the library repeats deals, which `average`
+    and `frequency` then count more than once — a sample with replacement, not a
+    bigger sample. The run reports it when it happens. `-g` alone is a ceiling
+    on what is read and never repeats anything.
 - **`--input-deals` reads a solved-deal library from a pipe**, so a library can
   be fetched by something that already knows how:
 

--- a/docs/command_line_comparison.md
+++ b/docs/command_line_comparison.md
@@ -24,7 +24,7 @@ UPDATE_DOCS=1 cargo test -p dealer
 
 <!-- BEGIN GENERATED: switches -->
 
-dealer3 implements **39 of the 49 switches** listed here. The dealer3 column is read from the argument parser itself, so it cannot drift; the other two columns are reference data (see `dealer/src/switches.rs` for their provenance).
+dealer3 implements **41 of the 51 switches** listed here. The dealer3 column is read from the argument parser itself, so it cannot drift; the other two columns are reference data (see `dealer/src/switches.rs` for their provenance).
 
 In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed and then refused with an explanation, so a script using it gets told rather than ignored. In the other two columns ✅ means the same meaning, ⚠️ a different one, and — not present at all.
 
@@ -96,7 +96,9 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 
 | Switch | What it does | dealer3 | dealer.exe | DealerV2_4 | Notes |
 |---|---|---|---|---|---|
-| `--input-deals` | Filter deals from a file instead of generating | ✅ | ⚠️ -l replays from a library file by index | ⚠️ -L names a library path: Pavlicek's solved-deal library, in ZRD format | Reads PBN or one-line, auto-detected, `-` for stdin. Unrecognised lines are skipped, so check the reported count. |
+| `--input-deals` | Filter deals from a file instead of generating | ✅ | ⚠️ -l replays from a library file by index | ⚠️ -L names a library path: Pavlicek's solved-deal library, in ZRD format | Reads a Pavlicek `.zrd` library, PBN or one-line, decided by the content, `-` for stdin. Unrecognised lines are skipped, so check the reported count. |
+| `--input-offset` | Start a solved-deal library at this record | ✅ | — | ⚠️ `-s` doubles as the offset: it counts 1000-record blocks to skip | Counts records, separators included, not deals. Without it the seed picks the starting record, so a library run reproduces from `-s` the way a generated one does. DealerV2_4's block skip is not followed: it makes a seed mean different deals in different libraries, an error in a small one, and adjacent seeds adjacent blocks. |
+| `--input-limit` | Read this many deals from a solved-deal library | ✅ | — | — | Counts deals, so separators do not spend it. Only the window is read. More than the library holds wraps round and repeats deals, which `average` and `frequency` then count twice; the run says when that happened. |
 
 ### Recognised but not supported
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -615,7 +615,13 @@ pub fn generate_from_deals(
     // One decoder, two front ends. Anything read here that the command line
     // would not read the same way is a bug in one of them, not a difference
     // between a page and a terminal.
-    let (supplied, report) = dealer_run::deals_from_bytes(deals).map_err(|e| JsError::new(&e))?;
+    // The whole file, in order. A page that wants to start somewhere else —
+    // the seed picking a position in a large library, which is what #68 asks
+    // for — will pass a window of its own; that is a decision about what the
+    // page offers, not one to make while wiring two branches together.
+    let (supplied, report) =
+        dealer_run::deals_from_bytes(deals, dealer_run::deal_input::Window::all())
+            .map_err(|e| JsError::new(&e))?;
     run_script(
         script,
         seed,
@@ -1522,7 +1528,8 @@ mod tests {
 
     /// Run a script over supplied bytes, as the page would.
     fn over(deals: &[u8], script: &str) -> Result<serde_json::Value, String> {
-        let (supplied, report) = dealer_run::deals_from_bytes(deals)?;
+        let (supplied, report) =
+            dealer_run::deals_from_bytes(deals, dealer_run::deal_input::Window::all())?;
         let json = run_script(
             script,
             1,
@@ -1611,7 +1618,9 @@ mod tests {
         // here: what is under test is that the condition is applied to these
         // deals, and a hand-copied count would agree just as well with a filter
         // that had stopped being applied at all.
-        let (deals, _) = dealer_run::deals_from_bytes(LIBRARY).expect("read the fixture");
+        let (deals, _) =
+            dealer_run::deals_from_bytes(LIBRARY, dealer_run::deal_input::Window::all())
+                .expect("read the fixture");
         let expected = deals
             .iter()
             .filter(|(deal, _)| deal.hand(Position::North).hcp() >= 13)
@@ -1743,7 +1752,9 @@ mod tests {
         // The rest of the machinery has to reach supplied deals too, not just
         // the list of them: an `average` over a file is most of why one is
         // read.
-        let (deals, _) = dealer_run::deals_from_bytes(LIBRARY).expect("read the fixture");
+        let (deals, _) =
+            dealer_run::deals_from_bytes(LIBRARY, dealer_run::deal_input::Window::all())
+                .expect("read the fixture");
         let expected: f64 = deals
             .iter()
             .map(|(deal, _)| deal.hand(Position::North).hcp() as f64)


### PR DESCRIPTION
Closes #65. Part of the roadmap in #70.

Reading a solved-deal library loaded **every record** before the run started — a
1M-deal library is 23MB on disk and more as `InputDeal`s, whether the script
wanted forty deals or all of them.

## Two switches, both long-only

**`--input-offset N`** — start at record N, counting from zero. Past the end
wraps: the library is a ring and there is nothing to fall off.

**`--input-limit N`** — read this many deals. Without it the ceiling is `-g` and
the library is never repeated.

Either without `--input-deals` is refused rather than ignored.

**The offset counts records; the limit counts deals.** That asymmetry is
deliberate and stated in both help texts. An offset is arithmetic on a file
position — a separator is a record and spends one, which is what makes it a seek
rather than a scan. A limit is what a run spends, and a run spends deals.
`an_offset_counts_records_and_a_limit_counts_deals` pins it by splicing a
synthesised separator in front of the fixture.

## The seed picks the start

`-s` now means one thing across both deal sources: a generated run reproduces
from its seed, and so does a library run.
`Xoshiro256PlusPlus::seed_from_u64(seed).next_u64() % records`, using the
project's own RNG, and the chosen record is reported.

**Not DealerV2_4's scheme** (`seek_rpdd_pos()`, where the seed is a count of
1000-record blocks to skip), for three reasons: it makes a seed mean different
deals in different libraries; it makes a small library *reject* seeds it cannot
reach; and it puts `-s 1`, `2` and `3` in adjacent blocks of a file whose
records are in generated order.

## Wrap-around is reported, because it changes what the numbers mean

> the library holds 10 deals and the run asked for 25; deals repeat from the
> start after the first pass, so `average` and `frequency` count the repeats.

That is a sample with replacement in a correlated order, not a bigger sample.
Repeating only ever happens when `--input-limit` asks for it — hence the
`AtMost`/`Exactly` split, found by wiring `-g` to it and watching a ten-record
library become ten million cloned deals and the suite take 28s instead of 0.4s.

## Verified by hand as well as by tests

Same offset, identical deals. Offsets 500 and 900 differ. `-s 1/2/3` give
records 387, 970 and 937 of 1000 — scattered, as intended.

Every test was broken deliberately and confirmed to fail; one is worth naming:
removing the `pass == 0` guard makes
`a_library_with_no_deals_in_it_is_not_repeated_for_ever` **hang** rather than
fail, which is exactly the infinite loop it exists to prevent.

## And a CI gap this pair exposed

`wasm/` is its own workspace and **nothing in this repository's CI built it**.
#66 merged a wasm caller of `deals_from_bytes`; this branch changed that
function's signature; both gates were green and `main` would have been broken.

CI now has a WebAssembly job — fmt, clippy, host-target tests and a wasm32
build — and `build-summary` waits on it. The call sites pass `Window::all()`,
which is what the wasm build did before; a page that wants to start elsewhere
will pass its own window, and that is #68's decision to make.

`docs/command_line_comparison.md` regenerated with `UPDATE_DOCS=1`; the stale
`--input-deals` note that still said "PBN or one-line" after #69 is fixed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)