### PR TITLE
Call it "the supplied data" when it turns out not to be deals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ scripts/__pycache__/
 
 # Generated at build time by web/scripts/emit-reference.mjs
 web/public/reference.txt
+
+# Agent worktrees, created inside the repo directory and never part of it.
+.claude/worktrees/

--- a/dealer-run/src/deal_input.rs
+++ b/dealer-run/src/deal_input.rs
@@ -298,7 +298,7 @@ pub fn read(source: &str, window: Window) -> Result<(Vec<InputDeal>, InputReport
 /// so that a supplied library behaves the same in a tab as at a terminal rather
 /// than through a second decoder that drifts from this one.
 pub fn read_bytes(bytes: &[u8], window: Window) -> Result<(Vec<InputDeal>, InputReport), String> {
-    read_named(bytes, "the supplied deals", window)
+    read_named(bytes, "the supplied data", window)
 }
 
 /// [`read_bytes`], with a name for the bytes so an error can say where they came


### PR DESCRIPTION
The bytes handed to `deal_input::read_bytes` were named "the supplied deals".
That reads correctly everywhere except the one place the name actually surfaces
— an error reporting that the bytes are not deals:

> the supplied deals **is** neither a Pavlicek library nor text

A singular verb against a plural noun, and a subject asserting the very thing
its predicate denies. "The supplied data" is neither of those.

Worth fixing now rather than later: since #66 a page can hand bytes over, so
this is a browser dialog rather than a line of stderr.

One word. Tests and clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)