### PR TITLE
The browser can fetch the solved-deal library a piece at a time (#77)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,30 @@ jobs:
       working-directory: wasm
       run: cargo build --target wasm32-unknown-unknown --release
 
+    # The host tests above run the engine; these run the actual bindings and
+    # compare them against the native CLI over the same deals. Nothing else
+    # does: #65 changed what a seed means for a library, `verify.mjs` started
+    # disagreeing with the CLI, and it reached main because no job ran it.
+    - name: Install wasm-pack
+      uses: jetli/wasm-pack-action@v0.4.0
+
+    - name: Build the bindings for node
+      working-directory: wasm
+      run: ./build.sh nodejs
+
+    # verify.mjs runs this against the bindings over the same deals, so the
+    # comparison needs both halves built.
+    - name: Build the command line to compare against
+      run: cargo build --release --bin dealer
+
+    - name: The bindings agree with the command line
+      working-directory: wasm
+      run: node verify.mjs
+
+    - name: The library serves what it should
+      working-directory: wasm
+      run: node library-check.mjs
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,7 @@ All located alongside this repo, under the same GitHub directory:
 | [Bridge-Parsers](../Bridge-Parsers) | PBN/LIN file parsing | sibling |
 | [pbn-to-pdf](../pbn-to-pdf) | PDF generation | sibling |
 | [bridge-wrangler](../bridge-wrangler) | CLI tool for PBN operations | sibling |
+| [rpdd-reader](../rpdd-reader) | Pavlicek's 10,485,760 solved deals: deals by index, paired with fetched tables | sibling, used by `wasm/` |
 
 ## Known Issues
 

--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -53,6 +53,8 @@ cover this build too: it is the same generator.
 |---|---|---|
 | `generate(script, seed, produce, max_generate, format, auto_level, round_robin, params, on_progress)` | JSON | `format` is `"oneline"`, `"printall"` or `"pbn"`; `params` fills `$0`-`$9` |
 | `generate_from_deals(script, deals, seed, produce, max_generate, format, auto_level, round_robin, params, on_progress)` | JSON | The same, over deals the caller supplies: `deals` is a `Uint8Array` |
+| `new Library(manifestUrl)` | object | The published solved-deal library, fetched a piece at a time; see below |
+| `rpdd_manifest_url()` | string | The manifest of the library we host, for `new Library(...)` |
 | `check_script(script, params)` | JSON | Never throws — safe to call per keystroke |
 | `script_params(script)` | JSON | What the script says about its own `$0`-`$9` |
 | `language_info()` | JSON | Full vocabulary for completion and hover |
@@ -174,6 +176,62 @@ The bytes are decoded in full, so the caller decides how much to hand over: a
 library is 23 bytes a record, and slicing the `Uint8Array` before passing it
 reads a window of one. (Issue #65 covers an offset and limit in the engine
 itself.)
+
+### `Library`
+
+Deals that arrive with their double-dummy tables, so `tricks()`, `dds()` and
+`par()` are lookups rather than searches. There are 10,485,760 of them — Richard
+Pavlicek's, solved over almost two years of computer time — but the file is
+241 MB, which is not a download a tab can make to look at five deals.
+
+So only the tables are published, as 640 KiB pieces, and the deals are not
+published at all: they are a pure function of their index, and `rpdd-reader`
+recreates them here at about 640ns each. `Library` joins the two and hands back
+`.zrd` bytes for `generate_from_deals` — the same bytes, the same reader and the
+same run as `--input-deals` at a terminal. There is deliberately no second run
+path.
+
+**The page does the fetching.** `fetch` is asynchronous and a wasm export cannot
+await one, so the library says what it needs and is told:
+
+```js
+const lib = new Library(rpdd_manifest_url())
+
+let need
+while ((need = lib.needs(index, count)).length)
+  for (const url of need)
+    lib.supply(url, new Uint8Array(await (await fetch(url)).arrayBuffer()))
+
+const result = JSON.parse(w.generate_from_deals(
+  script, lib.zrd(index, count), seed, 40, 1000000, "oneline",
+  false, false, [], null))
+```
+
+The first round asks for the manifest and the second for the chunks it names;
+the caller fetches URLs and never learns which is which. Cache them however you
+like — a `Map`, the Cache API, IndexedDB — and hand the same bytes back.
+
+| Member | Returns | Notes |
+|---|---|---|
+| `needs(firstDeal, count)` | `string[]` | URLs still wanted. Empty means `zrd` will answer |
+| `supply(url, bytes)` | — | Bytes for a URL `needs` returned. Throws for one it did not |
+| `zrd(firstDeal, count)` | `Uint8Array` | The run, for `generate_from_deals`. Throws while anything is missing |
+| `manifest_url` | string | What it was pointed at |
+| `total_deals` | number \| undefined | Known once the manifest has been supplied |
+| `forget_chunks()` | — | Release held pieces, keeping the manifest |
+
+A page asks for **deals from index N** and never computes a piece number, an
+offset or a wrap. Which piece holds a deal, how a run crossing a boundary is
+stitched and how one past the end wraps to the beginning are all derived from
+the manifest, inside `rpdd-reader`. `firstDeal` past the end of the library
+wraps, so an index may be derived from a seed without knowing the size.
+
+The layout is data, not code: `deals_per_chunk`, `record_bytes`, `total_deals`
+and every chunk's path and first deal come from the manifest, and chunk paths
+are resolved relative to it. Point `new Library(...)` at a different manifest of
+the same shape and it works.
+
+There is no UI for this yet; that is issue #68.
 
 ### `check_script`
 
@@ -309,6 +367,24 @@ path, which produced plausible-looking deals that simply did not honour the
 script's `predeal` lines. Run it after changing either the bindings or the CLI's
 generation loop.
 
+It passes `--input-offset 0` to the CLI, which is what makes it a comparison:
+without it the seed chooses where in a library to start (#65), and the two sides
+then read the same records in different rotations.
+
+`wasm/library-check.mjs` does the same job for `Library`, against the JS
+boundary rather than the CLI:
+
+```bash
+cd wasm && ./build.sh nodejs && node library-check.mjs
+```
+
+`cargo test` inside `wasm/` already checks the arithmetic, in Rust, on the host.
+What it cannot check is that `needs()` arrives as an array, that a `Uint8Array`
+handed to `supply()` reaches Rust as `&[u8]`, and that `zrd()` comes back as
+bytes `generate_from_deals` accepts. Those are `wasm-bindgen`'s, and they are
+where the wiring bugs happen. It serves the ten-record fixture as two `.zdd`
+chunks and checks the run byte for byte, across the join and around the wrap.
+
 ## Testing the bindings off a browser
 
 `cargo test` inside `wasm/` runs the entry points on the host, not in a browser:
@@ -322,6 +398,17 @@ file's ten, that the filter still applies to them, and what `input` says about
 each format. It is not a browser, so it does not cover the JS boundary itself:
 that a `Uint8Array` arrives as `&[u8]` is `wasm-bindgen`'s, and is exercised by
 building and calling the package (`./build.sh nodejs`).
+
+The same fixture covers `Library`, cut up the way the library is published: its
+ten records become two chunks of five tables with the deals thrown away, served
+through the ask/supply loop, and the run that comes back must be **the fixture's
+own records byte for byte** — including one that crosses the boundary between
+the two chunks and one that runs off the end and wraps. That is the check that
+catches an off-by-one in a chunk's starting deal, which would otherwise pair
+every deal with its neighbour's table: legal deals, well-formed tables, right
+lengths, wrong answers. `rpdd-reader` runs the same comparison against the whole
+241 MB library, which is not committed anywhere and which its tests skip when it
+is absent.
 
 ## Known gaps
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -26,6 +26,19 @@ dealer-pbn = { path = "../dealer-pbn" }
 dealer-level = { path = "../dealer-level" }
 dealer-run = { path = "../dealer-run" }
 
+# The solved-deal library, which the CLI does not need: it has the whole
+# 241MB file and seeks in it. A page cannot download that to look at five
+# deals, so it fetches 640 KiB pieces of tables and this crate makes the deals
+# those tables belong to. Git rather than a version: it is not published, and
+# the local [patch] in ../.cargo/config.toml is what a development build
+# resolves it to — see ../dev-build.sh for why bare cargo is not safe here.
+#
+# `chunks` is the layer that turns "deals from index N" into the URLs that
+# answer it. Without it the crate is the generator and the pairing alone.
+rpdd-reader = { git = "https://github.com/bridge-craftwork/rpdd-reader", features = [
+    "chunks",
+] }
+
 wasm-bindgen = "0.2"
 # For a wall-clock reading: std::time::SystemTime::now() panics on
 # wasm32-unknown-unknown. js_sys::Date works in both the browser and Node.

--- a/wasm/library-check.mjs
+++ b/wasm/library-check.mjs
@@ -1,0 +1,103 @@
+// Drive `Library` from JavaScript, the way a page will.
+//
+//   cd wasm && ./build.sh nodejs && node library-check.mjs
+//
+// `cargo test` inside wasm/ already checks the arithmetic, on the host, in
+// Rust. What it cannot check is the boundary: that `needs()` arrives as an
+// array with a `.length`, that a `Uint8Array` handed to `supply()` reaches
+// Rust as `&[u8]`, that `zrd()` comes back as bytes `generate_from_deals`
+// accepts, and that the getters are getters. Those are wasm-bindgen's, they
+// are not exercised by a host build, and they are where the wiring bugs
+// actually happen.
+//
+// The library it serves is the ten-record fixture with the deals thrown away —
+// which is exactly what a .zdd chunk is — cut into two chunks of five. So the
+// run that comes back must be the fixture's own records, including across the
+// join between the two chunks, and that is checked byte for byte.
+
+import { createRequire } from 'module'
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const w = createRequire(import.meta.url)('./pkg-node/dealer3_wasm.js')
+
+const RECORD = 23, DEAL = 13, TABLE = 10, PER_CHUNK = 5
+const fixture = new Uint8Array(
+  readFileSync(join(here, '..', 'dealer-run', 'tests', 'fixtures', 'rpdd_10First.zrd')))
+const MANIFEST = 'https://example.test/data/manifest.json'
+
+let failures = 0
+const check = (name, ok, detail = '') => {
+  if (ok) console.log(`  ✓ ${name}${detail && ' ' + detail}`)
+  else { console.error(`  ✗ ${name}: ${detail}`); failures++ }
+}
+const same = (a, b) => a.length === b.length && a.every((byte, i) => byte === b[i])
+
+/** The table halves of five of the fixture's records: one .zdd chunk. */
+const chunk = (n) => {
+  const out = new Uint8Array(PER_CHUNK * TABLE)
+  for (let i = 0; i < PER_CHUNK; i++) {
+    const at = (n * PER_CHUNK + i) * RECORD
+    out.set(fixture.subarray(at + DEAL, at + RECORD), i * TABLE)
+  }
+  return out
+}
+
+const manifest = new TextEncoder().encode(JSON.stringify({
+  schema: 1, record_bytes: TABLE, deals_per_chunk: PER_CHUNK, total_deals: 10,
+  chunks: [{ file: 'zdd/a.zdd', first_deal: 0, deals: PER_CHUNK },
+           { file: 'zdd/b.zdd', first_deal: PER_CHUNK, deals: PER_CHUNK }],
+}))
+/** What a `fetch` would return, served from the fixture instead. */
+const serve = (url) => {
+  if (url === MANIFEST) return manifest
+  if (url.endsWith('a.zdd')) return chunk(0)
+  if (url.endsWith('b.zdd')) return chunk(1)
+  throw new Error(`asked for a URL this library does not publish: ${url}`)
+}
+
+const lib = new w.Library(MANIFEST)
+check('nothing is known before the manifest arrives', lib.total_deals === undefined)
+
+// The loop a page runs, exactly as documented in docs/WASM.md.
+const asked = []
+let need
+while ((need = lib.needs(3, 5)).length) {
+  for (const url of need) { asked.push(url); lib.supply(url, serve(url)) }
+}
+
+check('the manifest is asked for first, then both chunks the run crosses',
+  asked.length === 3 && asked[0] === MANIFEST
+    && asked[1].endsWith('zdd/a.zdd') && asked[2].endsWith('zdd/b.zdd'),
+  `(${asked.map((u) => u.split('/').pop()).join(', ')})`)
+check('total_deals is known once the manifest is in', lib.total_deals === 10)
+check('manifest_url is what it was pointed at', lib.manifest_url === MANIFEST)
+
+const zrd = lib.zrd(3, 5)
+check('a run across the chunk boundary is the library\'s own records, byte for byte',
+  same(zrd, fixture.subarray(3 * RECORD, 8 * RECORD)))
+
+// And the point of emitting .zrd: the existing run reads it unchanged.
+const out = JSON.parse(w.generate_from_deals(
+  'condition 1\naction printoneline, average "N HCP" hcp(north)\n',
+  zrd, 1, 40, 1000000, 'oneline', false, false, []))
+check('the bytes feed generate_from_deals unchanged',
+  out.input?.format === 'zrd' && out.input?.read === 5 && out.produced === 5,
+  JSON.stringify(out.input))
+check('every deal arrived with its table, so tricks() is a lookup',
+  out.input?.solved === 5 && out.input?.unsolved === 0)
+
+while ((need = lib.needs(9, 2)).length) for (const url of need) lib.supply(url, serve(url))
+check('a run past the end wraps to the beginning',
+  same(lib.zrd(9, 2), new Uint8Array(
+    [...fixture.subarray(9 * RECORD, 10 * RECORD), ...fixture.subarray(0, RECORD)])))
+
+let refused = null
+try { lib.supply('https://example.test/data/zdd/nope.zdd', chunk(0)) }
+catch (e) { refused = String(e) }
+check('bytes for a URL it never asked for are refused', refused !== null, refused ?? '')
+
+console.log(failures ? `\n${failures} failure(s)` : '\nthe library serves what it should')
+process.exit(failures ? 1 : 0)

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -16,6 +16,8 @@
 //! Output is byte-identical to the native binary for the same seed and script,
 //! so the Tier 2 regression hashes pin this build too.
 
+mod library;
+
 use dealer_core::{Deal, FastDealConfig, Position};
 use dealer_parser::vocabulary;
 use dealer_parser::{Statement, VulnerabilityType};

--- a/wasm/src/library.rs
+++ b/wasm/src/library.rs
@@ -1,0 +1,285 @@
+//! The published solved-deal library, fetched a piece at a time.
+//!
+//! A page that wants `tricks()`, `dds()` or `par()` to be a lookup rather than
+//! a search needs deals that arrive with their double-dummy tables. Those exist
+//! — 10,485,760 of them, solved by Richard Pavlicek — but the file is 241 MB,
+//! which is not a download a tab can make to look at five deals.
+//!
+//! So the tables are published as 640 KiB pieces and the deals are not
+//! published at all: they are a pure function of their index, and `rpdd-reader`
+//! recreates them here, in the browser, at about 640ns each. This module is the
+//! binding for that crate. It adds no arithmetic of its own — which piece holds
+//! deal N, how a run crossing a boundary is stitched, how one past the end
+//! wraps — all of that is the crate's, derived from a manifest.
+//!
+//! # Why the caller does the fetching
+//!
+//! `fetch` is asynchronous and this is synchronous Rust called from JavaScript,
+//! so a wasm export cannot await one. The library therefore says what it needs
+//! and is told:
+//!
+//! ```js
+//! const lib = new Library(rpdd_manifest_url())
+//! let need
+//! while ((need = lib.needs(index, count)).length)
+//!     for (const url of need) lib.supply(url, new Uint8Array(await (await fetch(url)).arrayBuffer()))
+//! const out = generate_from_deals(script, lib.zrd(index, count), seed, ...)
+//! ```
+//!
+//! The first round asks for the manifest and the second for the chunks it
+//! names; the caller fetches URLs and never learns which is which.
+//!
+//! # Why it hands back `.zrd` bytes
+//!
+//! Because [`crate::generate_from_deals`] already reads them, unchanged. The
+//! same bytes, the same reader and the same run as `--input-deals` at a
+//! terminal — so a library run in a tab and a library run in a shell cannot
+//! come to different conclusions about what they read.
+//!
+//! An entry point taking deals and tables directly would be a second run path.
+//! The two front ends each had one of those until 2026-08-29; they drifted, and
+//! nothing said so until someone compared them.
+
+use rpdd_reader::{Library as Chunked, LibraryError};
+use wasm_bindgen::prelude::*;
+
+/// The manifest of the library published by rpdd-library.
+///
+/// A page may point [`Library`] at any manifest of the same shape; this is the
+/// one we host, offered so a caller does not have to hold the URL itself.
+#[wasm_bindgen]
+pub fn rpdd_manifest_url() -> String {
+    rpdd_reader::RPDD_MANIFEST.to_string()
+}
+
+/// A solved-deal library, described by a manifest and holding the pieces it has
+/// been given.
+///
+/// See the [module documentation](self) for the ask/supply loop.
+#[wasm_bindgen]
+pub struct Library {
+    inner: Chunked,
+}
+
+#[wasm_bindgen]
+impl Library {
+    /// A library described by the manifest at `manifest_url`.
+    ///
+    /// Nothing is fetched — nothing here can fetch. The first call to
+    /// [`needs`](Self::needs) asks for the manifest.
+    #[wasm_bindgen(constructor)]
+    pub fn new(manifest_url: String) -> Library {
+        Library {
+            inner: Chunked::at(manifest_url),
+        }
+    }
+
+    /// The manifest URL this library was pointed at.
+    #[wasm_bindgen(getter)]
+    pub fn manifest_url(&self) -> String {
+        self.inner.manifest_url().to_string()
+    }
+
+    /// How many deals the library holds, or `undefined` until the manifest has
+    /// been supplied.
+    #[wasm_bindgen(getter)]
+    pub fn total_deals(&self) -> Option<u32> {
+        self.inner.total_deals().map(|n| n as u32)
+    }
+
+    /// The URLs still needed before [`zrd`](Self::zrd) can answer, in the order
+    /// worth fetching them.
+    ///
+    /// An empty array means the run can be produced. Call it in a loop: the
+    /// manifest comes back on the first round and the chunks it names on the
+    /// second.
+    ///
+    /// `first_deal` past the end of the library wraps to its beginning, so any
+    /// index answers and a page may derive one from a seed.
+    pub fn needs(&self, first_deal: u32, count: u32) -> Result<Vec<String>, JsError> {
+        self.inner
+            .needs(first_deal as u64, count as u64)
+            .map_err(explain)
+    }
+
+    /// Hand back the bytes fetched for a URL [`needs`](Self::needs) returned.
+    ///
+    /// The manifest and a chunk arrive by the same call; which one it is comes
+    /// from the URL.
+    pub fn supply(&mut self, url: &str, bytes: &[u8]) -> Result<(), JsError> {
+        self.inner.supply(url, bytes.to_vec()).map_err(explain)
+    }
+
+    /// `count` deals from `first_deal`, each with its double-dummy table, as
+    /// `.zrd` bytes for [`crate::generate_from_deals`].
+    ///
+    /// Fails while anything is still missing; ask [`needs`](Self::needs) first.
+    pub fn zrd(&self, first_deal: u32, count: u32) -> Result<Vec<u8>, JsError> {
+        zrd_bytes(&self.inner, first_deal as u64, count as u64).map_err(|e| JsError::new(&e))
+    }
+
+    /// Drop every chunk held, keeping the manifest.
+    ///
+    /// A page walking a long way through the library would otherwise keep every
+    /// piece it passed through.
+    pub fn forget_chunks(&mut self) {
+        self.inner.forget_chunks();
+    }
+}
+
+/// The run, or why it cannot be produced yet.
+///
+/// Split out so it can be called from an ordinary test: `JsError::new` reaches
+/// for JavaScript's `Error`, which does not exist off wasm, so a failure raised
+/// through it would abort the test process rather than be something a test can
+/// assert on.
+fn zrd_bytes(library: &Chunked, first_deal: u64, count: u64) -> Result<Vec<u8>, String> {
+    library.zrd(first_deal, count).map_err(|e| explanation(&e))
+}
+
+/// Turn a library error into a `JsError`, with `Needs` saying what to do.
+fn explain(error: LibraryError) -> JsError {
+    JsError::new(&explanation(&error))
+}
+
+/// The message a page should see.
+///
+/// `Needs` is not a failure — it is the protocol — so if it surfaces as one the
+/// caller has skipped [`Library::needs`], and the message says so rather than
+/// listing URLs it did not ask for.
+fn explanation(error: &LibraryError) -> String {
+    match error {
+        LibraryError::Needs(urls) => format!(
+            "{} piece(s) of the library have not been supplied yet; call needs() \
+             and supply() them first",
+            urls.len()
+        ),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rpdd_reader::{pair, RECORD_LEN, TABLE_LEN};
+
+    /// The first ten records of Pavlicek's library — real deals with their real
+    /// tables — which is what the whole chain has to reproduce from tables
+    /// alone. The same fixture `dealer-run` and the bindings' other tests read.
+    const LIBRARY: &[u8] = include_bytes!("../../dealer-run/tests/fixtures/rpdd_10First.zrd");
+
+    const DEAL_LEN: usize = RECORD_LEN - TABLE_LEN;
+    const MANIFEST_URL: &str = "https://example.invalid/data/manifest.json";
+    const PER_CHUNK: usize = 5;
+
+    /// The fixture's records, as a server would hold them: tables only, in two
+    /// chunks of five.
+    fn chunk(n: usize) -> Vec<u8> {
+        LIBRARY
+            .as_chunks::<RECORD_LEN>()
+            .0
+            .iter()
+            .skip(n * PER_CHUNK)
+            .take(PER_CHUNK)
+            .flat_map(|record| record[DEAL_LEN..].iter().copied())
+            .collect()
+    }
+
+    fn manifest() -> Vec<u8> {
+        format!(
+            r#"{{"schema":1,"record_bytes":{TABLE_LEN},"deals_per_chunk":{PER_CHUNK},
+                 "total_deals":10,"chunks":[
+                   {{"file":"zdd/a.zdd","first_deal":0,"deals":{PER_CHUNK}}},
+                   {{"file":"zdd/b.zdd","first_deal":{PER_CHUNK},"deals":{PER_CHUNK}}}]}}"#
+        )
+        .into_bytes()
+    }
+
+    /// Run the protocol to completion, serving from the fixture.
+    fn served(first_deal: u64, count: u64) -> Vec<u8> {
+        let mut library = Chunked::at(MANIFEST_URL);
+        loop {
+            match zrd_bytes(&library, first_deal, count) {
+                Ok(bytes) => return bytes,
+                Err(_) => {
+                    let needed = library
+                        .needs(first_deal, count)
+                        .expect("the manifest describes a usable library");
+                    assert!(!needed.is_empty(), "asked for nothing and still not ready");
+                    for url in needed {
+                        let bytes = match url.as_str() {
+                            MANIFEST_URL => manifest(),
+                            "https://example.invalid/data/zdd/a.zdd" => chunk(0),
+                            "https://example.invalid/data/zdd/b.zdd" => chunk(1),
+                            other => panic!("asked for an unpublished URL: {other}"),
+                        };
+                        library
+                            .supply(&url, bytes)
+                            .expect("supplying what was asked");
+                    }
+                }
+            }
+        }
+    }
+
+    /// The chain's whole claim: tables fetched in pieces, deals made here, and
+    /// the result is the library's own records byte for byte — across a chunk
+    /// boundary, which is the join a page cannot see and must not notice.
+    #[test]
+    fn a_run_across_two_chunks_is_the_librarys_own_records() {
+        let served = served(3, 5);
+        assert_eq!(
+            served,
+            &LIBRARY[3 * RECORD_LEN..8 * RECORD_LEN],
+            "deals 3..8 served from two chunks are not the library's records"
+        );
+    }
+
+    /// And a run that reaches the end continues from the beginning.
+    #[test]
+    fn a_run_past_the_end_wraps() {
+        let served = served(9, 2);
+        let expected = [
+            &LIBRARY[9 * RECORD_LEN..10 * RECORD_LEN],
+            &LIBRARY[..RECORD_LEN],
+        ]
+        .concat();
+        assert_eq!(served, expected, "the wrap is not the library's records");
+    }
+
+    /// What the bindings exist for: the bytes go into the run unchanged, and
+    /// the deals that come out are the library's, with their tables — so
+    /// `tricks()` is a lookup and nothing is solved again.
+    #[test]
+    fn the_bytes_feed_the_existing_run() {
+        let zrd = served(0, 10);
+        let (supplied, report) =
+            dealer_run::deals_from_bytes(&zrd, dealer_run::deal_input::Window::all())
+                .expect("the run's own reader accepts what the library served");
+        assert_eq!(supplied.len(), 10, "ten records should be ten deals");
+        assert_eq!(
+            report.solved, 10,
+            "every deal should have arrived with its table, or tricks() is not a lookup"
+        );
+    }
+
+    /// Pairing is what makes those bytes; served and paired directly must
+    /// agree, or the chunk layer is slicing somewhere other than it says.
+    #[test]
+    fn serving_agrees_with_pairing_the_same_tables_directly() {
+        let tables: Vec<u8> = [chunk(0), chunk(1)].concat();
+        assert_eq!(served(0, 10), pair(&tables, 0).expect("ten records pair"));
+    }
+
+    /// `Needs` is the protocol, not a failure, and must not reach a page as a
+    /// list of URLs it never asked about.
+    #[test]
+    fn asking_for_a_run_before_supplying_anything_says_what_to_do() {
+        let library = Chunked::at(MANIFEST_URL);
+        let message = zrd_bytes(&library, 0, 1).expect_err("nothing is supplied yet");
+        assert!(
+            message.contains("needs()") && message.contains("supply()"),
+            "unhelpful: {message}"
+        );
+    }
+}

--- a/wasm/verify.mjs
+++ b/wasm/verify.mjs
@@ -148,8 +148,14 @@ for (const c of SUPPLIED) {
   const path = join(tmp, `${c.name.replace(/\W+/g, '_')}.dlr`)
   writeFileSync(path, c.script)
 
+  // `--input-offset 0` is what makes this a comparison. Without it the CLI
+  // lets the seed choose where in the library to start (#65), and with no
+  // `-s` it picks the seed at random — so the two sides read the same ten
+  // records in different rotations and the diff was noise. The bindings are
+  // handed the bytes from the beginning, so the CLI is told to start there.
   const cli = parseCli(execFileSync(CLI,
-    [path, '--input-deals', LIBRARY, '-p', '100', '-f', 'oneline', '-X'],
+    [path, '--input-deals', LIBRARY, '--input-offset', '0',
+     '-p', '100', '-s', '1', '-f', 'oneline', '-X'],
     { encoding: 'utf8' }))
   const bytes = new Uint8Array(readFileSync(LIBRARY))
   const wasm = JSON.parse(

--- a/web/public/THIRD-PARTY-NOTICES
+++ b/web/public/THIRD-PARTY-NOTICES
@@ -17,7 +17,7 @@ was written, not the one in the copy you hold. What does not drift is
 the list of packages and what each is licensed under, which is what a
 notice is for.
 
-69 third-party packages, all under permissive licences.
+70 third-party packages, all under permissive licences.
 Dev-dependencies are excluded: a test harness is not in a binary.
 
 Summary
@@ -28,7 +28,7 @@ Summary
     1  Apache-2.0/MIT
     2  MIT
    57  MIT OR Apache-2.0
-    2  Unlicense
+    3  Unlicense
     2  Unlicense OR MIT
 
 
@@ -254,6 +254,11 @@ regex-syntax
     Licence: MIT OR Apache-2.0
     Source:  https://github.com/rust-lang/regex
     Copyright (c) 2014 The Rust Project Developers
+
+rpdd-reader
+    Licence: Unlicense
+    Source:  https://github.com/bridge-craftwork/rpdd-reader
+    Dedicated to the public domain; no copyright asserted.
 
 rustc-hash
     Licence: Apache-2.0 OR MIT


### PR DESCRIPTION
Closes #77. The last piece before #68 — the page can now ask for deals from an
index and get them.

## `rpdd-reader` gains two layers

Pushed separately to [bridge-craftwork/rpdd-reader](https://github.com/bridge-craftwork/rpdd-reader);
this PR is dealer3's side.

**Pairing.** `pair(tables, first_deal_index) -> .zrd bytes`. Works on any slice —
the whole 105 MiB file, one chunk, ten records — and knows nothing about chunks.
Emits `.zrd` so the output can be compared byte for byte against the real
library, and so dealer3 feeds the reader it already has.

**The chunk layer**, feature-gated. Driven by a manifest URL, so it is not tied
to the library we happen to publish: `deals_per_chunk`, `record_bytes` and each
chunk's `first_deal` all come from the manifest.

## Where the ask/supply loop came from

The crate cannot fetch — fetching is async, this is synchronous Rust — so it
asks and is told:

```js
const lib = new Library(rpdd_manifest_url())
let need; while ((need = lib.needs(index, count)).length)
  for (const url of need) lib.supply(url, await fetchBytes(url))
const out = generate_from_deals(script, lib.zrd(index, count), seed, ...)
```

The page's whole share is a URL per chunk and a cache. It never learns that
65,536 is a number. **`generate_from_deals` is untouched** — no second run path,
no generate loop in a front end.

## Verified against the real library, not against itself

`#[ignore]`d and skipping cleanly when the 241MB file is absent: a whole
65,536-deal chunk, scattered windows including the last 5,000 deals, and the
full ask/supply loop over the **real published manifest and chunks** — inside a
chunk, across a boundary, and wrapping from deal 10,485,758 back to 0. All
byte-identical to `rpdd.zrd`.

Breaking the starting index by one fails all three of those and **nothing else**,
which is the point: every other test stays green while every deal gets its
neighbour's table.

## And a CI gap this found

`verify.mjs` compares the bindings against the native CLI, and
`library-check.mjs` drives the protocol. **Neither ran in CI.** Host-target tests
cannot substitute — they test the engine, not the bindings, and not the two
front ends agreeing.

#65 changed what a seed means for a library, `verify.mjs`'s supplied-deal cases
passed no `-s`, and so the CLI started at a random rotation while the bindings
read from the beginning. It has disagreed since #65 merged and reached main
because nothing ran it. Harness fixed; both now run in CI, about ninety seconds.

## Not in this

`web/` is untouched — that is #68. And `rpdd-reader` cannot go to crates.io
while it depends on `bridge-encodings` by git, which is worth knowing before
planning to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)