### PR TITLE
The page can deal from the solved-deal library (#68)

### DIFF
--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -55,6 +55,8 @@ cover this build too: it is the same generator.
 | `generate_from_deals(script, deals, seed, produce, max_generate, format, auto_level, round_robin, params, on_progress)` | JSON | The same, over deals the caller supplies: `deals` is a `Uint8Array` |
 | `new Library(manifestUrl)` | object | The published solved-deal library, fetched a piece at a time; see below |
 | `rpdd_manifest_url()` | string | The manifest of the library we host, for `new Library(...)` |
+| `record_for_seed(seed, records)` | number | Which record a run's seed starts at — the CLI's own mapping, not a page's |
+| `script_uses_double_dummy(script, params)` | bool \| undefined | Whether anything in the script can reach the solver |
 | `check_script(script, params)` | JSON | Never throws — safe to call per keystroke |
 | `script_params(script)` | JSON | What the script says about its own `$0`-`$9` |
 | `language_info()` | JSON | Full vocabulary for completion and hover |
@@ -231,7 +233,42 @@ and every chunk's path and first deal come from the manifest, and chunk paths
 are resolved relative to it. Point `new Library(...)` at a different manifest of
 the same shape and it works.
 
-There is no UI for this yet; that is issue #68.
+The browser app uses this behind its **Pre-solved deals** radio: `web/src/lib/library.js`
+holds the page's half — fetching, caching and how much to ask for — and drives it
+from inside the engine worker, since a `Library` is a handle into one wasm
+instance's memory and cannot be passed to another thread.
+
+### `record_for_seed`
+
+```js
+const first = record_for_seed(seed, lib.total_deals)   // then needs/zrd from there
+```
+
+Where a seed starts in a library of `records` records. **A page must not work
+this out for itself.** The mapping is
+`Xoshiro256PlusPlus::seed_from_u64(seed).next_u64() % records` — the same
+`deal_input::Start::Seed` the command line reduces `-s` through, so `dealer -s 7
+--input-deals rpdd.zrd` and a browser run with seed 7 read the same deals. A
+JavaScript hash, however reasonable, lands somewhere else, and nothing fails:
+the two front ends simply disagree, healthily, for ever. `wasm/verify.mjs`
+compares a handful of seeds against the CLI's own note rather than trusting the
+agreement.
+
+`records` is the library being read, not a chunk: the seed names a deal in the
+library, and the piece follows from it. A partial library answers differently,
+which is correct — the seed names a position in the file it was given.
+
+### `script_uses_double_dummy`
+
+`true`, `false`, or `undefined` when the script does not parse — which is not
+the same as `false`, and a page must not tell someone their script asks for
+nothing when it could not read the script at all.
+
+The question a page asks before offering to fetch a library: a script that never
+calls `tricks()`, `dds()` or `par()` gains nothing from deals that arrive with
+the answers. Answered by `dd_demand::touches_solver` off the parsed program, so
+`t = tricks(north, notrump)` counts through the variable that reads it and a
+comment mentioning `par` does not count at all.
 
 ### `check_script`
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1502,6 +1502,31 @@ pub fn script_params(script: &str) -> String {
     serde_json::to_string(&result).unwrap_or_default()
 }
 
+/// Whether anything in `script` can reach the double-dummy solver.
+///
+/// `true` when a `tricks`, `dds`, `par` or `trix` — under any of its spellings,
+/// in a condition, an action or a variable either of them reads — is actually
+/// evaluated. The question a page asks with it is whether solved deals are
+/// worth fetching: a script that never asks a double-dummy question gains
+/// nothing from a library that arrives with the answers, and should not be
+/// paying a download for it.
+///
+/// `undefined` when the script does not parse, which is not the same as no. A
+/// page must not tell someone their script wants no double-dummy work when it
+/// has not been able to read the script at all.
+///
+/// Answered by the same [`dealer_run::dd_demand::touches_solver`] the run uses
+/// to decide whether to carry answers with its deals, rather than by looking
+/// for the words: `t = tricks(north, notrump)` mentions one and `x = t` does
+/// not, and a comment mentioning `par` is not a call.
+#[wasm_bindgen]
+pub fn script_uses_double_dummy(script: &str, params: Vec<String>) -> Option<bool> {
+    let params = script_params_from(&params).ok()?;
+    let preprocessed = dealer_parser::preprocess_all(script, &params).ok()?;
+    let program = dealer_parser::parse_program(&preprocessed).ok()?;
+    Some(dealer_run::dd_demand::touches_solver(&program))
+}
+
 /// Engine version, so a page can show which build it is running.
 #[wasm_bindgen]
 pub fn version() -> String {
@@ -1778,5 +1803,59 @@ mod tests {
             expected
         );
         assert_eq!(result["averages"][0]["count"], 10);
+    }
+
+    /// What a page asks before offering to fetch a solved-deal library: does
+    /// this script ask a double-dummy question at all?
+    ///
+    /// Read off the parsed program rather than the text, which is the whole
+    /// reason it is answered here and not in JavaScript — the last two cases
+    /// are ones a search for the words gets wrong in both directions.
+    #[test]
+    fn a_script_says_whether_it_asks_a_double_dummy_question() {
+        let cases: [(&str, Option<bool>, &str); 7] = [
+            (
+                "condition hcp(north) >= 20\n",
+                Some(false),
+                "nothing here reaches the solver",
+            ),
+            (
+                "condition tricks(north, notrump) >= 9\n",
+                Some(true),
+                "a condition that solves",
+            ),
+            (
+                "condition 1\naction printoneline, average \"par\" par(north)\n",
+                Some(true),
+                "an action that solves",
+            ),
+            (
+                "condition 1\naction printoneline, average \"t\" dds(north, notrump)\n",
+                Some(true),
+                "dds under its own spelling",
+            ),
+            (
+                "t = tricks(south, hearts)\ncondition t >= 10\n",
+                Some(true),
+                "through a variable",
+            ),
+            (
+                "# par and tricks are what this script does not do\ncondition hcp(north) >= 4\n",
+                Some(false),
+                "the words in a comment are not calls",
+            ),
+            (
+                "condition hcp(north) >=\n",
+                None,
+                "an unreadable script is not a no",
+            ),
+        ];
+        for (script, expected, why) in cases {
+            assert_eq!(
+                script_uses_double_dummy(script, Vec::new()),
+                expected,
+                "{why}: {script:?}"
+            );
+        }
     }
 }

--- a/wasm/src/library.rs
+++ b/wasm/src/library.rs
@@ -52,6 +52,41 @@ pub fn rpdd_manifest_url() -> String {
     rpdd_reader::RPDD_MANIFEST.to_string()
 }
 
+/// Which record a run's seed starts at, in a library of `records` records.
+///
+/// This is the *whole* of what a page needs to turn its seed box into a
+/// position in the library — and it is deliberately not arithmetic a page may
+/// do for itself. The mapping is [`dealer_run::deal_input::Start::Seed`]'s: one
+/// expansion of `SplitMix64` and one draw of xoshiro256++. A JavaScript hash
+/// that looked every bit as reasonable would land somewhere else, and nothing
+/// would fail — the page and the terminal would simply read different deals
+/// from the same seed, and only someone comparing the two would ever find out.
+///
+/// So there is one implementation with two callers, as with the reader and the
+/// run. `wasm/verify.mjs` checks the agreement rather than trusting it.
+///
+/// `records` is the size of the library being read — [`Library::total_deals`]
+/// for the published one — because the seed names a position in the file it was
+/// given. A partial library answers differently, and correctly so.
+#[wasm_bindgen]
+pub fn record_for_seed(seed: u32, records: u32) -> Result<u32, JsError> {
+    if records == 0 {
+        return Err(JsError::new(
+            "an empty library has no record for a seed to start at",
+        ));
+    }
+    // Fits: `records` is a u32, so the remainder of a division by it is one too.
+    Ok(record_of(seed, records as u64) as u32)
+}
+
+/// The mapping itself, callable from an ordinary test.
+///
+/// Split out for the same reason as [`zrd_bytes`]: a `JsError` in the signature
+/// is a `JsError` a host test cannot handle.
+fn record_of(seed: u32, records: u64) -> u64 {
+    dealer_run::deal_input::Start::Seed(seed).record(records)
+}
+
 /// A solved-deal library, described by a manifest and holding the pieces it has
 /// been given.
 ///
@@ -269,6 +304,52 @@ mod tests {
     fn serving_agrees_with_pairing_the_same_tables_directly() {
         let tables: Vec<u8> = [chunk(0), chunk(1)].concat();
         assert_eq!(served(0, 10), pair(&tables, 0).expect("ten records pair"));
+    }
+
+    /// The record a seed names is the record the reader starts at.
+    ///
+    /// The binding is three lines, so what wants testing is not the arithmetic
+    /// but the tie: the deal a page derives from its seed must be the deal a
+    /// run handed the same seed would begin with. Written against the reader
+    /// rather than against `Start::record` — which the binding calls, and which
+    /// would therefore agree with itself no matter what either of them meant.
+    #[test]
+    fn the_record_a_seed_names_is_where_the_reader_starts() {
+        use dealer_run::deal_input::{Start, Take, Window};
+
+        let (whole, _) = dealer_run::deals_from_bytes(LIBRARY, Window::all())
+            .expect("the fixture is a readable library");
+        let records = whole.len() as u64;
+
+        for seed in [0u32, 1, 2, 42, 1_000_003, u32::MAX] {
+            let record = record_of(seed, records);
+            assert!(record < records, "seed {seed} names a record off the end");
+            let (from_seed, _) = dealer_run::deals_from_bytes(
+                LIBRARY,
+                Window {
+                    start: Start::Seed(seed),
+                    take: Take::AtMost(1),
+                },
+            )
+            .expect("the fixture is a readable library");
+            assert_eq!(
+                from_seed[0].0, whole[record as usize].0,
+                "seed {seed} says record {record}, but the reader starts elsewhere"
+            );
+        }
+    }
+
+    /// Neighbouring seeds must not give neighbouring records. Mixing is the
+    /// reason `-s 1`, `-s 2` and `-s 3` across a lesson set are not three
+    /// adjacent windows of a file that is in generated order.
+    #[test]
+    fn adjacent_seeds_do_not_give_adjacent_records() {
+        let records = 10_485_760;
+        let (one, two) = (record_of(1, records), record_of(2, records));
+        assert!(
+            one.abs_diff(two) > 1_000,
+            "seeds 1 and 2 land at {one} and {two}, which is not a mix"
+        );
     }
 
     /// `Needs` is the protocol, not a failure, and must not reach a page as a

--- a/wasm/verify.mjs
+++ b/wasm/verify.mjs
@@ -9,7 +9,7 @@
 // Requires a release build of the CLI: ./dev-build.sh build --release
 
 import { createRequire } from 'module'
-import { execFileSync } from 'child_process'
+import { execFileSync, spawnSync } from 'child_process'
 import { writeFileSync, mkdtempSync, readFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join, dirname } from 'path'
@@ -182,7 +182,44 @@ for (const c of SUPPLIED) {
   if (!failures) console.log(`  \u2713 ${c.name} (read=${read?.read} produced=${wasm.produced})`)
 }
 
+// The seed's meaning across the two front ends.
+//
+// `record_for_seed` exists so that a page does not work this out for itself. A
+// JavaScript hash would be wrong in the one way nothing catches: the same seed
+// would read different deals in a tab and at a terminal, both runs would look
+// perfectly healthy, and only a comparison like this one would ever say so.
+//
+// The CLI is asked through `--input-deals` with no `--input-offset`, which is
+// what lets the seed choose the starting record; it names the record it chose
+// on stderr, and that is the number the binding has to produce.
+const SEEDS = [0, 1, 2, 42, 1000003, 4294967295]
+const seedScript = join(tmp, 'seed_start.dlr')
+writeFileSync(seedScript, 'condition 1\n')
+
+for (const seed of SEEDS) {
+  const run = spawnSync(CLI,
+    [seedScript, '--input-deals', LIBRARY, '-p', '1', '-s', String(seed), '-q'],
+    { encoding: 'utf8' })
+  const note = (run.stderr || '').match(
+    /seed (\d+) starts this library at record (\d+) of (\d+)/)
+  if (!note) {
+    fail(`seed ${seed}`,
+      `the CLI said nothing about where it started: ${JSON.stringify(run.stderr)}`)
+    continue
+  }
+  const [, said, record, records] = note
+  const fromWasm = w.record_for_seed(seed, Number(records))
+  if (Number(said) !== seed) {
+    fail(`seed ${seed}`, `the CLI reported seed ${said}`)
+  } else if (fromWasm !== Number(record)) {
+    fail(`seed ${seed}`, `cli starts at record ${record}, wasm says ${fromWasm} — `
+      + 'the same seed would read different deals in a browser and at a terminal')
+  } else {
+    console.log(`  \u2713 seed ${seed} starts at record ${record} of ${records} in both`)
+  }
+}
+
 console.log(failures
   ? `\n${failures} mismatch(es) between wasm and the native CLI`
-  : `\nall ${CASES.length + SUPPLIED.length} cases match the native CLI`)
+  : `\nall ${CASES.length + SUPPLIED.length + SEEDS.length} cases match the native CLI`)
 process.exit(failures ? 1 : 0)

--- a/web/README.md
+++ b/web/README.md
@@ -27,6 +27,7 @@ src/
 │   ├── reference.js      shaping the vocabulary into reference sections
 │   ├── guide.js          rendering a docs/ markdown file as a page
 │   ├── engine.worker.js  generation, off the main thread
+│   ├── library.js        the solved-deal library: fetching, caching, wording
 │   └── download.js       saving results as PBN or text
 ├── Reference.vue         the language reference page
 ├── Leveling.vue          the levelling guide, rendered from docs/
@@ -216,6 +217,59 @@ Rolling before rather than after is what made a separate "new seed" button
 unnecessary — there is no other reason to want one. A restored session keeps its
 seed, so a reload reproduces what was there.
 
+## Where the deals come from
+
+A radio pair above the editor, and the only control on that row that is about
+the deals rather than about the run:
+
+**Random deals** shuffles them here, from the seed, as this page always has.
+
+**Pre-solved deals** draws them from
+[Pavlicek's 10,485,760 solved deals](https://github.com/bridge-craftwork/rpdd-library),
+so `tricks()`, `dds()` and `par()` are lookups rather than searches — the
+difference between double-dummy being usable in a tab and not, since a solve is
+about 23ms a deal and a browser has one thread to do it on.
+
+Everything else means what it meant. The seed still reproduces the run; it picks
+where in the library to start instead of driving a shuffle, and **the same seed
+reads the same deals here as `dealer -s N --input-deals rpdd.zrd` does at a
+terminal** — verified against the CLI in `wasm/verify.mjs`, because the page
+does not compute that mapping. It asks the engine
+(`record_for_seed`), which is the mapping the command line reduces `-s` through.
+
+Three things the page says that a terminal would put on stderr:
+
+* **what arrived** — "Read 20,000 deals from the solved-deal library, starting
+  at deal 246,427 of 10,485,760. Every one arrived with its double-dummy
+  table…", with warnings when fewer deals arrived than were asked for, when some
+  came unsolved, or when a run read the whole library and a longer one would
+  start repeating deals;
+* **the fetch**, while it happens, since it is the one part of a run that waits
+  on something outside the tab;
+* **that pre-solved buys this script nothing**, when the script never calls
+  `tricks()`, `dds()` or `par()`. Asked of the engine off the parsed program,
+  not searched for in the text — a comment mentioning `par` is not a call.
+
+### Where the fetching lives, and why
+
+In the **worker**, with the rest of the engine. A `Library` is a handle into one
+wasm instance's linear memory: the page has its own instance for the editor's
+instant calls, and only the worker's can say which URLs a run wants, since that
+answer comes from `needs()`. Fetching on the main thread would put a round trip
+between every ask and its answer for nothing.
+
+Caching is arranged to survive the worker, which Cancel terminates: pieces go
+into the Cache API under `dealer3-library-v1`, and an in-memory map on top of it
+saves the cache read. A piece is immutable — `rpdd-042.zdd` is the same 640 KiB
+for ever — so nothing there expires; the manifest is deliberately not cached.
+After a reload, a repeat run fetches only the manifest.
+
+A run asks for at most 65,536 deals (`MAX_LIBRARY_DEALS`), which is about one
+published piece. That is a download budget rather than arithmetic: a `Max
+generate` of a million would otherwise pull sixteen pieces — ten megabytes — to
+look at twenty deals. A filter more selective than that runs out of deals rather
+than out of matches, and the report above says so.
+
 ## Script parameters
 
 A script using `$0`-`$9` gets a row of fields above the editor, one per
@@ -250,7 +304,9 @@ stored result could silently disagree with the script shown beside it.
 
 Every access is guarded. `localStorage` throws outright in some privacy modes
 rather than returning null, and a corrupt value means "start fresh" rather than
-a page that fails to load.
+a page that fails to load. The deal source is restored the same way, with one
+extra rule: anything but `library` reads back as random deals, so a stored value
+that no longer means anything cannot start a visit by downloading a library.
 
 ## Editor appearance
 
@@ -283,8 +339,10 @@ npm test
 
 Cases covering manifest parsing, the language derivation — tokenizer
 classification, longest-first matching, case-insensitivity, completion shape —
-the reference page's transforms of the vocabulary, and the levelling guide's
-markdown rendering.
+the reference page's transforms of the vocabulary, the levelling guide's
+markdown rendering, and the solved-deal library's half of the page: how much of
+it a run asks for, the ask/supply loop against a stand-in library, both levels of
+the cache, and every line the page says about what came back.
 
 The Vue components are not covered by unit tests; they are exercised by the
 browser smoke checks instead. That division is deliberate: every real bug in

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -40,6 +40,21 @@
 
       <section class="col col-editor">
         <div class="controls">
+          <!-- Where the deals come from. The one control on this row that is
+               about the deals rather than the run: everything beside it means
+               exactly what it meant, the seed included — on Pre-solved it picks
+               a starting position in the library instead of driving a shuffle,
+               so the same seed still gives the same deals. -->
+          <span class="source" role="radiogroup" aria-label="Deal source">
+            <label class="check" title="Shuffle deals here, from the seed. What this page has always done.">
+              <input v-model="dealSource" type="radio" name="deal-source" value="random" />
+              Random deals
+            </label>
+            <label class="check" :title="libraryHint">
+              <input v-model="dealSource" type="radio" name="deal-source" value="library" />
+              Pre-solved deals
+            </label>
+          </span>
           <label>Produce <input v-model.number="produce" class="narrow" type="number" min="1" /></label>
           <label>
             Max generate
@@ -74,6 +89,19 @@
             </select>
           </label>
         </div>
+
+        <!-- Said where it is chosen rather than in the results, because it is
+             a reason to choose differently before pressing Run: a script with
+             no double-dummy question in it downloads 640 KiB and reads none of
+             the answers. Asked of the engine, off the parsed script. -->
+        <p v-if="dealSource === 'library' && pointlessLibrary" class="source-warn">
+          {{ pointlessLibrary }}
+        </p>
+        <p v-else-if="dealSource === 'library'" class="source-note">
+          Deals come from Pavlicek's 10,485,760 solved deals, so tricks(), dds() and par() are
+          lookups rather than searches. The seed picks where in the library to start. A piece is
+          640 KiB and is kept, so only the first run of a region waits for it.
+        </p>
 
         <!-- Tabs, the levelling switch and Run share a row: three things that
              all decide what the pane below shows, and one row rather than two
@@ -128,6 +156,11 @@
                have used. -->
           <button v-if="showProgress" class="cancel" @click="cancel">Cancel</button>
         </div>
+
+        <!-- Not held back the way the bars below are. Fetching is the one part
+             of a run that waits on something outside the tab, and a page that
+             sits still for a second with nothing said reads as broken. -->
+        <p v-if="libraryStatus" class="library-status" aria-live="polite">{{ libraryStatus }}</p>
 
         <!-- Held back for a second, so the common short run does not flash a
              bar up and down. What it costs is that a run finishing at 1.1s
@@ -196,7 +229,7 @@
     :result="result"
     :scenario="selectedFile"
     :engine-ready="engineReady"
-    :params="{ seed, produce, maxGenerate, format }"
+    :params="{ seed, produce, maxGenerate, format, dealSource }"
   />
 </template>
 
@@ -208,7 +241,8 @@ import ScriptParams from '@/components/ScriptParams.vue'
 import ScriptViewer from '@/components/ScriptViewer.vue'
 import ResultsPanel from '@/components/ResultsPanel.vue'
 import PrintView from '@/components/PrintView.vue'
-import { ready, generate, version } from '@/lib/engine.js'
+import { ready, generate, usesDoubleDummy, version } from '@/lib/engine.js'
+import { libraryStatusText, pointlessLibraryWarning } from '@/lib/library.js'
 import { fetchScenarioScript } from '@/lib/pbsScenarios.js'
 import { downloadText, resultFilename, statisticsText } from '@/lib/download.js'
 import { loadSession, saveSession } from '@/lib/session.js'
@@ -250,6 +284,19 @@ const roundRobin = ref(restored?.roundRobin ?? false)
 // truncated run is a worse outcome than a second of waiting.
 const maxGenerate = ref(restored?.maxGenerate ?? 1000000)
 const format = ref(restored?.format || 'oneline')
+
+// Where the deals come from: 'random' shuffles them here, as this page always
+// has; 'library' draws them from the published solved-deal library, where every
+// deal arrives with its double-dummy table and the seed picks a starting
+// position rather than driving a shuffle.
+//
+// Random by default. Pre-solved costs a download and pays for it only when a
+// script asks a double-dummy question, which almost none do.
+const dealSource = ref(restored?.dealSource || 'random')
+
+/// The one line shown while pieces of the library are being fetched, and empty
+/// the rest of the time.
+const libraryStatus = ref('')
 
 // What has been typed into the parameter fields, by parameter number. Empty
 // means "use whatever the script declares", so clearing a field returns to the
@@ -437,6 +484,32 @@ const runHint = computed(() => {
   } and declares no default.`
 })
 
+const libraryHint =
+  'Draw from Pavlicek\u2019s 10,485,760 pre-solved deals, so tricks(), dds() and par() are ' +
+  'lookups rather than searches. The seed picks where in the library to start.'
+
+/// Whether this script asks a double-dummy question at all, as the engine reads
+/// it off the parsed program: true, false, or undefined while the engine is
+/// still loading or the script does not parse.
+///
+/// Not a search for the words. `t = tricks(north, notrump)` mentions one and
+/// `x = t` does not, and a comment mentioning `par` is not a call — which is
+/// why this is asked of the engine rather than answered with a regular
+/// expression here.
+const scriptUsesDoubleDummy = computed(() => {
+  if (!engineReady.value) return undefined
+  try {
+    return usesDoubleDummy(script.value, paramSpecs.value)
+  } catch {
+    // A script the engine cannot even look at is not a script asking for
+    // nothing; say nothing rather than the wrong thing.
+    return undefined
+  }
+})
+
+/// Why pre-solved deals are the wrong choice for this script, if they are.
+const pointlessLibrary = computed(() => pointlessLibraryWarning(scriptUsesDoubleDummy.value))
+
 // Ticked for you the first time a script with hand types appears, and left
 // alone afterwards.
 watch(hasHandTypes, (has) => {
@@ -478,6 +551,7 @@ watch(
     roundRobin,
     maxGenerate,
     format,
+    dealSource,
     selectedFile,
     autoLevel,
     newSeedEachRun,
@@ -493,6 +567,7 @@ watch(
         roundRobin: roundRobin.value,
         maxGenerate: maxGenerate.value,
         format: format.value,
+        dealSource: dealSource.value,
         scenario: selectedFile.value,
         autoLevel: autoLevel.value,
         newSeedEachRun: newSeedEachRun.value,
@@ -550,6 +625,10 @@ async function onDownload(kind) {
         maxGenerate: maxGenerate.value,
         format: 'pbn',
         params: paramSpecs.value,
+        // Saving re-runs the script, so it has to read from the same place the
+        // run on screen did — otherwise the file would hold different deals
+        // from the ones it was saved from.
+        source: dealSource.value,
       })
       downloadText(
         resultFilename(name, seed.value, 'pbn'),
@@ -564,6 +643,7 @@ async function onDownload(kind) {
         maxGenerate: maxGenerate.value,
         format: format.value === 'pbn' ? 'oneline' : format.value,
         params: paramSpecs.value,
+        source: dealSource.value,
       })
       // `printes` first, as it appears on screen: leaving it out would drop
       // what the script printed from the file the user saves.
@@ -632,9 +712,15 @@ async function run() {
       format: format.value,
       params: paramSpecs.value,
       autoLevel: !onLeveled && autoLevel.value && hasHandTypes.value,
+      // The deals themselves. Everything above is the same either way, which is
+      // the point of it being a choice of source rather than a second mode.
+      source: dealSource.value,
       signal: abort.signal,
       onProgress: (report) => {
         phases.value = { ...phases.value, [report.phase]: report }
+      },
+      onLibrary: (status) => {
+        libraryStatus.value = libraryStatusText(status)
       },
     })
     if (result.value.leveling) leveling.value = result.value.leveling
@@ -645,6 +731,7 @@ async function run() {
     error.value = e?.cancelled ? '' : e?.message || String(e)
   } finally {
     stopProgress()
+    libraryStatus.value = ''
     abort = null
     running.value = false
   }
@@ -777,6 +864,34 @@ body {
   background: #fff; color: var(--fg-muted); cursor: pointer;
 }
 .cancel:hover { color: #b23b3b; border-color: #d8a9a9; }
+
+/* The deal source, set apart from the numeric fields beside it: it is the one
+   control on the row that changes what a run reads rather than how much of it.
+   The rule after it does that without a second row. */
+.source {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding-right: 10px; border-right: 1px solid var(--line);
+}
+
+/* Both sit under the controls in the space a script would otherwise start in,
+   so they are read before Run rather than after it. */
+.source-note, .source-warn {
+  margin: 6px 0 0; font-size: 11.5px; line-height: 1.45;
+}
+.source-note { color: var(--fg-muted); }
+.source-warn {
+  color: var(--warn-fg);
+  background: var(--warn-subtle);
+  border-left: 3px solid var(--warn);
+  padding: 5px 8px;
+}
+
+/* Shown the moment a fetch starts, where the progress bars are held back for a
+   second: a network wait has nothing else to show for itself. */
+.library-status {
+  margin: 6px 0 2px;
+  font-size: 11px; font-family: var(--mono); color: var(--fg-muted);
+}
 
 /* Between the run row and the editor, so it sits where the wait is felt
    without pushing the script down permanently — it exists only while running. */

--- a/web/src/components/PrintView.vue
+++ b/web/src/components/PrintView.vue
@@ -11,6 +11,12 @@
         <div><dt>Max generate</dt><dd>{{ params.maxGenerate.toLocaleString() }}</dd></div>
         <div><dt>Format</dt><dd>{{ params.format }}</dd></div>
         <div class="p-seed"><dt>Seed</dt><dd>{{ params.seed }}</dd></div>
+        <!-- Only when it was not the usual shuffle: a printed set from the
+             solved-deal library is reproducible from the seed the same way, but
+             only if the reader knows which source to reproduce it from. -->
+        <div v-if="params.dealSource === 'library'">
+          <dt>Deals</dt><dd>pre-solved library</dd>
+        </div>
       </dl>
     </header>
 

--- a/web/src/components/ResultsPanel.vue
+++ b/web/src/components/ResultsPanel.vue
@@ -31,6 +31,16 @@
         <span v-else><strong>{{ result.seconds.toFixed(3) }}</strong> sec</span>
       </div>
 
+      <!-- What the run READ, when it read rather than dealt. Above everything
+           else because it says what the numbers below were computed over: a run
+           handed forty deals from a library of four thousand produces fewer
+           matches and looks exactly like a selective filter. The CLI writes
+           this to stderr, and a page has no stderr. -->
+      <template v-if="inputReport">
+        <p class="results-note">{{ inputReport.summary }}</p>
+        <p v-for="(w, i) in inputReport.warnings" :key="'in' + i" class="results-warn">{{ w }}</p>
+      </template>
+
       <!-- Not while a round was being dealt: the hand types below say which
            ones ran out, which is the same news with the part that matters in
            it. Two warnings saying it once each read as two problems. -->
@@ -314,6 +324,7 @@ import { ref, computed } from 'vue'
 import DealGrid from '@/components/DealGrid.vue'
 import { parseOnelineDeals } from '@/lib/cardFormatting.js'
 import { formatAverage } from '@/lib/format.js'
+import { describeInput } from '@/lib/library.js'
 import { handTypePalette } from '@/lib/handTypes.js'
 import {
   rowLabels as heatRowLabels,
@@ -340,6 +351,14 @@ defineEmits(['download', 'print'])
 
 // Hands read far more easily than one-line strings, so that is the default.
 const view = ref('grid')
+
+/// What the run read, for a run that read rather than dealt: how many deals
+/// arrived, whether they came with double-dummy tables, and anything the reader
+/// could not make sense of. Null for an ordinary shuffled run, which reads
+/// nothing and has nothing to say.
+const inputReport = computed(() =>
+  props.result?.input ? describeInput(props.result.input, props.result.library) : null,
+)
 
 // The script's hand types, in the order it declares them, which is the order
 // their colours follow.

--- a/web/src/lib/engine.js
+++ b/web/src/lib/engine.js
@@ -109,6 +109,7 @@ function runInWorker(script, options) {
         maxGenerate: options.maxGenerate,
         format: options.format,
         autoLevel: options.autoLevel,
+        roundRobin: options.roundRobin,
         // A plain copy: the caller's array is a Vue ref's, and a reactive
         // proxy cannot be structured-cloned — postMessage fails outright with
         // "[object Object] could not be cloned", which says nothing about

--- a/web/src/lib/engine.js
+++ b/web/src/lib/engine.js
@@ -6,6 +6,7 @@
 
 import init, {
   check_script as wasmCheck,
+  script_uses_double_dummy as wasmUsesDoubleDummy,
   script_params as wasmScriptParams,
   language_info as wasmLanguageInfo,
   version as wasmVersion,
@@ -67,6 +68,13 @@ function runInWorker(script, options) {
       const data = event.data || {}
       // A message from a run that was cancelled and replaced.
       if (data.id !== id) return
+      // Fetching a piece of the solved-deal library: a network wait, where
+      // generating is immediate. Reported from the first byte rather than held
+      // back like the progress bars, because there is nothing else to see.
+      if (data.type === 'library') {
+        options.onLibrary?.(data.status)
+        return
+      }
       if (data.type === 'progress') {
         if (options.onProgress) {
           try {
@@ -77,7 +85,7 @@ function runInWorker(script, options) {
         }
         return
       }
-      if (data.type === 'done') finish(resolve, data.raw)
+      if (data.type === 'done') finish(resolve, data)
       else finish(reject, new Error(data.message || 'the engine failed'))
     }
 
@@ -110,6 +118,11 @@ function runInWorker(script, options) {
         format: options.format,
         autoLevel: options.autoLevel,
         roundRobin: options.roundRobin,
+        // Where the deals come from: 'random' shuffles from the seed, 'library'
+        // draws from the published solved-deal library, where the seed picks
+        // the starting position instead. The worker does the fetching — see
+        // engine.worker.js for why it cannot be done out here.
+        source: options.source,
         // A plain copy: the caller's array is a Vue ref's, and a reactive
         // proxy cannot be structured-cloned — postMessage fails outright with
         // "[object Object] could not be cloned", which says nothing about
@@ -165,23 +178,35 @@ export async function generate(
     /// A parameter left out here falls back to the script's own `# param`
     /// default, and fails the run if it has none.
     params = [],
+    /// Where the deals come from: `'random'` shuffles them from the seed, as
+    /// this page always has; `'library'` draws them from the published
+    /// solved-deal library, where the seed picks a starting position instead
+    /// and every deal arrives with its double-dummy table.
+    source = 'random',
     /// Called with `{ phase, produced, generated, target }` as the run goes.
     onProgress = null,
+    /// Called with `{ stage, done, total, url }` while pieces of the library
+    /// are being fetched. Only a library run reports this, and it reports it
+    /// before any deal has been looked at.
+    onLibrary = null,
     /// Resolves — or rejects — if the caller abandons the run.
     signal = null,
   } = {},
 ) {
-  const raw = JSON.parse(await runInWorker(script, {
+  const message = await runInWorker(script, {
     seed,
     produce,
     maxGenerate,
     format,
     autoLevel,
     roundRobin,
+    source,
     params,
     onProgress,
+    onLibrary,
     signal,
-  }))
+  })
+  const raw = JSON.parse(message.raw)
   return {
     deals: raw.deals,
     generated: raw.generated,
@@ -211,6 +236,17 @@ export async function generate(
     // rounds, how many deals were left over, and whether the rounds were even
     // or weighted by `HandType_X_Share`.
     roundRobin: raw.round_robin,
+    // What the run read, when it read rather than dealt: how many deals
+    // arrived, how many came with double-dummy tables, what could not be read.
+    // A page has no stderr, and this is the only thing that tells a run over a
+    // short library from a run over all of it — neither `produced` nor
+    // `hitLimit` can, since a run that exhausts its deals has not hit its
+    // budget. Absent for a run that shuffled.
+    input: raw.input || null,
+    // Where in the library this run started, how big the library is and how
+    // many deals were asked for. From the worker rather than the engine: it is
+    // what the page asked for, against which `input.read` is worth reading.
+    library: message.library || null,
     // `deals` is capped by the engine; `produced` counts every match. A script
     // gathering statistics over 50,000 deals returns statistics for all of them
     // and only the first few hundred deals.
@@ -228,6 +264,22 @@ export async function generate(
 export function checkScript(script, params = []) {
   assertReady('checkScript')
   return JSON.parse(wasmCheck(script, params))
+}
+
+/**
+ * Whether anything in the script can reach the double-dummy solver: `true`,
+ * `false`, or `undefined` when the script does not parse, which is not the same
+ * as no.
+ *
+ * The page asks before offering pre-solved deals, since a script that never
+ * calls `tricks()`, `dds()` or `par()` gains nothing from deals that arrive
+ * with the answers. Answered by the engine off the parsed program rather than
+ * by searching the text here: `t = tricks(north, notrump)` mentions one and
+ * `x = t` does not, and a comment mentioning `par` is not a call.
+ */
+export function usesDoubleDummy(script, params = []) {
+  assertReady('usesDoubleDummy')
+  return wasmUsesDoubleDummy(script, params)
 }
 
 /**

--- a/web/src/lib/engine.worker.js
+++ b/web/src/lib/engine.worker.js
@@ -17,6 +17,12 @@
 // worth an await, so they stay on the main thread's own instance.
 
 import init, * as engine from '@/wasm/dealer3_wasm.js'
+import {
+  createLibraryFetcher,
+  dealsToRequest,
+  learnLibrarySize,
+  supplyLibraryPieces,
+} from '@/lib/library.js'
 
 let ready = null
 
@@ -50,6 +56,76 @@ async function bringUp() {
   }
 }
 
+// --- The solved-deal library ----------------------------------------------
+//
+// The fetching lives HERE, in the worker, and not on the main thread, because
+// the wasm `Library` cannot leave the wasm instance that made it. There are two
+// instances — the page's, for the editor's instant calls, and this one, for
+// generating — and a `Library` is a handle into linear memory, not something
+// `postMessage` can clone. The main thread could fetch the bytes and send them
+// across, but only this side can say which URLs are wanted, because that answer
+// comes from `needs()`. Splitting the loop over the two would put a round trip
+// between every ask and its answer to no purpose.
+//
+// So the worker fetches, and the caching is arranged to survive the worker:
+// pieces go into the browser's Cache API, which outlives a `terminate()` — how
+// Cancel works — and a reload. The in-memory map on top of it is per worker and
+// merely saves the cache read. See `library.js`.
+//
+// The `Library` itself is kept between runs, so a second run in the same region
+// of the library fetches nothing at all.
+
+let library = null
+let fetchPiece = null
+let piecesHeld = 0
+
+/// Pieces to hold before releasing them all. Each is 640 KiB of tables inside
+/// the wasm's memory; the fetched bytes are still cached, so releasing costs a
+/// re-supply and not a download.
+const MAX_HELD_PIECES = 8
+
+/// The library, and the fetcher that feeds it, made once per worker.
+function libraryHandle() {
+  if (!library) {
+    library = new engine.Library(engine.rpdd_manifest_url())
+    fetchPiece = createLibraryFetcher({ manifestUrl: library.manifest_url })
+  }
+  return library
+}
+
+/// The deals this run should read, as `.zrd` bytes for `generate_from_deals`.
+///
+/// The order matters and is forced: the manifest says how big the library is,
+/// the size is what the seed is reduced against, and only then is there an
+/// index to say which pieces to fetch.
+async function dealsFromLibrary(options, report) {
+  const lib = libraryHandle()
+  const totalDeals = await learnLibrarySize(lib, fetchPiece, report)
+
+  // The engine's mapping, never one of ours. A JavaScript hash would send the
+  // page to a different deal from the one `dealer -s N --input-deals` reads,
+  // and nothing anywhere would say so — see `record_for_seed`.
+  const firstDeal = engine.record_for_seed(options.seed, totalDeals)
+  const requested = dealsToRequest({
+    produce: options.produce,
+    maxGenerate: options.maxGenerate,
+    totalDeals,
+  })
+
+  const { fetched } = await supplyLibraryPieces(lib, firstDeal, requested, {
+    fetchPiece,
+    onProgress: report,
+  })
+  piecesHeld += fetched
+
+  const zrd = lib.zrd(firstDeal, requested)
+  if (piecesHeld > MAX_HELD_PIECES) {
+    lib.forget_chunks()
+    piecesHeld = 0
+  }
+  return { zrd, info: { firstDeal, totalDeals, requested, fetched } }
+}
+
 self.onmessage = async (event) => {
   const { id, script, options } = event.data || {}
   try {
@@ -74,18 +150,42 @@ self.onmessage = async (event) => {
       self.postMessage({ id, type: 'progress', message })
     }
 
-    const raw = engine.generate(
-      script,
-      options.seed,
-      options.produce,
-      options.maxGenerate,
-      options.format,
-      options.autoLevel,
-      options.roundRobin,
-      options.params || [],
-      onProgress,
-    )
-    self.postMessage({ id, type: 'done', raw, threads: pool.threads })
+    // Two deal sources, one run. `generate_from_deals` is the same engine over
+    // deals it was handed instead of deals it shuffled — the filter, the
+    // statistics, the levelling and the output are all the ones above.
+    let raw
+    let libraryInfo = null
+    if (options.source === 'library') {
+      const { zrd, info } = await dealsFromLibrary(options, (status) =>
+        self.postMessage({ id, type: 'library', status }),
+      )
+      libraryInfo = info
+      raw = engine.generate_from_deals(
+        script,
+        zrd,
+        options.seed,
+        options.produce,
+        options.maxGenerate,
+        options.format,
+        options.autoLevel,
+        options.roundRobin,
+        options.params || [],
+        onProgress,
+      )
+    } else {
+      raw = engine.generate(
+        script,
+        options.seed,
+        options.produce,
+        options.maxGenerate,
+        options.format,
+        options.autoLevel,
+        options.roundRobin,
+        options.params || [],
+        onProgress,
+      )
+    }
+    self.postMessage({ id, type: 'done', raw, threads: pool.threads, library: libraryInfo })
   } catch (e) {
     // `Error` does not survive structured cloning with its message intact in
     // every browser, so send the text.

--- a/web/src/lib/library.js
+++ b/web/src/lib/library.js
@@ -1,0 +1,326 @@
+// The solved-deal library, from the page's side.
+//
+// Richard Pavlicek solved 10,485,760 deals over nearly two years of computer
+// time. A deal that arrives already solved makes `tricks()`, `dds()` and
+// `par()` lookups rather than searches — about 23ms a deal saved, which is the
+// difference between double-dummy being usable in a tab and not.
+//
+// Only the tables are published, as 640 KiB pieces; the deals are a pure
+// function of their index and the engine recreates them. Everything about which
+// piece holds which deal — the boundaries, the stitching, the wrap at the end —
+// belongs to the wasm `Library`, and none of it is repeated here. What this
+// module holds is the page's side of the bargain:
+//
+//   * fetching, because `fetch` is asynchronous and a wasm export cannot await
+//     one, so the library says what it needs and is told;
+//   * remembering what has been fetched, so changing a script does not spend
+//     another 640 KiB;
+//   * how much of the library one run should ask for;
+//   * and what to say about what came back.
+//
+// It does NOT work out where in the library a seed starts. That mapping is the
+// engine's `record_for_seed`, and doing it here in JavaScript is the one
+// mistake nothing would catch: a hash that looked perfectly reasonable would
+// simply read different deals from the same seed than the command line does,
+// with both runs looking healthy. See `wasm/verify.mjs`.
+
+/// Where fetched pieces are kept between visits.
+///
+/// Versioned in the name so a change of shape is a new store rather than a
+/// migration. A piece never changes — `rpdd-042.zdd` is the same 640 KiB
+/// forever — so nothing here expires.
+export const CACHE_NAME = 'dealer3-library-v1'
+
+/// The most deals one run will ask the library for.
+///
+/// A download budget, not arithmetic: this is roughly one published piece, so
+/// a run costs one fetch, or two where it straddles a boundary. Asking for
+/// everything a `Max generate` of a million allows would be sixteen pieces —
+/// ten megabytes — to look at twenty deals.
+///
+/// It bounds how selective a filter the library can satisfy, and the run report
+/// says how many deals were actually read, so a script that filters harder than
+/// this can see that it ran out of deals rather than out of matches.
+export const MAX_LIBRARY_DEALS = 65536
+
+/// Pieces held in memory at once, beyond which the oldest is dropped.
+///
+/// Each is 640 KiB of tables. The browser's cache still has them, so dropping
+/// one costs a cache read rather than a fetch.
+const MEMORY_PIECES = 8
+
+/// How many ask/supply rounds before something is wrong.
+///
+/// The protocol takes two: the manifest, then the pieces it names. A third is
+/// slack; a fourth means the library is asking for something it is never
+/// satisfied by, and looping for ever on a network resource is worse than
+/// failing.
+const MAX_ROUNDS = 4
+
+/**
+ * How many deals to ask the library for.
+ *
+ * Enough to filter through — `Max generate` is what the page already means by
+ * "how much work is this allowed" — but never more than the budget above, and
+ * never more than the library holds, which would ask it to come round to deals
+ * it has already served.
+ *
+ * At least `produce`, so that asking for more deals than the budget is a short
+ * run reported honestly rather than a request refused.
+ */
+export function dealsToRequest({ produce = 1, maxGenerate = 0, totalDeals = 0 } = {}) {
+  const wanted = Math.max(1, Math.min(maxGenerate || MAX_LIBRARY_DEALS, MAX_LIBRARY_DEALS), produce)
+  return totalDeals > 0 ? Math.min(wanted, totalDeals) : wanted
+}
+
+/**
+ * Bytes for one library URL, remembered in memory and in the browser's cache.
+ *
+ * Two levels because they fail differently. The `Map` is free and lives as long
+ * as the worker; the Cache API survives a cancelled run — which terminates the
+ * worker — and a reload, and is where "changing the script does not refetch"
+ * actually holds. Neither is required: a browser with no `caches` (an insecure
+ * origin, a private window in some browsers) falls back to the map, and one
+ * with neither still works, slowly.
+ *
+ * Everything but the manifest is treated as immutable, because it is: a piece
+ * is named after the deals in it. The manifest can gain chunks, so it is
+ * remembered only in memory and re-read on the next visit.
+ *
+ * @param {object} options
+ * @param {string} options.manifestUrl the one URL not written to the cache
+ * @param {Function} [options.fetchImpl] for tests; defaults to global `fetch`
+ * @param {CacheStorage} [options.cacheStorage] for tests; defaults to `caches`
+ * @param {string} [options.cacheName]
+ * @returns {(url: string) => Promise<Uint8Array>}
+ */
+export function createLibraryFetcher({
+  manifestUrl = '',
+  fetchImpl = undefined,
+  cacheStorage = undefined,
+  cacheName = CACHE_NAME,
+} = {}) {
+  const doFetch = fetchImpl || ((url) => globalThis.fetch(url))
+  const storage = cacheStorage === undefined ? globalThis.caches : cacheStorage
+  const memory = new Map()
+  let opening = null
+
+  // Opened once and never re-attempted: a browser that refuses the cache once
+  // refuses it every time, and asking again per piece would be a rejected
+  // promise per fetch.
+  const store = () => {
+    if (!storage) return Promise.resolve(null)
+    if (!opening) opening = Promise.resolve(storage.open(cacheName)).catch(() => null)
+    return opening
+  }
+
+  const remember = (url, bytes) => {
+    memory.set(url, bytes)
+    while (memory.size > MEMORY_PIECES) {
+      const oldest = memory.keys().next().value
+      if (oldest === undefined) break
+      memory.delete(oldest)
+    }
+    return bytes
+  }
+
+  return async function piece(url) {
+    const held = memory.get(url)
+    if (held) return held
+
+    const persist = url !== manifestUrl
+    const cache = persist ? await store() : null
+    if (cache) {
+      const hit = await cache.match(url).catch(() => null)
+      if (hit && hit.ok) return remember(url, new Uint8Array(await hit.arrayBuffer()))
+    }
+
+    let response
+    try {
+      response = await doFetch(url)
+    } catch (e) {
+      // A network failure reads as "Failed to fetch", which says nothing about
+      // what was being fetched or why the page wanted it.
+      throw new Error(
+        `Could not reach the solved-deal library at ${url} (${e?.message || e}). ` +
+          'Check the connection, or switch back to random deals.',
+      )
+    }
+    if (!response.ok) {
+      throw new Error(
+        `The solved-deal library answered HTTP ${response.status} for ${url}. ` +
+          'Switch back to random deals, or try again.',
+      )
+    }
+    const buffer = await response.arrayBuffer()
+    if (cache) {
+      // Failing to cache is not failing to fetch: a full quota should cost a
+      // refetch next time, not the run.
+      await cache.put(url, new Response(buffer)).catch(() => {})
+    }
+    return remember(url, new Uint8Array(buffer))
+  }
+}
+
+/**
+ * Learn how big the library is, fetching the manifest and nothing else.
+ *
+ * The size has to be known before the seed can name a starting deal, and the
+ * starting deal before any piece can be chosen — so this round deliberately
+ * fetches only the first URL `needs` asks for, which is the manifest. Taking
+ * the whole list would pull a 640 KiB piece chosen by an index nobody has
+ * worked out yet.
+ *
+ * @param {object} lib the wasm `Library`
+ * @param {(url: string) => Promise<Uint8Array>} fetchPiece
+ * @param {(status: object) => void} [onProgress]
+ * @returns {Promise<number>} how many deals the library holds
+ */
+export async function learnLibrarySize(lib, fetchPiece, onProgress) {
+  for (let round = 0; lib.total_deals === undefined && round < MAX_ROUNDS; round++) {
+    const [url] = lib.needs(0, 1)
+    if (!url) break
+    onProgress?.({ stage: 'manifest', done: 0, total: 1, url })
+    lib.supply(url, await fetchPiece(url))
+  }
+  if (lib.total_deals === undefined) {
+    throw new Error(
+      `The library at ${lib.manifest_url} did not say how many deals it holds.`,
+    )
+  }
+  return lib.total_deals
+}
+
+/**
+ * Fetch and supply every piece the run needs, so `lib.zrd(...)` can answer.
+ *
+ * The loop is the protocol from `docs/WASM.md`: ask what is missing, fetch it,
+ * hand it back, ask again. A piece already held — from an earlier run, or from
+ * the cache — is not asked for, which is what makes a second run over the same
+ * region free.
+ *
+ * @returns {Promise<{fetched: number}>} how many pieces this call had to get
+ */
+export async function supplyLibraryPieces(lib, firstDeal, count, { fetchPiece, onProgress } = {}) {
+  let fetched = 0
+  for (let round = 0; round < MAX_ROUNDS; round++) {
+    const needed = lib.needs(firstDeal, count)
+    if (!needed.length) return { fetched }
+    for (let i = 0; i < needed.length; i++) {
+      onProgress?.({ stage: 'pieces', done: i, total: needed.length, url: needed[i] })
+      lib.supply(needed[i], await fetchPiece(needed[i]))
+      fetched++
+    }
+    onProgress?.({ stage: 'pieces', done: needed.length, total: needed.length })
+  }
+  throw new Error(
+    'The solved-deal library kept asking for more pieces than it could use; ' +
+      'nothing was read. This is a bug — please report it.',
+  )
+}
+
+const count = (n) => Number(n || 0).toLocaleString()
+
+/**
+ * What to say about the deals a run read.
+ *
+ * A page has no stderr, and this is the half of a library run that nothing else
+ * reports: a run handed forty deals from a library of four thousand produces
+ * fewer matches and looks exactly like a selective filter. `read` against what
+ * was asked for is the only thing that tells the two apart.
+ *
+ * @param {object} input the engine's `input` report
+ * @param {object} [library] `{ firstDeal, totalDeals, requested }` for a run
+ *   drawn from the solved-deal library
+ * @returns {{summary: string, warnings: string[]}}
+ */
+export function describeInput(input, library = null) {
+  if (!input) return { summary: '', warnings: [] }
+
+  const solved = input.solved || 0
+  const read = input.read || 0
+  const where =
+    library && library.totalDeals
+      ? ` from the solved-deal library, starting at deal ${count(library.firstDeal)} of ${count(
+          library.totalDeals,
+        )}`
+      : ''
+  const tables =
+    read > 0 && solved === read
+      ? ' Every one arrived with its double-dummy table, so tricks(), dds() and par() were lookups rather than searches.'
+      : solved > 0
+        ? ` ${count(solved)} of them arrived with double-dummy tables.`
+        : ' None of them came with double-dummy tables.'
+  const summary = `Read ${count(read)} deal${read === 1 ? '' : 's'}${where}.${tables}`
+
+  const warnings = []
+  const requested = library?.requested
+  if (requested && read < requested) {
+    warnings.push(
+      `Asked for ${count(requested)} deals and read ${count(read)}. ` +
+        'The run had fewer deals to filter than it expected, so a short result here ' +
+        'is not necessarily a selective condition.',
+    )
+  }
+  if (input.unsolved) {
+    warnings.push(
+      `${count(input.unsolved)} deal${input.unsolved === 1 ? '' : 's'} arrived without a ` +
+        'double-dummy table and will be solved on demand, which is the slow path this ' +
+        'library exists to avoid.',
+    )
+  }
+  if (library?.totalDeals && requested >= library.totalDeals) {
+    warnings.push(
+      `This run read the whole library (${count(library.totalDeals)} deals). ` +
+        'A longer one would come round to deals it has already seen, and average and ' +
+        'frequency would count them twice.',
+    )
+  }
+  if (input.skipped_count) {
+    const reasons = (input.skipped || []).slice(0, 3).join('; ')
+    warnings.push(
+      `${count(input.skipped_count)} record${input.skipped_count === 1 ? '' : 's'} could not ` +
+        `be read${reasons ? `: ${reasons}` : ''}. The deals around them were still read.`,
+    )
+  }
+  for (const note of input.notes || []) warnings.push(note)
+
+  return { summary, warnings }
+}
+
+/**
+ * The one line to show while pieces of the library are being fetched.
+ *
+ * Worth showing at all because this is the only part of a run that waits on
+ * something outside the tab: generating is immediate, and a page that sits
+ * still for a second and a half with nothing said reads as broken.
+ *
+ * @param {object} status from `learnLibrarySize` and `supplyLibraryPieces`
+ * @returns {string} empty once there is nothing left to fetch
+ */
+export function libraryStatusText(status) {
+  if (!status) return ''
+  if (status.stage === 'manifest') return "Reading the solved-deal library's index…"
+  if (status.done >= status.total) return 'Running the script over the library\u2019s deals…'
+  return `Fetching the solved-deal library — piece ${status.done + 1} of ${status.total}…`
+}
+
+/**
+ * What to say to someone who chose pre-solved deals for a script that asks no
+ * double-dummy question.
+ *
+ * `usesDoubleDummy` comes from the engine, which reads it off the parsed
+ * program: `t = tricks(north, notrump)` mentions one and `x = t` does not, and
+ * a comment mentioning `par` is not a call. `undefined` means the script could
+ * not be parsed, which is not the same as no.
+ *
+ * @returns {string} empty when there is nothing worth saying
+ */
+export function pointlessLibraryWarning(usesDoubleDummy) {
+  if (usesDoubleDummy !== false) return ''
+  return (
+    'This script never calls tricks(), dds() or par(), so pre-solved deals buy it ' +
+    'nothing — it will download the library and use none of the answers. Random deals ' +
+    'will be faster.'
+  )
+}

--- a/web/src/lib/library.test.js
+++ b/web/src/lib/library.test.js
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  MAX_LIBRARY_DEALS,
+  createLibraryFetcher,
+  dealsToRequest,
+  describeInput,
+  learnLibrarySize,
+  libraryStatusText,
+  pointlessLibraryWarning,
+  supplyLibraryPieces,
+} from './library.js'
+
+const MANIFEST = 'https://example.test/data/manifest.json'
+const PIECE = (n) => `https://example.test/data/zdd/rpdd-00${n}.zdd`
+
+/// A stand-in for the wasm `Library`, with the same ask/supply protocol: the
+/// manifest first, then the pieces a run crosses. Nothing here is the real
+/// arithmetic — which piece holds which deal is Rust's, and tested there — only
+/// the shape of the conversation the page has to hold up its end of.
+function fakeLibrary({ dealsPerChunk = 10, totalDeals = 100 } = {}) {
+  const held = new Set()
+  let manifestIn = false
+  return {
+    manifest_url: MANIFEST,
+    get total_deals() {
+      return manifestIn ? totalDeals : undefined
+    },
+    needs(firstDeal, count) {
+      if (!manifestIn) return [MANIFEST]
+      const wanted = []
+      const first = Math.floor(firstDeal / dealsPerChunk)
+      const last = Math.floor((firstDeal + count - 1) / dealsPerChunk)
+      for (let n = first; n <= last; n++) if (!held.has(n)) wanted.push(PIECE(n))
+      return wanted
+    },
+    supply(url) {
+      if (url === MANIFEST) manifestIn = true
+      else held.add(Number(url.match(/rpdd-0*(\d+)\.zdd$/)[1]))
+    },
+    held,
+  }
+}
+
+describe('dealsToRequest', () => {
+  it('asks for as much as the run is allowed to look at', () => {
+    expect(dealsToRequest({ produce: 20, maxGenerate: 5000, totalDeals: 10485760 })).toBe(5000)
+  })
+
+  it('never asks for more than the download budget', () => {
+    expect(dealsToRequest({ produce: 20, maxGenerate: 1000000, totalDeals: 10485760 })).toBe(
+      MAX_LIBRARY_DEALS,
+    )
+  })
+
+  it('never asks for more than the library holds, which would repeat deals', () => {
+    expect(dealsToRequest({ produce: 20, maxGenerate: 1000000, totalDeals: 10 })).toBe(10)
+  })
+
+  it('still asks for as many as the run must produce', () => {
+    expect(dealsToRequest({ produce: 400, maxGenerate: 10, totalDeals: 10485760 })).toBe(400)
+  })
+})
+
+describe('learnLibrarySize', () => {
+  it('fetches the manifest and no piece, because the seed cannot pick one yet', async () => {
+    const lib = fakeLibrary()
+    const asked = []
+    const fetchPiece = vi.fn(async (url) => {
+      asked.push(url)
+      return new Uint8Array()
+    })
+    expect(await learnLibrarySize(lib, fetchPiece)).toBe(100)
+    expect(asked).toEqual([MANIFEST])
+  })
+
+  it('says so when a library never announces its size', async () => {
+    const lib = { total_deals: undefined, manifest_url: MANIFEST, needs: () => [], supply() {} }
+    await expect(learnLibrarySize(lib, async () => new Uint8Array())).rejects.toThrow(
+      /did not say how many deals/,
+    )
+  })
+})
+
+describe('supplyLibraryPieces', () => {
+  it('fetches every piece the run crosses, and then stops asking', async () => {
+    const lib = fakeLibrary({ dealsPerChunk: 10 })
+    lib.supply(MANIFEST)
+    const asked = []
+    const fetchPiece = async (url) => {
+      asked.push(url)
+      return new Uint8Array()
+    }
+    const { fetched } = await supplyLibraryPieces(lib, 8, 5, { fetchPiece })
+    expect(asked).toEqual([PIECE(0), PIECE(1)])
+    expect(fetched).toBe(2)
+    expect(lib.needs(8, 5)).toEqual([])
+  })
+
+  it('fetches nothing for a region already held, which is what makes a re-run free', async () => {
+    const lib = fakeLibrary()
+    lib.supply(MANIFEST)
+    const fetchPiece = vi.fn(async () => new Uint8Array())
+    await supplyLibraryPieces(lib, 0, 5, { fetchPiece })
+    expect(fetchPiece).toHaveBeenCalledTimes(1)
+    await supplyLibraryPieces(lib, 0, 5, { fetchPiece })
+    expect(fetchPiece).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports each piece as it goes, so a 640 KiB wait is not a frozen page', async () => {
+    const lib = fakeLibrary({ dealsPerChunk: 10 })
+    lib.supply(MANIFEST)
+    const seen = []
+    await supplyLibraryPieces(lib, 8, 5, {
+      fetchPiece: async () => new Uint8Array(),
+      onProgress: (status) => seen.push(`${status.done}/${status.total}`),
+    })
+    expect(seen).toEqual(['0/2', '1/2', '2/2'])
+  })
+
+  it('gives up rather than looping for ever on a library it cannot satisfy', async () => {
+    const insatiable = {
+      manifest_url: MANIFEST,
+      total_deals: 100,
+      needs: () => [PIECE(0)],
+      supply() {},
+    }
+    await expect(
+      supplyLibraryPieces(insatiable, 0, 5, { fetchPiece: async () => new Uint8Array() }),
+    ).rejects.toThrow(/kept asking/)
+  })
+})
+
+describe('createLibraryFetcher', () => {
+  const bytes = (n) => new Uint8Array([n, n, n])
+  const respond = (body) => ({ ok: true, status: 200, arrayBuffer: async () => body.buffer })
+
+  it('fetches once and remembers, so changing the script does not refetch', async () => {
+    const fetchImpl = vi.fn(async () => respond(bytes(1)))
+    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage: null })
+    expect(Array.from(await piece(PIECE(0)))).toEqual([1, 1, 1])
+    await piece(PIECE(0))
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes pieces to the browser cache but not the manifest, which can change', async () => {
+    const put = vi.fn(async () => {})
+    const cacheStorage = { open: async () => ({ match: async () => null, put }) }
+    const fetchImpl = vi.fn(async () => respond(bytes(2)))
+    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage })
+    await piece(MANIFEST)
+    expect(put).not.toHaveBeenCalled()
+    await piece(PIECE(0))
+    expect(put).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads a piece back from the cache without touching the network', async () => {
+    const cached = { ok: true, arrayBuffer: async () => bytes(3).buffer }
+    const cacheStorage = { open: async () => ({ match: async () => cached, put: async () => {} }) }
+    const fetchImpl = vi.fn()
+    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage })
+    expect(Array.from(await piece(PIECE(0)))).toEqual([3, 3, 3])
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('works where the cache is refused, which is a private window not a failure', async () => {
+    const cacheStorage = { open: async () => { throw new Error('denied') } }
+    const fetchImpl = vi.fn(async () => respond(bytes(4)))
+    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage })
+    expect(Array.from(await piece(PIECE(0)))).toEqual([4, 4, 4])
+  })
+
+  it('names the library in a network failure, where "Failed to fetch" does not', async () => {
+    const fetchImpl = async () => {
+      throw new TypeError('Failed to fetch')
+    }
+    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage: null })
+    await expect(piece(PIECE(0))).rejects.toThrow(/solved-deal library.*rpdd-000\.zdd/s)
+  })
+
+  it('reports an HTTP failure rather than reading an error page as tables', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) })
+    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage: null })
+    await expect(piece(PIECE(0))).rejects.toThrow(/HTTP 404/)
+  })
+})
+
+describe('describeInput', () => {
+  const solved = { format: 'zrd', read: 500, solved: 500, unsolved: 0, skipped_count: 0, notes: [] }
+  const library = { firstDeal: 4192003, totalDeals: 10485760, requested: 500 }
+
+  it('says how many deals arrived and that they came with tables', () => {
+    const { summary, warnings } = describeInput(solved, library)
+    expect(summary).toContain('Read 500 deals')
+    expect(summary).toContain('4,192,003 of 10,485,760')
+    expect(summary).toMatch(/Every one arrived with its double-dummy table/)
+    expect(warnings).toEqual([])
+  })
+
+  it('warns when fewer deals arrived than were asked for', () => {
+    const short = describeInput({ ...solved, read: 40, solved: 40 }, library)
+    expect(short.warnings.join(' ')).toMatch(/Asked for 500 deals and read 40/)
+  })
+
+  it('warns when deals arrived unsolved, which is the slow path this avoids', () => {
+    const { warnings } = describeInput({ ...solved, solved: 400, unsolved: 100 }, library)
+    expect(warnings.join(' ')).toMatch(/100 deals arrived without a double-dummy table/)
+  })
+
+  it('warns when a run reads the whole library, because repeats would be counted twice', () => {
+    const whole = { firstDeal: 3, totalDeals: 500, requested: 500 }
+    const { warnings } = describeInput(solved, whole)
+    expect(warnings.join(' ')).toMatch(/come round to deals it has already seen/)
+  })
+
+  it('names records that could not be read, and passes the reader notes on', () => {
+    const { warnings } = describeInput(
+      { ...solved, skipped_count: 2, skipped: ['record 3: short'], notes: ['a note'] },
+      library,
+    )
+    expect(warnings.join(' ')).toMatch(/2 records could not be read: record 3: short/)
+    expect(warnings).toContain('a note')
+  })
+
+  it('has nothing to say about a run that read nothing', () => {
+    expect(describeInput(null)).toEqual({ summary: '', warnings: [] })
+  })
+})
+
+describe('libraryStatusText', () => {
+  it('names the piece being fetched, since a network wait shows nothing else', () => {
+    expect(libraryStatusText({ stage: 'pieces', done: 0, total: 2 })).toBe(
+      'Fetching the solved-deal library — piece 1 of 2…',
+    )
+  })
+
+  it('says what is happening while the index is read', () => {
+    expect(libraryStatusText({ stage: 'manifest', done: 0, total: 1 })).toMatch(/index/)
+  })
+
+  it('moves on once every piece is in, rather than sitting on the last one', () => {
+    expect(libraryStatusText({ stage: 'pieces', done: 2, total: 2 })).toMatch(/Running the script/)
+  })
+
+  it('has nothing to say when nothing is being fetched', () => {
+    expect(libraryStatusText(null)).toBe('')
+  })
+})
+
+describe('pointlessLibraryWarning', () => {
+  it('warns when a script asks no double-dummy question', () => {
+    expect(pointlessLibraryWarning(false)).toMatch(/never calls tricks\(\), dds\(\) or par\(\)/)
+  })
+
+  it('says nothing when the script does ask one', () => {
+    expect(pointlessLibraryWarning(true)).toBe('')
+  })
+
+  it('says nothing when the script could not be read, which is not a no', () => {
+    expect(pointlessLibraryWarning(undefined)).toBe('')
+  })
+})

--- a/web/src/lib/session.js
+++ b/web/src/lib/session.js
@@ -41,6 +41,10 @@ export function loadSession() {
       roundRobin: typeof v.roundRobin === 'boolean' ? v.roundRobin : false,
       maxGenerate: Number.isFinite(v.maxGenerate) ? v.maxGenerate : 1000000,
       format: typeof v.format === 'string' ? v.format : 'oneline',
+      // Where the deals came from last time. Anything unrecognised falls back
+      // to random: a stored value that no longer means anything should not
+      // silently start a run by downloading a library.
+      dealSource: v.dealSource === 'library' ? 'library' : 'random',
       scenario: typeof v.scenario === 'string' ? v.scenario : '',
       // Left undefined rather than defaulted, so the caller can tell "never
       // chosen" from "chosen false" — auto-level ticks itself the first time a

--- a/web/src/lib/session.test.js
+++ b/web/src/lib/session.test.js
@@ -21,6 +21,7 @@ const session = {
   roundRobin: false,
   maxGenerate: 100000,
   format: 'printall',
+  dealSource: 'library',
   scenario: 'Weak_2_Bids',
   paramValues: { 0: 'west', 1: '15' },
 }
@@ -37,6 +38,16 @@ describe('saveSession / loadSession', () => {
     const { roundRobin, ...older } = session
     localStorage.setItem('dealer3:session:v1', JSON.stringify(older))
     expect(loadSession().roundRobin).toBe(false)
+  })
+
+  it('reads a session saved before the library existed as random deals', () => {
+    // A session with no opinion must not come back asking to download a
+    // library, and nor must a stored value that no longer means anything.
+    const { dealSource, ...older } = session
+    localStorage.setItem('dealer3:session:v1', JSON.stringify(older))
+    expect(loadSession().dealSource).toBe('random')
+    localStorage.setItem('dealer3:session:v1', JSON.stringify({ ...session, dealSource: 'wat' }))
+    expect(loadSession().dealSource).toBe('random')
   })
 
   it('reads a session saved before script parameters existed as none', () => {


### PR DESCRIPTION
Closes #68, and with it the roadmap in #70.

A radio pair at the head of the controls: **Random deals** / **Pre-solved deals**.
Everything else keeps its meaning — script, produce count, format, seed.

## It works, and it is checkable

Screenshot evidence in the issue thread. On a script asking for `par(ns)` and
`tricks(north, notrump)` over 20,000 library deals:

> Read 20,000 deals from the solved-deal library, starting at deal 246,427 of
> 10,485,760. Every one arrived with its double-dummy table, so tricks(), dds()
> and par() were lookups rather than searches.

**0.002 seconds.** The same script over dealt deals would have spent about
100 ms a deal solving.

And the page agrees with the command line, verified against the real 241 MB
`rpdd.zrd`: seeds 1, 7 and 99 give records 246,427 / 7,246,141 / 1,441,412 in
both, the same five deals, and the same averages (`NS par: 266`,
`N NT tricks: 6.6`).

## The seed goes through Rust, not JavaScript

`Start::record` claimed "a seed picks the same record in a browser as at a
terminal" and **nothing enforced it — the mapping was not exposed to wasm at
all.** A JavaScript hash would not reproduce xoshiro256++ seeded through
SplitMix64, so the same seed would have given different deals in the two front
ends, silently.

New binding `record_for_seed(seed, records)`, three lines over
`Start::Seed(seed).record(records)`. `verify.mjs` gains six seed cases, so the
agreement is now asserted rather than intended — 17 cases in all.

## Where the fetching lives, and why

In the worker. A `Library` is a handle into one wasm instance's memory and
cannot cross `postMessage`; only the worker's instance can say which URLs are
wanted, since that comes from `needs()`. Splitting the loop would put a round
trip between every ask and answer.

Cancel terminates the worker, so caching is arranged to outlive it: pieces go to
the Cache API with an in-memory map above. The manifest is deliberately not
cached. A run asks for at most 65,536 deals — a download budget, since
`Max generate` of a million would otherwise pull ~10 MB.

## Telling the user what happened

A page has no stderr, so the input report is on the page: how many deals were
read and from where, warnings for a short read, unsolved deals, unreadable
records, and a run long enough to lap the library (where `average` and
`frequency` would double-count).

And a warning when pre-solved buys nothing — *"This script never calls tricks(),
dds() or par()…"*. It goes through `dd_demand::touches_solver` on the parsed
script, not a text match, so a script that only mentions `par` in a comment
still gets warned.

## A pre-existing bug, found and fixed separately

`engine.js` destructured `roundRobin` and never put it in the worker's
`postMessage`. **The Round robin box has done nothing since generation moved off
the main thread**, silently — an undealt round robin looks exactly like an
ordinary run. Confirmed in a browser both ways: with the line, "Exactly 2 of
each"; without it, 4 / 2 / 0.

## Not verified

Chromium only. The production `dist/` build was made but not loaded in a
browser. No test of a browser without the Cache API beyond the unit-test
fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)