### PR TITLE
Print a two-axis frequency as its table, not its row sums

### DIFF
--- a/web/src/components/PrintView.vue
+++ b/web/src/components/PrintView.vue
@@ -54,12 +54,49 @@
 
       <template v-for="(f, i) in result.frequencies" :key="'f' + i">
         <h3>{{ (f.label || 'Frequency').trim() }}</h3>
-        <p v-if="f.below || f.above" class="p-outside">
+        <p v-if="!f.grid && (f.below || f.above)" class="p-outside">
           <span v-if="f.below">{{ f.below }} below {{ f.min }}</span>
           <span v-if="f.below && f.above"> · </span>
           <span v-if="f.above">{{ f.above }} above {{ f.max }}</span>
         </p>
-        <table class="p-table p-freq">
+
+        <!-- Two dimensions is a table of counts, not a row of bars. Printing
+             the bars would show only the row sums, which is a different and
+             much less interesting statistic than the one that was asked for:
+             the whole point of a second axis is how the count is spread along
+             it. No shading — a paper table is read by its numbers, and a grey
+             ramp survives neither a mono printer nor a photocopier. -->
+        <table v-if="f.grid" class="p-table p-grid-freq">
+          <thead>
+            <tr>
+              <th></th>
+              <th v-for="label in gridColumnLabels(f.grid)" :key="'c' + label">
+                {{ label }}
+              </th>
+              <th class="p-sum">Sum</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(row, r) in f.grid.counts" :key="'r' + r">
+              <th>{{ gridRowLabels(f.grid)[r] }}</th>
+              <td v-for="(count, c) in row" :key="'x' + c" :class="{ 'p-zero': !count }">
+                {{ count || '' }}
+              </td>
+              <td class="p-sum">{{ gridRowSum(row) || '' }}</td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <th class="p-sum">Sum</th>
+              <td v-for="(sum, c) in gridColumnSums(f.grid)" :key="'s' + c" class="p-sum">
+                {{ sum || (isOutlierBucket(c, gridColumnSums(f.grid).length) ? 0 : '') }}
+              </td>
+              <td class="p-sum"></td>
+            </tr>
+          </tfoot>
+        </table>
+
+        <table v-else class="p-table p-freq">
           <tbody>
             <tr v-for="bin in f.bins" :key="bin.value">
               <th>{{ bin.value }}</th>
@@ -114,6 +151,13 @@ import { SUIT_ORDER, SUIT_SYMBOLS, RED_SUITS, parseOnelineDeals } from '@/lib/ca
 import { dlrStreamParser, tokenizeLine } from '@/lib/dlrLanguage.js'
 import { languageInfo, isReady } from '@/lib/engine.js'
 import { formatAverage } from '@/lib/format.js'
+import {
+  rowLabels as gridRowLabels,
+  columnLabels as gridColumnLabels,
+  rowSum as gridRowSum,
+  columnSums as gridColumnSums,
+  isOutlierBucket,
+} from '@/lib/heatmap.js'
 
 const props = defineProps({
   script: { type: String, default: '' },

--- a/web/src/print.css
+++ b/web/src/print.css
@@ -103,6 +103,28 @@
   }
   .p-count { text-align: right; width: 3em; }
 
+  /* A two-axis frequency prints as its table of counts, not as bars. Bars can
+     only show one axis, so they would quietly show the row sums — a different
+     and much duller statistic than the one asked for, since the whole point of
+     a second axis is how each row spreads along it.
+
+     No shading. A paper table is read by its numbers, and a grey ramp survives
+     neither a mono printer nor a photocopier. Small and tight instead: this
+     fits a 21x14 grid across a portrait page, which is the shape these usually
+     have. */
+  .p-grid-freq { font-size: 6.5pt; border-collapse: collapse; width: auto; }
+  .p-grid-freq th, .p-grid-freq td {
+    padding: 0.5mm 0.9mm; text-align: right; font-variant-numeric: tabular-nums;
+    width: auto;
+  }
+  .p-grid-freq thead th { border-bottom: 0.3pt solid #999; font-weight: 600; }
+  .p-grid-freq tbody th { font-weight: 600; padding-right: 1.4mm; }
+  .p-grid-freq .p-sum { border-left: 0.3pt solid #ccc; font-weight: 600; }
+  .p-grid-freq tfoot .p-sum { border-left: none; border-top: 0.3pt solid #999; }
+  /* Empty rather than nought: on a sparse grid the zeros are the majority and
+     printing them all buries the shape the table exists to show. */
+  .p-grid-freq .p-zero { color: transparent; }
+
   /* --- deals ------------------------------------------------------------- */
   .p-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6pt; }
   .p-board {


### PR DESCRIPTION
Saving a run to PDF drew every `frequency` as a row of bars. A bar carries one
number, so a **two-dimensional** frequency printed as its **row sums** — the
marginal distribution of the first expression, with the second axis averaged
away entirely.

That is not a smaller version of what was asked for; it is a different
statistic. On screen, NS combined points against notrump tricks is a diagonal
ridge six or seven tricks wide at every point count. On paper it was a single
smooth hump.

## The fix

`PrintView` now renders `f.grid` as a table of counts when it is there, and
falls back to bars only for a genuine one-axis frequency. Both axes' labels,
both sets of sums, reading the same `lib/heatmap.js` helpers the screen uses —
one arithmetic, two renderings.

**No shading on paper.** A grey ramp survives neither a mono printer nor a
photocopier, and a printed table is read by its numbers. Zero cells are blank
rather than `0`, because on a sparse grid the noughts are the majority and they
bury the shape.

## Verified in a browser

100,000 library deals through the script from the report, then compared the two
renderings cell by cell in the DOM: **every cell of the printed table equals the
corresponding cell on screen** (23 rows, 16 columns, sums included). Before the
change the print view had one bar table and no grid; after, the reverse.

`npm test` 186 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)