### PR TITLE
A format that collects no deals, wider number boxes, and a scenario list that gets out of the way

### DIFF
--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -48,7 +48,12 @@ struct Args {
     #[arg(short = 's', long = "seed")]
     seed: Option<u32>,
 
-    /// Output format (defaults to printall, or value from input file if not specified)
+    /// Output format: printall, printew, printns, printpbn, printcompact,
+    /// printoneline, or none (defaults to printall, or the value from the input
+    /// file). `none` writes no deals at all and keeps the statistics, for a run
+    /// that only wants its `average` and `frequency` results — nothing is
+    /// rendered, so a hundred thousand boards cost nothing to not print. The
+    /// script's own `printes`, `printrpt` and `print(...)` output is unaffected.
     #[arg(short = 'f', long = "format")]
     format: Option<OutputFormat>,
 
@@ -332,6 +337,18 @@ enum OutputFormat {
     PrintPBN,
     PrintCompact,
     PrintOneLine,
+    /// No deals at all: the statistics, and nothing else.
+    ///
+    /// A run that only wants its `average` and `frequency` results never looks
+    /// at a hand, and rendering a hundred thousand boards to throw them away is
+    /// work nobody asked for. Nothing is rendered and, under `--interleave`,
+    /// nothing is held either.
+    ///
+    /// A new *value* for `-f`, not a remapped switch: `-f` is dealer3's own —
+    /// the original picks a format with an `action` statement — so nothing a
+    /// dealer.exe script or command line means changes. The browser offers the
+    /// same choice in its format list, where there is no `-q` to reach for.
+    None,
 }
 
 impl std::str::FromStr for OutputFormat {
@@ -345,8 +362,9 @@ impl std::str::FromStr for OutputFormat {
             "printpbn" | "pbn" => Ok(OutputFormat::PrintPBN),
             "printcompact" | "compact" => Ok(OutputFormat::PrintCompact),
             "printoneline" | "oneline" => Ok(OutputFormat::PrintOneLine),
+            "none" => Ok(OutputFormat::None),
             _ => Err(format!(
-                "Invalid format '{}'. Valid options: printall, printew, printns, printpbn, printcompact, printoneline",
+                "Invalid format '{}'. Valid options: printall, printew, printns, printpbn, printcompact, printoneline, none",
                 s
             )),
         }
@@ -659,6 +677,10 @@ fn render_board(
         ),
         OutputFormat::PrintCompact => format_printcompact(deal),
         OutputFormat::PrintOneLine => format_oneline(deal),
+        // Never reached: `print_deals` is false under `none`, so no caller gets
+        // this far. Empty rather than a panic, so a mistake here would cost a
+        // missing board rather than an aborted run.
+        OutputFormat::None => String::new(),
     }
 }
 
@@ -1444,8 +1466,22 @@ fn main() {
 
         // `printall` is the default *action*, so naming an action list without
         // a printing one replaces it. `-f` on the command line still asks for
-        // deals explicitly and wins.
-        let print_deals = !measuring_only || args.format.is_some();
+        // deals explicitly and wins — except `-f none`, which is the one value
+        // that asks for the opposite.
+        let print_deals =
+            output_format != OutputFormat::None && (!measuring_only || args.format.is_some());
+
+        // `--interleave` orders the deals on their way out, and under `none`
+        // there is no way out: it would hold every produced deal for a
+        // reordering that is never printed. Refused rather than swallowed, for
+        // the same reason `--interleave` is refused during `--write-leveled`.
+        if args.interleave && output_format == OutputFormat::None {
+            eprintln!(
+                "Error: --interleave orders the deals as they are written out, and -f none \
+                 writes none.\n       Drop one of the two."
+            );
+            std::process::exit(1);
+        }
 
         let dealer_position = args.dealer.or(dealer_from_input);
 

--- a/dealer/src/switches.rs
+++ b/dealer/src/switches.rs
@@ -349,7 +349,11 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
         what: "Output format",
         dealer_exe: Origin::Absent,
         dealer_v2: Origin::Absent,
-        note: Some("The original selects a format with an `action` statement instead."),
+        note: Some(
+            "The original selects a format with an `action` statement instead. `-f none` writes \
+             no deals and keeps the statistics, for a run that only wants its `average` and \
+             `frequency` results.",
+        ),
     },
     SwitchRow {
         short: "-d",

--- a/dealer/tests/format_none.rs
+++ b/dealer/tests/format_none.rs
@@ -1,0 +1,144 @@
+//! `-f none`: the statistics, and no deals at all.
+//!
+//! The point of the value is that it changes what is *written*, never what is
+//! *computed*. So every test here runs the same script twice — once printing
+//! deals, once not — and compares. A `none` that quietly dealt differently, or
+//! stopped at a different point, would still print no boards and would look
+//! exactly like a success.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// One run, returning stdout, stderr and whether it succeeded.
+fn run(script: &str, args: &[&str]) -> (String, String, bool) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_dealer"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("dealer should run");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(script.as_bytes())
+        .expect("write");
+    let out = child.wait_with_output().expect("output");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    )
+}
+
+/// A script asking for both kinds of statistic, so "the numbers are untouched"
+/// is a claim about both.
+const STATISTICS: &str = "condition hcp(north) >= 12\n\
+     action printoneline,\n\
+     average \"N HCP\" hcp(north),\n\
+     frequency \"N HCP\" (hcp(north), 12, 20)\n";
+
+#[test]
+fn none_prints_the_statistics_and_not_one_deal() {
+    let shown = run(STATISTICS, &["-f", "oneline", "-p", "40", "-s", "9", "-v"]).0;
+    let (quiet, _, ok) = run(STATISTICS, &["-f", "none", "-p", "40", "-s", "9", "-v"]);
+    assert!(ok, "-f none should be an ordinary run");
+
+    // A one-line board names all four seats. None of them should appear.
+    assert!(
+        shown.contains(" e ") && shown.contains(" w "),
+        "the control run should be printing boards:\n{shown}"
+    );
+    assert!(
+        !quiet.contains(" e ") && !quiet.contains(" w "),
+        "-f none should write no deals:\n{quiet}"
+    );
+
+    // And the statistics should survive whole — the average, the histogram, and
+    // the counts underneath them. All but the clock, which is the one line that
+    // is allowed to differ, and the one this change is meant to move.
+    for line in shown
+        .lines()
+        .filter(|l| !l.contains(" e ") && !l.starts_with("Time needed"))
+    {
+        assert!(
+            quiet.contains(line),
+            "-f none dropped a line that is not a deal: {line:?}\n\
+             --- with deals ---\n{shown}\n--- without ---\n{quiet}"
+        );
+    }
+    assert!(
+        quiet.contains("N HCP"),
+        "the labels should be there:\n{quiet}"
+    );
+}
+
+#[test]
+fn none_changes_what_is_shown_and_never_what_is_computed() {
+    // The claim that actually matters. `Generated`/`Produced` come from the
+    // run itself, so if `none` shortened it, skipped deals or stopped early,
+    // these two numbers would part company and nothing else on screen would
+    // say so.
+    let counts = |format: &str| {
+        let out = run(STATISTICS, &["-f", format, "-p", "40", "-s", "9", "-v"]).0;
+        let pick = |word: &str| {
+            out.lines()
+                .find(|l| l.starts_with(word))
+                .map(str::to_string)
+                .unwrap_or_else(|| panic!("no {word} line in:\n{out}"))
+        };
+        (pick("Generated"), pick("Produced"))
+    };
+    assert_eq!(counts("none"), counts("oneline"));
+}
+
+#[test]
+fn none_leaves_the_scripts_own_output_alone() {
+    // `printes` is a statement the script ran, not a rendering of a deal, and
+    // `-f` has no business turning it off. Without this, a script whose whole
+    // output is its own `printes` line would come back blank under `none` and
+    // look like a run that matched nothing.
+    let script = "condition hcp(north) >= 12\naction printes(\"N=\", hcp(north), \\n)\n";
+    let shown = run(script, &["-f", "oneline", "-p", "5", "-s", "9"]).0;
+    let quiet = run(script, &["-f", "none", "-p", "5", "-s", "9"]).0;
+
+    let printed = |out: &str| {
+        out.lines()
+            .filter(|l| l.starts_with("N="))
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(printed(&shown).len(), 5, "the control run:\n{shown}");
+    assert_eq!(printed(&quiet), printed(&shown));
+    assert!(!quiet.contains(" e "), "and still no boards:\n{quiet}");
+}
+
+#[test]
+fn interleave_is_refused_rather_than_silently_ordering_nothing() {
+    // `--interleave` holds every produced deal to order it on the way out.
+    // Under `none` there is no way out, so the switch would swallow the whole
+    // run's deals for a reordering nobody sees.
+    let script = "HandType_Strong = hcp(north) >= 15\n\
+         HandType_Weak = hcp(north) < 15\n\
+         condition HandType_Strong || HandType_Weak\n";
+    let (_, stderr, ok) = run(
+        script,
+        &["-f", "none", "--interleave", "-p", "8", "-s", "9"],
+    );
+    assert!(!ok, "the combination should be refused");
+    assert!(
+        stderr.contains("--interleave") && stderr.contains("none"),
+        "the refusal should name both halves: {stderr}"
+    );
+}
+
+#[test]
+fn an_unknown_format_offers_none_among_the_rest() {
+    let (_, stderr, ok) = run("condition 1\n", &["-f", "hands", "-p", "1"]);
+    assert!(!ok, "there is no such format");
+    assert!(
+        stderr.contains("none"),
+        "the refusal should list none: {stderr}"
+    );
+}

--- a/docs/command_line_comparison.md
+++ b/docs/command_line_comparison.md
@@ -55,7 +55,7 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 |---|---|---|---|---|---|
 | `-u` | Upper-case the honour cards in output | ✅ | ✅ | — | Accepted and ignored, because it does nothing in dealer.exe either: `-u` sets a flag read only by the `representation` macro in `dealer.c`, and that macro is never invoked — every output path uses `ucrep` directly. Verified; the reference binary's output is byte-identical with and without it. dealer3's honours are upper case too, so the switch is accepted rather than refused and a command line carrying it still runs. `-v` says so. |
 | `--interleave` | Order the output so each hand type appears before any repeats | ✅ | — | — | Needs `HandType_*` variables to classify against. Rare types are spread across the run rather than exhausted early. See `docs/leveling-guide.md`. |
-| `-f`, `--format` | Output format | ✅ | — | — | The original selects a format with an `action` statement instead. |
+| `-f`, `--format` | Output format | ✅ | — | — | The original selects a format with an `action` statement instead. `-f none` writes no deals and keeps the statistics, for a run that only wants its `average` and `frequency` results. |
 | `-d`, `--dealer` | Dealer position | ✅ | — | — | The original uses the `dealer` statement, which dealer3 also accepts. |
 | `--vulnerable` | Vulnerability | ✅ | — | ⚠️ -P sets vulnerability for par | Long form only. `-v` is verbose, as in the original — this was the 0.2.0 breaking change. |
 | `-v`, `--verbose` | Toggle the closing statistics | ✅ | ✅ | ✅ |  |

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -45,6 +45,19 @@ enum Format {
     PrintAll,
     /// Full PBN, suitable for saving and opening elsewhere.
     Pbn,
+    /// No deals at all: the statistics, and nothing else.
+    ///
+    /// A run gathering numbers — the HCP-against-tricks cross-tabulation is the
+    /// case that asked for this — never looks at a hand. Every other format
+    /// holds deals as they are produced and renders each to a string, which is
+    /// then serialised, posted across from the worker, parsed again and laid
+    /// out as bridge diagrams nobody reads. This one holds none of them.
+    ///
+    /// The command line spells it `-f none`, and means the same thing. That is
+    /// a new *value* for `-f` rather than a remapped switch — `-f` is dealer3's
+    /// own, since the original picks a format with an `action` statement — so
+    /// the compatibility rule is untouched and the two front ends agree.
+    None,
 }
 
 impl Format {
@@ -53,11 +66,21 @@ impl Format {
             "oneline" | "printoneline" => Ok(Format::OneLine),
             "printall" | "all" => Ok(Format::PrintAll),
             "pbn" | "printpbn" => Ok(Format::Pbn),
+            "none" => Ok(Format::None),
             other => Err(format!(
-                "Unknown format '{}'. Use 'oneline', 'printall' or 'pbn'.",
+                "Unknown format '{}'. Use 'oneline', 'printall', 'pbn' or 'none'.",
                 other
             )),
         }
+    }
+
+    /// Whether a produced deal is worth holding on to at all.
+    ///
+    /// The one thing that separates `None` from the rest, and it is asked
+    /// before a deal is cloned rather than after it has been rendered: holding
+    /// the deal is most of the cost and rendering it is the remainder.
+    fn collects_deals(self) -> bool {
+        self != Format::None
     }
 
     fn render(
@@ -85,6 +108,10 @@ impl Format {
                     ..Default::default()
                 },
             ),
+            // Never reached: nothing is held under `None`, so there is nothing
+            // to render. Empty rather than a panic, so a mistake here would
+            // cost a missing deal rather than a dead page.
+            Format::None => String::new(),
         }
     }
 }
@@ -211,6 +238,14 @@ struct LevelingResult {
 #[derive(Serialize)]
 struct GenerateResult {
     deals: Vec<String>,
+    /// Whether the format asked for renders deals at all.
+    ///
+    /// False only under `none`, and it travels with the result rather than
+    /// being read off whatever the format control says now: changing the
+    /// dropdown without pressing Run again must not make the page describe the
+    /// result on screen as something it is not. An empty `deals` cannot say
+    /// this on its own — a run that matched nothing has one too.
+    renders_deals: bool,
     /// Deals examined, including those the filter rejected.
     generated: usize,
     /// Deals that matched.
@@ -438,8 +473,18 @@ struct Page<'a> {
     /// Deals it may take, which is the other thing that can stop it short.
     max_generate: usize,
     /// Deals to hand back, capped: a large `produce` used to gather statistics
-    /// does not have to ship every deal to JS.
+    /// does not have to ship every deal to JS. Left empty altogether under
+    /// `Format::None`, which is the whole point of that format.
     held: Vec<(Option<usize>, Deal)>,
+    /// Whether the chosen format has any use for a deal. False only under
+    /// `Format::None`, and then nothing is cloned, rendered or shipped.
+    collects_deals: bool,
+    /// Produced deals whose output has been taken, which is what the cap counts.
+    ///
+    /// Not `held.len()`: under `Format::None` nothing lands in `held`, and the
+    /// cap still has to hold for `printed` — otherwise a script with a
+    /// `printes` statement would build one string per deal over the whole run.
+    kept: usize,
     /// Everything the script's `printes` and `printrpt` statements wrote,
     /// capped alongside the deals so the two stay in step.
     printed: String,
@@ -511,16 +556,26 @@ impl RunHost for Page<'_> {
     }
 
     fn produced(&mut self, deal: &Produced) -> Result<(), String> {
-        if self.held.len() >= MAX_RETURNED_DEALS {
+        if self.kept >= MAX_RETURNED_DEALS {
             return Ok(());
         }
+        self.kept += 1;
+        // What the script itself wrote, whatever the format. `printes` and
+        // `printrpt` are statements the script ran, not a rendering of a deal,
+        // so a format that shows no hands must not quietly turn them off. Both
+        // cost nothing at all when the script declares none, which is nearly
+        // every script.
         for row in deal.rows()?.printed {
             self.printed.push(' ');
             self.printed.push_str(&row);
             self.printed.push('\n');
         }
         self.printed.push_str(&deal.printes()?);
-        self.held.push((deal.hand_type, deal.deal.clone()));
+        // The deal itself, which `Format::None` has no use for: no clone here,
+        // no render after the run, and nothing to serialise across to the page.
+        if self.collects_deals {
+            self.held.push((deal.hand_type, deal.deal.clone()));
+        }
         Ok(())
     }
 }
@@ -744,6 +799,8 @@ fn run_script(
         deadline: started + MEASURE_BUDGET_MS,
         max_generate,
         held: Vec::new(),
+        collects_deals: format.collects_deals(),
+        kept: 0,
         printed: String::new(),
         ran_out: false,
         characterizing_started: started,
@@ -910,6 +967,7 @@ fn run_script(
 
     let result = GenerateResult {
         deals,
+        renders_deals: format.collects_deals(),
         deal_types,
         generated: report.generated,
         produced: report.produced,
@@ -1555,6 +1613,11 @@ mod tests {
 
     /// Run a script over supplied bytes, as the page would.
     fn over(deals: &[u8], script: &str) -> Result<serde_json::Value, String> {
+        over_as(deals, script, "oneline")
+    }
+
+    /// The same, in a named format — which is the only thing `none` changes.
+    fn over_as(deals: &[u8], script: &str, format: &str) -> Result<serde_json::Value, String> {
         let (supplied, report) =
             dealer_run::deals_from_bytes(deals, dealer_run::deal_input::Window::all())?;
         let json = run_script(
@@ -1562,7 +1625,7 @@ mod tests {
             1,
             1000,
             1_000_000,
-            "oneline",
+            format,
             false,
             false,
             &[],
@@ -1803,6 +1866,76 @@ mod tests {
             expected
         );
         assert_eq!(result["averages"][0]["count"], 10);
+    }
+
+    /// A script that asks for every kind of statistic there is, so that "the
+    /// numbers are untouched" is a claim about all of them.
+    const EVERY_STATISTIC: &str = "condition 1\n\
+         action printoneline,\n\
+         average \"N HCP\" hcp(north),\n\
+         frequency \"N HCP\" (hcp(north), 0, 20)\n";
+
+    #[test]
+    fn none_keeps_every_statistic_and_not_one_deal() {
+        let shown = over_as(LIBRARY, EVERY_STATISTIC, "oneline").expect("one line runs");
+        let quiet = over_as(LIBRARY, EVERY_STATISTIC, "none").expect("none runs");
+
+        // The run itself is untouched: the same deals looked at, the same deals
+        // matched, and the same numbers over them. `none` decides what is
+        // written out, never what is generated or measured.
+        assert_eq!(quiet["generated"], shown["generated"]);
+        assert_eq!(quiet["produced"], shown["produced"]);
+        assert_eq!(quiet["averages"], shown["averages"]);
+        assert_eq!(quiet["frequencies"], shown["frequencies"]);
+        assert_eq!(quiet["hand_types"], shown["hand_types"]);
+        // The page has no stderr, so the input report is the only thing that
+        // says what a run over a library actually read. It must survive too.
+        assert_eq!(quiet["input"], shown["input"]);
+
+        // And nothing whatever is held or rendered.
+        assert_eq!(shown["deals"].as_array().map(Vec::len), Some(10));
+        assert_eq!(
+            quiet["deals"].as_array().map(Vec::len),
+            Some(0),
+            "none holds no deals"
+        );
+        assert_eq!(quiet["deal_types"].as_array().map(Vec::len), Some(0));
+
+        // Said in the result rather than inferred from an empty list: a run
+        // that matched nothing has an empty list too, and the page has to tell
+        // the two apart to say the right thing about either.
+        assert_eq!(shown["renders_deals"], true);
+        assert_eq!(quiet["renders_deals"], false);
+    }
+
+    #[test]
+    fn none_still_writes_what_the_script_itself_printed() {
+        // `printes` is a statement the script ran, not a rendering of a deal.
+        // A format that shows no hands must not quietly stop it, or a script
+        // whose whole output is its own `printes` line would come back blank.
+        let script = "condition 1\naction printes(\"N=\", hcp(north), \\n)\n";
+        let quiet = over_as(LIBRARY, script, "none").expect("none runs");
+        let shown = over_as(LIBRARY, script, "oneline").expect("one line runs");
+
+        assert_eq!(quiet["printes"], shown["printes"]);
+        assert!(
+            quiet["printes"]
+                .as_str()
+                .is_some_and(|s| s.lines().count() == 10),
+            "one line per deal, as the terminal would have written it: {}",
+            quiet["printes"]
+        );
+    }
+
+    #[test]
+    fn an_unknown_format_names_the_ones_that_exist() {
+        let error = over_as(LIBRARY, "condition 1\n", "hands").expect_err("no such format");
+        for offered in ["oneline", "printall", "pbn", "none"] {
+            assert!(
+                error.contains(offered),
+                "the refusal should offer {offered}: {error}"
+            );
+        }
     }
 
     /// What a page asks before offering to fetch a solved-deal library: does

--- a/web/README.md
+++ b/web/README.md
@@ -332,6 +332,22 @@ a page that fails to load. The deal source is restored the same way, with one
 extra rule: anything but `library` reads back as random deals, so a stored value
 that no longer means anything cannot start a visit by downloading a library.
 
+Whether the scenario list is showing is kept here too, and it is the one setting
+with a right answer for someone who has never chosen: anything that is not a
+stored `false` reads back as open, because the list is how a first visit finds
+something to run. Once closed it stays closed — someone who closed it is editing
+a script, and having to close it again on every reload is the whole complaint.
+
+## Hiding the scenario list
+
+The picker finds a starting point and then costs 260px for as long as the script
+is being edited. **‹** beside the search closes it; what is left is a 28px rail
+labelled *Scenarios*, and the whole rail is the way back. A rail rather than
+nothing at all, because closing it is the only thing that hides it and clicking
+somewhere unmarked is not a way back anyone would find. The two `1fr` columns
+take the 232px between them, so the editor and the results both grow rather than
+a gap being left where the panel was.
+
 ## Editor appearance
 
 The editor is dark (One Dark) on an otherwise light page. Syntax palettes are

--- a/web/README.md
+++ b/web/README.md
@@ -164,6 +164,30 @@ The grid only applies to the one-line format: `printall` is already a visual
 layout and PBN is a record format, so those offer Text instead rather than an
 empty grid.
 
+**None is an engine setting, not a display one.** A run gathering statistics —
+HCP against tricks is the case that asked for it — never looks at a hand, so
+`None` stops the engine collecting them: no deal is cloned, none is rendered,
+nothing is serialised out of the worker and nothing is laid out. Over 100,000
+library deals the command line's equivalent measures 0.31s against 0.09s, and
+7.6 MB of output against 742 bytes. The counts, averages, frequencies, the input
+report and the script's own `printes` output are all exactly what the same run
+produces in any other format — `none` decides what is written, never what is
+computed.
+
+The consequences are said rather than left to be discovered. The Hands/Text
+toggle goes, because there is nothing to toggle between; **Save PBN** is
+disabled with a reason, since saving re-runs the script and a PBN of a run that
+kept no deals would mean dealing the whole thing again — the expensive half of
+what `None` was picked to avoid; **Save text** stays and writes the statistics,
+built from the result on screen rather than by re-running; **Save PDF** stays
+and gives the script and the statistics without boards.
+
+The command line spells the same thing `-f none`. That is a new *value* for
+`-f`, not a remapped switch — `-f` is dealer3's own, since the original picks a
+format with an `action` statement — so nothing a dealer.exe script or command
+line means has changed. `--interleave` is refused alongside it rather than
+holding every produced deal for a reordering that is never printed.
+
 `cardFormatting.js` is vendored from `Bridge-Classroom/src/utils/cardFormatting.js`.
 Its `HandDisplay.vue` was **not**: at 521 lines it is built for an interactive
 table — clickable cards, a selector popup, per-card marks, dynamic fit — and

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -55,21 +55,27 @@
               Pre-solved deals
             </label>
           </span>
-          <label>Produce <input v-model.number="produce" class="narrow" type="number" min="1" /></label>
+          <label>Produce <input v-model.number="produce" class="num-produce" type="number" min="1" /></label>
           <label>
             Max generate
             <!-- `min` must be a multiple of `step`, or the browser snaps to the
                  sequence min + n*step. With min=1 step=1000 the only valid
                  values were 1, 1001, 2001…, so 500000 stepped up to 500001 and
                  down to 499001. A zero is rejected at run time instead. -->
-            <input v-model.number="maxGenerate" type="number" min="0" :step="generateStep" />
+            <input
+              v-model.number="maxGenerate"
+              class="num-generate"
+              type="number"
+              min="0"
+              :step="generateStep"
+            />
           </label>
           <!-- After the two limits, because on Random it is a field to read
                rather than set: it says which run this was, for quoting or
                coming back to. -->
           <label>
             Seed
-            <input v-model.number="seed" type="number" min="0" max="4294967295" />
+            <input v-model.number="seed" class="num-seed" type="number" min="0" max="4294967295" />
           </label>
           <!-- Rolled *before* the run and written into the field beside it, so
                the seed on screen is still the seed that produced what is shown.
@@ -807,13 +813,24 @@ body {
   font: inherit; font-size: 12px; padding: 3px 5px;
   border: 1px solid var(--line); border-radius: 3px; background: var(--bg); color: var(--fg);
 }
-/* Wide enough for a ten-digit seed, which is the longest thing any of them
-   holds. Produce is a board count and never needs half of that. */
-.controls input[type="number"] { width: 7em; }
-/* Two digits narrower than the seed's seven ems, which is sized for a
-   ten-figure seed. A board count is two or three digits nearly always, and the
-   spinner takes a good part of a small box. */
-.controls input.narrow { width: 4.5em; }
+/* Numeric fields sized for the values they actually hold.
+   A number input draws its spinner INSIDE its own box, and the box also carries
+   the field's padding and border, so the digits are clipped well before the
+   border is reached. The old widths were set by eye against that and both came
+   up short: `Produce` at 4.5em showed `2000(` for 20000, and the 7em the other
+   two shared runs out around eight digits, two short of a ten-figure seed.
+   So the width is stated as what it has to hold rather than as a round number:
+   `--num-digits` of text, plus `--num-chrome` for everything the browser draws
+   around it. */
+.controls { --num-chrome: 2.6em; }
+.controls input[type="number"] { width: calc(var(--num-digits, 8) * 1ch + var(--num-chrome)); }
+/* A board count. Seven digits is a million boards — far past anything anyone
+   asks a browser for, and still the narrowest of the three. */
+.controls input.num-produce { --num-digits: 7; }
+/* Up to 10,000,000, which the field's own arrows will walk it to. */
+.controls input.num-generate { --num-digits: 8; }
+/* A u32: 4294967295, and the widest thing on the row. */
+.controls input.num-seed { --num-digits: 10; }
 .check {
   display: inline-flex;
   align-items: center;

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -86,12 +86,16 @@
             <input v-model="newSeedEachRun" type="checkbox" />
             Random
           </label>
-          <label>
+          <!-- `None` is not a way of hiding the deals: the engine stops
+               collecting them, so a statistics run does not build, ship and
+               lay out hands nobody is going to look at. -->
+          <label :title="formatHint">
             Format
             <select v-model="format">
               <option value="oneline">One line</option>
               <option value="printall">Print all</option>
               <option value="pbn">PBN</option>
+              <option value="none">None — statistics only</option>
             </select>
           </label>
         </div>
@@ -490,6 +494,12 @@ const runHint = computed(() => {
   } and declares no default.`
 })
 
+const formatHint = computed(() =>
+  format.value === 'none'
+    ? 'Statistics only: the engine collects no deals, so nothing is rendered, shipped or laid out. Averages, frequencies and the counts are all still measured over every deal produced.'
+    : 'How each produced deal is written out. None keeps the statistics and collects no deals at all, which is what a run gathering numbers wants.',
+)
+
 const libraryHint =
   'Draw from Pavlicek\u2019s 10,485,760 pre-solved deals, so tricks(), dds() and par() are ' +
   'lookups rather than searches. The seed picks where in the library to start.'
@@ -641,6 +651,16 @@ async function onDownload(kind) {
         pbn.deals.join('\n') + '\n',
         'application/x-pbn',
       )
+    } else if (format.value === 'none') {
+      // Nothing was collected, so there is nothing to re-run FOR: the
+      // statistics on screen are the whole of what a text file would hold.
+      // Re-running would deal the hundred thousand again to arrive at numbers
+      // already in hand, which is the expensive half of what None was picked to
+      // avoid. Written from the result instead.
+      const shown = result.value
+      if (!shown) return
+      const printed = shown.printes ? shown.printes + '\n' : ''
+      downloadText(resultFilename(name, seed.value, 'txt'), printed + statisticsText(shown))
     } else {
       const text = await generate(script.value, {
         seed: seed.value,

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -33,9 +33,31 @@
       <span v-if="engineVersion" class="bar-version">engine {{ engineVersion }}</span>
     </header>
 
-    <main class="cols">
-      <aside class="col col-picker">
-        <ScenarioPicker :selected="selectedFile" :busy-file="loadingFile" @select="pickScenario" />
+    <main class="cols" :class="{ 'picker-closed': !pickerOpen }">
+      <!-- The scenario list is how you find a starting point, and then it is
+           260px of nothing while you edit. Closing it hands that width to the
+           editor and the results, which share the rest of the row. -->
+      <aside class="col col-picker" :class="{ 'is-closed': !pickerOpen }">
+        <ScenarioPicker
+          v-if="pickerOpen"
+          :selected="selectedFile"
+          :busy-file="loadingFile"
+          @select="pickScenario"
+          @close="pickerOpen = false"
+        />
+        <!-- What is left when it is closed: a labelled rail, not a bare edge.
+             An icon alone would leave the list findable only by whoever hid
+             it, and this is the only way back. -->
+        <button
+          v-else
+          class="picker-open"
+          title="Show the scenario list"
+          aria-expanded="false"
+          @click="pickerOpen = true"
+        >
+          <span aria-hidden="true">›</span>
+          <span class="picker-open-label">Scenarios</span>
+        </button>
       </aside>
 
       <section class="col col-editor">
@@ -409,6 +431,11 @@ const result = ref(null)
 const error = ref('')
 const scriptValid = ref(true)
 const selectedFile = ref(restored?.scenario || '')
+// Whether the scenario list is showing. Open on a first visit — it is how you
+// find something to run — and remembered from then on, because someone who has
+// closed it is editing a script and would have to close it again on every
+// reload otherwise.
+const pickerOpen = ref(restored?.pickerOpen ?? true)
 const loadingFile = ref('')
 const downloading = ref(false)
 
@@ -569,6 +596,7 @@ watch(
     format,
     dealSource,
     selectedFile,
+    pickerOpen,
     autoLevel,
     newSeedEachRun,
     paramValues,
@@ -585,6 +613,7 @@ watch(
         format: format.value,
         dealSource: dealSource.value,
         scenario: selectedFile.value,
+        pickerOpen: pickerOpen.value,
         autoLevel: autoLevel.value,
         newSeedEachRun: newSeedEachRun.value,
         paramValues: paramValues.value,
@@ -822,6 +851,9 @@ body {
 .bar-version { font-size: 11px; color: var(--fg-muted); font-family: var(--mono); }
 
 .cols { display: grid; grid-template-columns: 260px 1fr 1fr; flex: 1; min-height: 0; }
+/* The first column shrinks to the rail; the two `1fr` columns take the 232px
+   it gave up between them, which is the point of closing it. */
+.cols.picker-closed { grid-template-columns: 28px 1fr 1fr; }
 .col { min-width: 0; min-height: 0; }
 .col-picker { border-right: 1px solid var(--line); }
 .col-editor { display: flex; flex-direction: column; padding: 8px; gap: 8px; min-height: 0; }
@@ -988,9 +1020,28 @@ body {
   .progress-fill.indeterminate { animation: none; width: 100%; opacity: 0.4; }
 }
 
+/* The rail the closed list leaves behind: the whole column is the way back, so
+   it cannot be missed and does not need aiming at. Vertical, because 28px of
+   width is what was freed and a horizontal label would not fit in it. */
+.picker-open {
+  width: 100%; height: 100%;
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  padding: 10px 0;
+  border: 0; background: var(--bg-subtle); color: var(--fg-muted);
+  font: inherit; font-size: 12px; cursor: pointer;
+}
+.picker-open:hover { background: var(--accent-subtle); color: var(--fg); }
+.picker-open-label { writing-mode: vertical-rl; letter-spacing: 0.04em; }
+
 @media (max-width: 1000px) {
   .cols { grid-template-columns: 1fr; grid-template-rows: auto 1fr 1fr; }
+  /* Stacked, the list is a row rather than a column, so the closed rail is a
+     strip across the top and its label reads the ordinary way round. */
+  .cols.picker-closed { grid-template-columns: 1fr; }
   .col-picker { border-right: 0; border-bottom: 1px solid var(--line); max-height: 220px; }
+  .col-picker.is-closed { max-height: none; }
+  .picker-open { height: auto; flex-direction: row; padding: 6px 10px; }
+  .picker-open-label { writing-mode: horizontal-tb; }
   .col-results { border-left: 0; border-top: 1px solid var(--line); }
 }
 </style>

--- a/web/src/components/ResultsPanel.vue
+++ b/web/src/components/ResultsPanel.vue
@@ -287,26 +287,49 @@
         </template>
       </section>
 
-      <section v-if="result.deals.length" class="block">
+      <!-- Kept on screen when the run collected nothing, rather than dropped:
+           an absent section reads as "no matches", which is a different thing
+           and the one people act on. -->
+      <section v-if="result.deals.length || !dealsRendered" class="block">
         <div class="deals-head">
           <h3>Deals</h3>
           <div class="deals-tools">
-            <div class="toggle" role="group" aria-label="Deal view">
+            <!-- Two views of the same deals, and no deals to view. -->
+            <div v-if="dealsRendered" class="toggle" role="group" aria-label="Deal view">
               <button :class="{ on: view === 'grid' }" @click="view = 'grid'">Hands</button>
               <button :class="{ on: view === 'text' }" @click="view = 'text'">Text</button>
             </div>
-            <button class="dl" :disabled="downloading" @click="$emit('download', 'pbn')">
+            <!-- Saving re-runs the script, so a PBN of a run that kept no deals
+                 would mean dealing the whole thing again — the expensive half
+                 of what None was picked to avoid. Disabled and explained,
+                 rather than offered and quietly costly. -->
+            <button
+              class="dl"
+              :disabled="downloading || !dealsRendered"
+              :title="pbnHint"
+              @click="$emit('download', 'pbn')"
+            >
               Save PBN
             </button>
-            <button class="dl" @click="$emit('download', 'text')">Save text</button>
+            <!-- Still worth having: under None it saves the statistics, which
+                 is the whole of what the run produced. -->
+            <button class="dl" :title="textHint" @click="$emit('download', 'text')">
+              Save text
+            </button>
             <!-- The browser's own print pipeline: a PDF with selectable text and
                  a live link back, which is the point — the script is meant to be
                  copied out of it. -->
-            <button class="dl" @click="$emit('print')">Save PDF</button>
+            <button class="dl" :title="pdfHint" @click="$emit('print')">Save PDF</button>
           </div>
         </div>
 
-        <p v-if="view === 'grid' && !parsedDeals.length" class="results-muted">
+        <p v-if="!dealsRendered" class="results-muted">
+          Format is <strong>None</strong>, so this run collected no deals: nothing was rendered
+          and there is no hand record to show or save. Everything above was measured over all
+          {{ result.produced.toLocaleString() }} of them. Choose One line, Print all or PBN, and
+          run again, to see the hands.
+        </p>
+        <p v-else-if="view === 'grid' && !parsedDeals.length" class="results-muted">
           This output format cannot be shown as hands. Switch to Text, or generate with the
           one-line format.
         </p>
@@ -378,6 +401,35 @@ defineEmits(['download', 'print'])
 
 // Hands read far more easily than one-line strings, so that is the default.
 const view = ref('grid')
+
+/// Whether this run collected deals at all.
+///
+/// Read off the RESULT, not off the format control: someone who changes the
+/// dropdown without pressing Run again is still looking at the previous run,
+/// and the page must go on describing that one correctly. An empty `deals`
+/// cannot answer it either — a run that matched nothing has one too, and that
+/// is the case this section already had words for.
+///
+/// Defaults to true for anything without the field, which keeps an older stored
+/// or replayed result reading as it always did.
+const dealsRendered = computed(() => props.result?.dealsRendered !== false)
+
+const pbnHint = computed(() =>
+  dealsRendered.value
+    ? 'Save every deal this run produced as a PBN file.'
+    : 'Format is None, so this run kept no deals — and saving would deal them all again. ' +
+      'Choose another format and run it.',
+)
+const textHint = computed(() =>
+  dealsRendered.value
+    ? 'Save the deals and the statistics as a text file.'
+    : 'Save the statistics as a text file. This run kept no deals to go with them.',
+)
+const pdfHint = computed(() =>
+  dealsRendered.value
+    ? 'Open the print dialog, from which "Save as PDF" gives the script, the statistics and the first boards.'
+    : 'Open the print dialog. This run kept no deals, so the document is the script and the statistics.',
+)
 
 /// What the run read, for a run that read rather than dealt: how many deals
 /// arrived, whether they came with double-dummy tables, and anything the reader

--- a/web/src/components/ScenarioPicker.vue
+++ b/web/src/components/ScenarioPicker.vue
@@ -9,6 +9,15 @@
         aria-label="Search scenarios"
       />
       <button class="picker-refresh" :disabled="loading" title="Reload the list" @click="load">↻</button>
+      <!-- Beside the search rather than in the page header: it belongs to this
+           panel, and the panel is what it acts on. -->
+      <button
+        class="picker-close"
+        title="Hide the scenario list, and give the width to the editor"
+        aria-label="Hide the scenario list"
+        aria-expanded="true"
+        @click="$emit('close')"
+      >‹</button>
     </div>
 
     <p v-if="loading" class="picker-muted">Loading scenarios…</p>
@@ -71,7 +80,7 @@ const props = defineProps({
   // Shown as loading while the parent fetches its script.
   busyFile: { type: String, default: '' },
 })
-defineEmits(['select'])
+defineEmits(['select', 'close'])
 
 const sections = ref([])
 const loading = ref(false)
@@ -151,6 +160,14 @@ watch(
   background: var(--bg-subtle); color: var(--fg); cursor: pointer;
 }
 .picker-refresh:disabled { opacity: 0.5; cursor: default; }
+/* Same chrome as Reload, and next to it: two small things this panel does to
+   itself, neither of them about a scenario. */
+.picker-close {
+  padding: 4px 8px; border: 1px solid var(--line); border-radius: 4px;
+  background: var(--bg-subtle); color: var(--fg-muted); cursor: pointer;
+  font: inherit; line-height: 1;
+}
+.picker-close:hover { color: var(--fg); }
 .picker-tree { overflow-y: auto; flex: 1; min-height: 0; }
 .picker-muted { padding: 12px; color: var(--fg-muted); font-size: 13px; }
 .picker-error { padding: 12px; color: var(--danger); font-size: 13px; }

--- a/web/src/lib/engine.js
+++ b/web/src/lib/engine.js
@@ -254,10 +254,18 @@ export async function generate(
     // many deals were asked for. From the worker rather than the engine: it is
     // what the page asked for, against which `input.read` is worth reading.
     library: message.library || null,
+    // Whether the format asked for renders deals at all: false only under
+    // `none`, which keeps the statistics and collects no hands. It travels with
+    // the result rather than being read off the format control, so changing
+    // that control without running again cannot make the page describe what is
+    // on screen as something else. An empty `deals` cannot say it — a run that
+    // matched nothing has one too.
+    dealsRendered: raw.renders_deals,
     // `deals` is capped by the engine; `produced` counts every match. A script
     // gathering statistics over 50,000 deals returns statistics for all of them
-    // and only the first few hundred deals.
-    dealsTruncated: raw.produced > raw.deals.length,
+    // and only the first few hundred deals. Under `none` there is no
+    // truncation to report: nothing was going to be shown in the first place.
+    dealsTruncated: raw.renders_deals && raw.produced > raw.deals.length,
   }
 }
 

--- a/web/src/lib/session.js
+++ b/web/src/lib/session.js
@@ -46,6 +46,10 @@ export function loadSession() {
       // silently start a run by downloading a library.
       dealSource: v.dealSource === 'library' ? 'library' : 'random',
       scenario: typeof v.scenario === 'string' ? v.scenario : '',
+      // Whether the scenario list is showing. Open unless it was explicitly
+      // closed: the list is how a first visit finds anything to run, and a
+      // stored value that is not a boolean says nothing about that.
+      pickerOpen: typeof v.pickerOpen === 'boolean' ? v.pickerOpen : true,
       // Left undefined rather than defaulted, so the caller can tell "never
       // chosen" from "chosen false" — auto-level ticks itself the first time a
       // script names hand types, and only until someone has had an opinion.

--- a/web/src/lib/session.test.js
+++ b/web/src/lib/session.test.js
@@ -23,6 +23,7 @@ const session = {
   format: 'printall',
   dealSource: 'library',
   scenario: 'Weak_2_Bids',
+  pickerOpen: true,
   paramValues: { 0: 'west', 1: '15' },
 }
 
@@ -124,6 +125,26 @@ describe('the checkbox settings', () => {
     saveSession({ ...session, autoLevel: false, newSeedEachRun: false })
     expect(loadSession().autoLevel).toBe(false)
     expect(loadSession().newSeedEachRun).toBe(false)
+  })
+
+  // Unlike those two, the scenario list has a right answer for someone who has
+  // never chosen: it is how a first visit finds anything to run. So it defaults
+  // to open rather than to undefined — but a visit that closed it must not have
+  // it re-open on the next load, which is what this pins.
+  it('remember the scenario list being closed', () => {
+    saveSession({ ...session, pickerOpen: false })
+    expect(loadSession().pickerOpen).toBe(false)
+
+    saveSession({ ...session, pickerOpen: true })
+    expect(loadSession().pickerOpen).toBe(true)
+  })
+
+  it('show the scenario list to a session that predates it, or one that says nonsense', () => {
+    const { pickerOpen, ...older } = session
+    localStorage.setItem('dealer3:session:v1', JSON.stringify(older))
+    expect(loadSession().pickerOpen).toBe(true)
+    localStorage.setItem('dealer3:session:v1', JSON.stringify({ ...session, pickerOpen: 'shut' }))
+    expect(loadSession().pickerOpen).toBe(true)
   })
 
   it('are undefined when never chosen, which is not the same as false', () => {


### PR DESCRIPTION
Three things asked for after using the page.

## `-f none` / Format **None**

For a run that only wants its `average` and `frequency` results — the
HCP-against-tricks analysis is the case — the hands are never looked at, and
rendering them is pure cost.

Measured, 100,000 library deals, `condition 1` plus an average and a frequency:

| | `-f oneline` | `-f none` |
|---|---|---|
| CLI, wall clock | 0.336 s | **0.092 s** |
| CLI, bytes written | 7,600,594 | **594** |
| Browser, Run → painted | 222 ms | **144 ms** |
| Browser, results-panel DOM nodes | 37,217 | **214** |

The statistics are identical, verified with a fixed seed — `none` changes what
is *shown*, never what is computed, and there is a test asserting exactly that.

**It is a new value for `-f`, not a remapped switch.** `-f` is dealer3's own —
the original selects a format with an `action` statement — so the compatibility
rule is untouched. `--interleave` is refused alongside it, since it orders deals
as they are written and `none` writes none. `docs/command_line_comparison.md`
regenerated with `UPDATE_DOCS=1`.

In the browser: Hands/Text toggle hidden, **Save PBN** disabled with a reason
(saving re-runs the script, so it would deal the whole run again), **Save text**
built from the on-screen result instead of re-running, **Save PDF** kept. The
panel says the run collected no deals — an absent Deals section would read as
"nothing matched". `printes` and `printrpt` are script statements, not deal
renderings, and still run.

## Number boxes sized for their contents

`Produce` showed `2000(` for `20000`. A number input draws its spinner inside
its box, so text clips before the border. Measured in Chromium at each field's
maximum: Produce 52px box / 62px needed, Max generate 82/83, Seed 82/100 — **all
three clipped**. Widths are now declared as what they must hold, seven digits
for Produce, eight for Max generate, ten for a u32 seed. The controls row wraps
at the same width it did before.

## A scenario list that folds away

Useful for finding a starting point, then just horizontal space. **‹** closes it
to a 28px rail labelled *Scenarios*, which reopens it; 260/590/590 becomes
28/706/706, so the freed width goes to the editor and results. Remembered in
`session.js`, defaulting to open for any session that predates the setting.

## Verification

Browser screenshots for all three. The playwright MCP screenshot tool times out
on this page, so Chromium was driven directly with a longer timeout — worth
knowing for next time.

Every new behaviour was broken deliberately and confirmed to fail. Gate: fmt,
both clippy variants, 45 Rust suites, 22 wasm tests, `verify.mjs` 17/17 against
the CLI, `library-check.mjs`, 194 web tests, `build:all`.

**Not verified:** the collapsed rail below 1000px, where the layout stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)