### PR TITLE
Say something while the solver works (#83)

### DIFF
--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -370,12 +370,14 @@ impl Workers {
     /// rather than being looked up in a store keyed by cards (#61).
     fn build_and_test(
         &self,
+        start: usize,
         count: usize,
         build: &(dyn Fn(usize) -> Deal + Sync),
         test: &(dyn Fn(usize, &Deal) -> Result<bool, EvalError> + Sync),
         harvest: bool,
     ) -> Vec<Tested> {
-        let one = |index: usize| {
+        let one = |offset: usize| {
+            let index = start + offset;
             let deal = build(index);
             let passed = test(index, &deal);
             let known = if harvest {
@@ -400,6 +402,44 @@ impl Workers {
             }
         }
         (0..count).map(one).collect()
+    }
+
+    /// The same, offered to a caller in pieces of `chunk`, with `between`
+    /// called after each piece that is not the last.
+    ///
+    /// `chunk >= count` is the ordinary case and does exactly what
+    /// [`Workers::build_and_test`] does: one map, one vector, straight out of
+    /// the pool, and the loop below never runs. `between` is never called.
+    ///
+    /// It lives here rather than in `run_pass` because of what it cost there.
+    /// Written as `if solving { chunked } else { whole }` in the pass, both
+    /// paths were live in the hottest function in the crate, and a run that
+    /// never solved — which is nearly all of them — paid **2.4%** for the one
+    /// it did not take. The same code with the chunked arm statically dead ran
+    /// **1.9% faster** than the version before any of this, which is the size
+    /// of what inlining and code layout were doing. One call site, always
+    /// taken, is the fix; the branch that chooses is a `chunk` value rather
+    /// than two paths through the caller.
+    ///
+    /// It cannot change what comes out: the work is a map from index to deal,
+    /// collected in the order the indices were drawn, so where the pieces are
+    /// cut changes when the threads are handed their work and nothing else.
+    fn build_and_test_in_chunks(
+        &self,
+        count: usize,
+        chunk: usize,
+        build: &(dyn Fn(usize) -> Deal + Sync),
+        test: &(dyn Fn(usize, &Deal) -> Result<bool, EvalError> + Sync),
+        harvest: bool,
+        between: &mut dyn FnMut(usize),
+    ) -> Vec<Tested> {
+        let mut built = self.build_and_test(0, chunk.min(count), build, test, harvest);
+        while built.len() < count {
+            between(built.len());
+            let from = built.len();
+            built.extend(self.build_and_test(from, chunk.min(count - from), build, test, harvest));
+        }
+        built
     }
 
     /// Run `warm` over every deal, on the pool.
@@ -901,14 +941,18 @@ fn pass_numbers(
 /// pass takes its batch whole, as it always did.
 const SOLVING_CHUNK: usize = 32;
 
-/// Produced deals between progress reports, once a pass is solving.
+/// Matching deals between progress reports, once a pass is solving.
 ///
 /// The produced loop runs on this thread, and a script whose `average` or whose
-/// action asks a double-dummy question the warm above could not read off the
-/// script solves here, one deal at a time. Counting to eight rather than
-/// reading a clock keeps the report off the per-deal path: the host reads its
-/// own clock and throttles, and it is asked eight times less often than there
-/// are deals.
+/// action asks a double-dummy question the warm could not read off the script
+/// solves here, one deal at a time. Counting to eight rather than reading a
+/// clock keeps the report cheap: the host reads its own clock and throttles,
+/// and is asked eight times less often than there are matching deals.
+///
+/// *Matching* deals, counted after the condition has had its say. Everything
+/// expensive on this thread is downstream of the condition, so a deal it
+/// rejected has nothing to report — and counting those instead put a compare
+/// and a branch on the one path every single deal takes.
 const SOLVING_REPORT_EVERY: usize = 8;
 
 fn run_pass(
@@ -1007,6 +1051,9 @@ fn run_pass(
     let mut produced = 0usize;
     let mut generated = 0usize;
     let mut replayed = 0usize;
+    // Deals that passed the condition, across the pass. Only ever read to space
+    // out progress reports, and only ever touched by a pass that solves.
+    let mut matched_seen = 0usize;
     let mut resumed = opts.replay.is_empty();
     let batch_size = opts.batch;
 
@@ -1063,42 +1110,52 @@ fn run_pass(
         // what comes out — it maps indices to deals and collects them in
         // order — only when the threads are handed their work.
         //
-        // The first call takes the whole batch unless the pass is solving, and
-        // then the loop below never runs and this is what it always was — one
-        // map, one vector, no copy. That is the point of writing it this way
-        // round rather than accumulating into a vector of the batch's size: the
-        // batch is a hundred kilobytes of `Tested`, and moving it twice cost
-        // very nearly one per cent of plain generation.
-        let first = if solving {
-            SOLVING_CHUNK.min(handles.len())
+        // Two paths, and the ordinary one is the single call it always was: one
+        // map, one vector, straight out of the worker pool with nothing copied
+        // and nothing appended. Reporting through a batch belongs to the pass
+        // that needs it, so it lives in `build_in_chunks` and this function is
+        // no bigger on the path almost every run takes.
+        // One call, always taken. Which of the two things it does is a `chunk`
+        // value rather than two paths through this function — see
+        // `Workers::build_and_test_in_chunks`, and the 2.4% that writing it the
+        // other way cost a run that never solves.
+        //
+        // Nothing is observed while a batch is being built, so what the pass
+        // has produced and what it is aiming at cannot move: worked out once,
+        // here, rather than per report.
+        let chunk = if solving {
+            SOLVING_CHUNK
         } else {
             handles.len()
         };
-        let mut built = workers.build_and_test(
-            first,
+        let (done, target) =
+            pass_numbers(opts.until_measured, &accumulator, produced, opts.produce);
+        // Copies, and they have to be. A closure captures what it reads by
+        // reference, so reading `generated` from inside one takes its address —
+        // and `generated` is incremented once per deal in the loop below, so
+        // that alone moves the pass's hottest counter out of a register and
+        // onto the stack for the whole function. Worth 1.7% of a script with a
+        // substantial condition, and invisible in the source until you look for
+        // it. These are read once each and never written, so the counter itself
+        // stays where it belongs.
+        let batch_generated = generated;
+        let batch_from_stream = from_stream;
+        let phase = opts.phase;
+        let built = workers.build_and_test_in_chunks(
+            handles.len(),
+            chunk,
             &|index| source.build(handles[index]),
             &|index, deal| test(known_at(&carried, index), deal),
             dd_in_play,
+            &mut |built_so_far| {
+                let so_far = if batch_from_stream {
+                    batch_generated + built_so_far
+                } else {
+                    batch_generated
+                };
+                host.progress(phase, done, so_far, target);
+            },
         );
-        while built.len() < handles.len() {
-            // What the chunk just built came to, before asking for another.
-            let (done, target) =
-                pass_numbers(opts.until_measured, &accumulator, produced, opts.produce);
-            let so_far = if from_stream {
-                generated + built.len()
-            } else {
-                generated
-            };
-            host.progress(opts.phase, done, so_far, target);
-            let from = built.len();
-            let take = SOLVING_CHUNK.min(handles.len() - from);
-            built.extend(workers.build_and_test(
-                take,
-                &|index| source.build(handles[from + index]),
-                &|index, deal| test(known_at(&carried, from + index), deal),
-                dd_in_play,
-            ));
-        }
 
         // Deals this pass has dealt and tested, counting the batch in hand.
         // Held rather than read off `generated`, which is incremented as the
@@ -1180,15 +1237,6 @@ fn run_pass(
         }
 
         for (index, tested) in built.iter().enumerate() {
-            // The main thread's own solving happens below: an `average` over
-            // `tricks()`, or an action asking for a cell the warm could not
-            // read off the script, is searched here one deal at a time. A run
-            // that never solves evaluates nothing after the `&&`.
-            if solving && index % SOLVING_REPORT_EVERY == 0 {
-                let (done, target) =
-                    pass_numbers(opts.until_measured, &accumulator, produced, opts.produce);
-                host.progress(opts.phase, done, dealt, target);
-            }
             let deal = &tested.deal;
             if from_stream {
                 generated += 1;
@@ -1202,6 +1250,26 @@ fn run_pass(
             }
             let observed =
                 accumulator.observe(deal, &variables, point_counts, known_at(&known, index))?;
+            // Where the main thread does its own solving: an `average` over
+            // `tricks()`, or an action asking for a cell the warm could not
+            // read off the script, is searched right here, one deal at a time.
+            //
+            // Below the early-out above, and counting deals that got this far
+            // rather than the batch index, because everything expensive on this
+            // thread is downstream of the condition. A deal the condition threw
+            // away costs nothing to report on — and testing for it up there put
+            // a compare and a branch on the one path every deal takes, and kept
+            // `index` live where it had been dead. That was worth 1.4% of a
+            // run whose condition matches nothing, which is the shape that
+            // shows it.
+            if solving {
+                matched_seen += 1;
+                if matched_seen.is_multiple_of(SOLVING_REPORT_EVERY) {
+                    let (done, target) =
+                        pass_numbers(opts.until_measured, &accumulator, produced, opts.produce);
+                    host.progress(opts.phase, done, dealt, target);
+                }
+            }
             if from_stream {
                 retained.offer(
                     handles[index],

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -281,6 +281,35 @@ pub trait RunHost {
     ) {
     }
 
+    /// How far a pass has got, offered from inside a batch. It cannot stop
+    /// anything.
+    ///
+    /// [`RunHost::should_stop`] is offered once per batch, and a batch is at
+    /// least 1024 deals. That is often enough while a deal costs a few hundred
+    /// nanoseconds and useless when it costs twenty-three milliseconds: one
+    /// batch of a script that wants a double-dummy table is tens of seconds, so
+    /// a page that paints from `should_stop` alone shows nothing at all and
+    /// reads as hung rather than busy (#83).
+    ///
+    /// Reporting-only on purpose. Offering `should_stop` more often would let a
+    /// run end where it previously would not — and a characterizing pass that
+    /// stops sooner measures less, which changes the keeps a levelled run deals
+    /// with. A report has no such power, so where it is offered is free to
+    /// follow where the time goes.
+    ///
+    /// It carries exactly what `should_stop` carries, so a host already
+    /// painting a bar has only to paint it from here as well. The numbers mean
+    /// what they mean there: for a characterizing pass, sightings of the
+    /// scarcest category against the goal; otherwise produced deals against
+    /// what was asked for.
+    ///
+    /// `generated` is the one that differs, and only ever upwards: it counts
+    /// the batch in hand as it is dealt and tested, where a pass's own count
+    /// only counts the deals it went on to walk. A pass that reaches its
+    /// `produce` half way through a batch dealt the whole of it, and a report
+    /// that shrank back to the walked count would be a meter running backwards.
+    fn progress(&mut self, _phase: Phase, _produced: usize, _generated: usize, _target: usize) {}
+
     /// A deal the producing pass is handing over.
     fn produced(&mut self, deal: &Produced) -> Result<(), String>;
 }
@@ -842,6 +871,46 @@ fn known_at(known: &[dealer_dds::DealTricks], index: usize) -> &dealer_dds::Deal
     known.get(index).unwrap_or(&dealer_dds::NOTHING_KNOWN)
 }
 
+/// How far a pass has got, and towards what.
+///
+/// A characterizing pass counts sightings of the scarcest category towards
+/// [`dealer_level::MEASURE_GOAL`]; every other pass counts produced deals
+/// towards what was asked for. Written once because four call sites now ask —
+/// `should_stop`, `pass_finished` and the two [`RunHost::progress`] reports
+/// inside a batch — and a bar jumps if any of them disagrees.
+fn pass_numbers(
+    until_measured: bool,
+    accumulator: &RunAccumulator,
+    produced: usize,
+    produce: usize,
+) -> (usize, usize) {
+    if until_measured {
+        (accumulator.rarest_measured(), dealer_level::MEASURE_GOAL)
+    } else {
+        (produced, produce)
+    }
+}
+
+/// Deals a solving pass builds, tests or warms between progress reports.
+///
+/// Chosen against the clock rather than the cache: a deal needing a
+/// double-dummy table costs about 23 ms, so this is a couple of hundred
+/// milliseconds of work spread over whatever threads there are — often enough
+/// to look alive, rare enough that dispatching the chunk is never the expensive
+/// part. It is only ever used by a pass that reaches the solver; an ordinary
+/// pass takes its batch whole, as it always did.
+const SOLVING_CHUNK: usize = 32;
+
+/// Produced deals between progress reports, once a pass is solving.
+///
+/// The produced loop runs on this thread, and a script whose `average` or whose
+/// action asks a double-dummy question the warm above could not read off the
+/// script solves here, one deal at a time. Counting to eight rather than
+/// reading a clock keeps the report off the per-deal path: the host reads its
+/// own clock and throttles, and it is asked eight times less often than there
+/// are deals.
+const SOLVING_REPORT_EVERY: usize = 8;
+
 fn run_pass(
     script: &str,
     source: &mut Source,
@@ -874,7 +943,20 @@ fn run_pass(
     // Whether any answer worth carrying can exist at all: the script reaches
     // the solver somewhere, or the deals arrived from a file that had already
     // been solved.
-    let dd_in_play = crate::dd_demand::touches_solver(&program) || source.carries_tables();
+    let asks_solver = crate::dd_demand::touches_solver(&program);
+    let arrives_solved = source.carries_tables();
+    let dd_in_play = asks_solver || arrives_solved;
+    // Whether this pass can actually be *slow*: it asks the solver something
+    // and the deals did not arrive with the answers already in them. That is
+    // what the progress reports below are gated on, and the gate is the whole
+    // of how they are kept off the hot path — a plain deal is a couple of
+    // hundred nanoseconds, so a run that never solves must pay one boolean per
+    // batch and one predictable branch per deal, and no clock read anywhere.
+    //
+    // A file that carried tables for only some of its deals falls on the fast
+    // side and reports once a batch, as before. That is the old behaviour for a
+    // case that is not slow enough to need better.
+    let solving = asks_solver && !arrives_solved;
     if let Some(plan) = opts.round_robin {
         accumulator = accumulator.with_round_robin(plan.clone());
     }
@@ -974,12 +1056,60 @@ fn run_pass(
         // and asking the condition about it. Which of the two costs more is the
         // script's business — a shuffle is about a microsecond, a `tricks()`
         // condition is ten milliseconds — so they travel together.
-        let built = workers.build_and_test(
-            handles.len(),
+        //
+        // Taken whole unless the pass is solving, and then a chunk at a time so
+        // that a caller answering to a clock hears from the run inside a batch
+        // rather than only at the end of one. Splitting the map cannot change
+        // what comes out — it maps indices to deals and collects them in
+        // order — only when the threads are handed their work.
+        //
+        // The first call takes the whole batch unless the pass is solving, and
+        // then the loop below never runs and this is what it always was — one
+        // map, one vector, no copy. That is the point of writing it this way
+        // round rather than accumulating into a vector of the batch's size: the
+        // batch is a hundred kilobytes of `Tested`, and moving it twice cost
+        // very nearly one per cent of plain generation.
+        let first = if solving {
+            SOLVING_CHUNK.min(handles.len())
+        } else {
+            handles.len()
+        };
+        let mut built = workers.build_and_test(
+            first,
             &|index| source.build(handles[index]),
             &|index, deal| test(known_at(&carried, index), deal),
             dd_in_play,
         );
+        while built.len() < handles.len() {
+            // What the chunk just built came to, before asking for another.
+            let (done, target) =
+                pass_numbers(opts.until_measured, &accumulator, produced, opts.produce);
+            let so_far = if from_stream {
+                generated + built.len()
+            } else {
+                generated
+            };
+            host.progress(opts.phase, done, so_far, target);
+            let from = built.len();
+            let take = SOLVING_CHUNK.min(handles.len() - from);
+            built.extend(workers.build_and_test(
+                take,
+                &|index| source.build(handles[from + index]),
+                &|index, deal| test(known_at(&carried, from + index), deal),
+                dd_in_play,
+            ));
+        }
+
+        // Deals this pass has dealt and tested, counting the batch in hand.
+        // Held rather than read off `generated`, which is incremented as the
+        // loop below walks the batch: a report that said "sixty-four dealt"
+        // while the batch was being solved and "one dealt" a moment later, as
+        // the walk began, would be a meter running backwards.
+        let dealt = if from_stream {
+            generated + built.len()
+        } else {
+            generated
+        };
 
         // A supplied deal's own answers, plus whatever testing it worked out.
         // From here on this is the deal's double-dummy knowledge, and it is the
@@ -1029,15 +1159,36 @@ fn run_pass(
                 .map(|(index, _)| index)
                 .collect();
             if wanted.len() > 1 {
-                let deals: Vec<&Deal> = wanted.iter().map(|index| &built[*index].deal).collect();
-                let warmed = workers.warm_each(&deals, &|deal| dd_demand.warm(deal));
-                for (index, warmed) in wanted.into_iter().zip(warmed) {
-                    known[index].merge(&warmed);
+                // A chunk at a time while the pass is solving, for the reason
+                // the building above is: this is where a whole batch's
+                // seventeen seconds go, and a bar that only moves afterwards
+                // has not moved at all.
+                let step = if solving { SOLVING_CHUNK } else { wanted.len() };
+                for chunk in wanted.chunks(step.max(1)) {
+                    let deals: Vec<&Deal> = chunk.iter().map(|index| &built[*index].deal).collect();
+                    let warmed = workers.warm_each(&deals, &|deal| dd_demand.warm(deal));
+                    for (index, warmed) in chunk.iter().zip(warmed) {
+                        known[*index].merge(&warmed);
+                    }
+                    if solving {
+                        let (done, target) =
+                            pass_numbers(opts.until_measured, &accumulator, produced, opts.produce);
+                        host.progress(opts.phase, done, dealt, target);
+                    }
                 }
             }
         }
 
         for (index, tested) in built.iter().enumerate() {
+            // The main thread's own solving happens below: an `average` over
+            // `tricks()`, or an action asking for a cell the warm could not
+            // read off the script, is searched here one deal at a time. A run
+            // that never solves evaluates nothing after the `&&`.
+            if solving && index % SOLVING_REPORT_EVERY == 0 {
+                let (done, target) =
+                    pass_numbers(opts.until_measured, &accumulator, produced, opts.produce);
+                host.progress(opts.phase, done, dealt, target);
+            }
             let deal = &tested.deal;
             if from_stream {
                 generated += 1;
@@ -1088,37 +1239,14 @@ fn run_pass(
                 break 'passing;
             }
         }
-        if host.should_stop(
-            opts.phase,
-            if opts.until_measured {
-                accumulator.rarest_measured()
-            } else {
-                produced
-            },
-            generated,
-            if opts.until_measured {
-                dealer_level::MEASURE_GOAL
-            } else {
-                opts.produce
-            },
-        ) {
+        let (done, target) =
+            pass_numbers(opts.until_measured, &accumulator, produced, opts.produce);
+        if host.should_stop(opts.phase, done, generated, target) {
             break;
         }
     }
-    host.pass_finished(
-        opts.phase,
-        if opts.until_measured {
-            accumulator.rarest_measured()
-        } else {
-            produced
-        },
-        generated,
-        if opts.until_measured {
-            dealer_level::MEASURE_GOAL
-        } else {
-            opts.produce
-        },
-    );
+    let (done, target) = pass_numbers(opts.until_measured, &accumulator, produced, opts.produce);
+    host.pass_finished(opts.phase, done, generated, target);
 
     let measurement = accumulator.measurement(generated);
     let hand_types: Vec<(String, usize)> = accumulator
@@ -1809,5 +1937,186 @@ action average \"strong\" 100 * HandType_Strong
             .plans
             .iter()
             .all(|p| p.keep > 0.0 && p.keep <= 1.0));
+    }
+
+    /// A host that listens to everything, and remembers what it heard.
+    ///
+    /// The same collector underneath, so a test can compare a run that was
+    /// listened to against one that was not and be comparing the run rather
+    /// than two different front ends.
+    #[derive(Default)]
+    struct Listener {
+        collector: Collector,
+        /// Every `progress` report, as (generated, produced).
+        reports: Vec<(usize, usize)>,
+        /// Where every `should_stop` offer fell, so a test can say a report
+        /// arrived somewhere an offer to stop did not.
+        stop_offers: Vec<usize>,
+    }
+
+    impl RunHost for Listener {
+        fn should_stop(&mut self, _: Phase, _: usize, generated: usize, _: usize) -> bool {
+            self.stop_offers.push(generated);
+            false
+        }
+        fn progress(&mut self, _: Phase, produced: usize, generated: usize, _: usize) {
+            self.reports.push((generated, produced));
+        }
+        fn pass_finished(&mut self, phase: Phase, a: usize, b: usize, c: usize) {
+            self.collector.pass_finished(phase, a, b, c);
+        }
+        fn produced(&mut self, produced: &Produced) -> Result<(), String> {
+            self.collector.produced(produced)
+        }
+    }
+
+    /// A condition that solves, so every deal the pass tests costs a search.
+    const SOLVING_CONDITION: &str = "condition tricks(north, notrump) >= 6\n";
+
+    /// An action that solves, so every deal the pass *produces* costs one.
+    const SOLVING_ACTION: &str = "condition 1\naction average \"nt\" tricks(north, notrump)\n";
+
+    /// Small enough to finish in a test, big enough to span more than one chunk.
+    fn solving_options(produce: usize) -> RunOptions {
+        RunOptions {
+            threads: 0,
+            batch: SOLVING_CHUNK * 2,
+            ..options(produce, false)
+        }
+    }
+
+    /// The whole point of the hook: a pass that solves says something before
+    /// its batch is over. `should_stop` is offered once a batch, and asking it
+    /// more often was not the answer because it can end a run (#83).
+    #[test]
+    fn a_solving_condition_reports_inside_its_batch() {
+        let mut host = Listener::default();
+        super::run(SOLVING_CONDITION, solving_options(1), &mut host).expect("run");
+        // The batch is two chunks, so the first report lands halfway through
+        // it — before the batch has been tested, and long before the offer to
+        // stop that used to be the only word a caller got.
+        assert!(
+            host.reports
+                .iter()
+                .any(|(generated, _)| *generated == SOLVING_CHUNK),
+            "nothing reported part-way through the first batch: {:?}",
+            host.reports
+        );
+        assert!(
+            host.stop_offers
+                .iter()
+                .all(|offer| *offer >= SOLVING_CHUNK * 2),
+            "an offer to stop arrived inside a batch: {:?}",
+            host.stop_offers
+        );
+    }
+
+    /// The same for the other place the time goes: solving a batch's produced
+    /// deals on the pool, which is where a table-shaped action spends it.
+    #[test]
+    fn a_solving_action_reports_while_it_warms() {
+        let batch = SOLVING_CHUNK * 4;
+        let mut host = Listener::default();
+        let opts = RunOptions {
+            batch,
+            ..solving_options(batch)
+        };
+        super::run(SOLVING_ACTION, opts, &mut host).expect("run");
+        // Warming happens with the batch dealt and nothing produced yet, so its
+        // reports are the ones saying every deal dealt and none produced. Four
+        // chunks give four of them, and the produced loop's first report says
+        // the same thing, so five. Warming the batch in one go would give that
+        // one report and no more — which is what "the bar moves only once the
+        // solving is over" looks like from here.
+        let while_warming = host
+            .reports
+            .iter()
+            .filter(|(generated, produced)| *generated == batch && *produced == 0)
+            .count();
+        assert!(
+            host.reports
+                .windows(2)
+                .all(|pair| pair[1].0 >= pair[0].0 && pair[1].1 >= pair[0].1),
+            "a report went backwards: {:?}",
+            host.reports
+        );
+        assert!(
+            while_warming >= 3,
+            "the batch's solving went unreported until it was over: {:?}",
+            host.reports
+        );
+    }
+
+    /// A run that never reaches the solver is not reported on inside a batch at
+    /// all — that gate is how this stays off the hot path. It still gets the
+    /// one offer a batch it always had.
+    #[test]
+    fn a_plain_run_is_not_reported_on_inside_its_batch() {
+        let mut host = Listener::default();
+        super::run(LADDER, solving_options(40), &mut host).expect("run");
+        assert!(
+            host.reports.is_empty(),
+            "a run that never solves paid for reports it could not need: {:?}",
+            host.reports
+        );
+        assert_eq!(host.collector.deals.len(), 40, "and it still dealt");
+    }
+
+    /// Listening changes nothing: same deals, same counts, same statistics.
+    /// That is the whole claim of a hook that cannot stop anything.
+    #[test]
+    fn listening_changes_nothing_about_what_a_run_produces() {
+        for script in [LADDER, SOLVING_CONDITION, SOLVING_ACTION] {
+            let mut deaf = Collector::default();
+            let quiet = super::run(script, solving_options(20), &mut deaf).expect("run");
+            let mut keen = Listener::default();
+            let loud = super::run(script, solving_options(20), &mut keen).expect("run");
+            assert_eq!(quiet.produced, loud.produced, "produced differed");
+            assert_eq!(quiet.generated, loud.generated, "generated differed");
+            assert_eq!(quiet.hand_types, loud.hand_types, "hand types differed");
+            assert_eq!(
+                format!("{:?}", quiet.stats),
+                format!("{:?}", loud.stats),
+                "statistics differed"
+            );
+            assert_eq!(
+                deaf.deals.len(),
+                keen.collector.deals.len(),
+                "a different number of deals came out"
+            );
+            assert!(
+                deaf.deals
+                    .iter()
+                    .zip(&keen.collector.deals)
+                    .all(|(a, b)| a == b),
+                "the deals or their order differed"
+            );
+            assert_eq!(deaf.phases, keen.collector.phases, "the passes differed");
+        }
+    }
+
+    /// And for a levelled run, where a stop in the wrong place would change no
+    /// deal but would change what the keeps were measured over.
+    #[test]
+    fn listening_changes_nothing_about_a_levelled_run() {
+        let mut deaf = Collector::default();
+        let quiet = super::run(LADDER, options(60, true), &mut deaf).expect("run");
+        let mut keen = Listener::default();
+        let loud = super::run(LADDER, options(60, true), &mut keen).expect("run");
+        let (a, b) = (
+            quiet.leveling.expect("levelled"),
+            loud.leveling.expect("levelled"),
+        );
+        assert_eq!(a.script, b.script, "the levelled scenario differed");
+        assert_eq!(
+            a.measured.counts, b.measured.counts,
+            "the measurement differed"
+        );
+        assert_eq!(a.characterized, b.characterized, "characterizing differed");
+        assert!(deaf
+            .deals
+            .iter()
+            .zip(&keen.collector.deals)
+            .all(|(x, y)| x == y));
     }
 }

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -24,7 +24,7 @@ use dealer_run::{Phase, Produced, RunHost, RunOptions};
 use std::fs::OpenOptions;
 use std::io::{self, BufWriter, Read, Write};
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Parser)]
 #[command(name = "dealer")]
@@ -981,6 +981,15 @@ fn report_parameters(script: &str, file: Option<&str>, as_json: bool) -> Result<
 /// Stands in the default column for a parameter that has none.
 const NO_DEFAULT: &str = "(none)";
 
+/// Shortest gap between `-m` lines, for a run too slow to reach the next
+/// 10,000 deals in a reasonable time.
+///
+/// dealer.exe reports every 10,000 deals and could take that for a moment. A
+/// deal that wants a double-dummy table costs about 23 ms, so 10,000 of them is
+/// nearly four minutes with nothing said (#83). Two seconds is often enough to
+/// read as a meter and slow enough that the lines are not the output.
+const PROGRESS_MIN_GAP: Duration = Duration::from_secs(2);
+
 /// `$1`, `$1 and $4`, `$1, $4 and $7`.
 fn and_list(indexes: &[usize]) -> String {
     let names: Vec<String> = indexes.iter().map(|i| format!("${}", i)).collect();
@@ -1765,11 +1774,62 @@ fn main() {
             produced: usize,
             /// The progress meter's last report, in deals.
             last_report: usize,
+            /// And when it went out, measured from `started`, which is the
+            /// other rule the meter answers to — see `PROGRESS_MIN_GAP`.
+            last_line: Duration,
             started: SystemTime,
             timed_out: bool,
         }
 
+        impl Terminal<'_> {
+            /// Print a `-m` line if one is due.
+            ///
+            /// Two rules, whichever comes first. The deal count is dealer.exe's
+            /// and is unchanged: every 10,000 deals. The clock is the second,
+            /// and it exists because 10,000 deals is a moment for an ordinary
+            /// script and nearly four minutes for one that solves a
+            /// double-dummy table per deal (#83). For an ordinary run the
+            /// count always gets there first and nothing about the meter
+            /// changes.
+            fn meter(&mut self, generated: usize) {
+                if !self.args.progress {
+                    return;
+                }
+                // Each pass counts its own deals from zero, so a levelled run's
+                // second pass reads as the count going backwards.
+                if generated < self.last_report {
+                    self.last_report = 0;
+                    self.last_line = Duration::ZERO;
+                }
+                let elapsed = self.started.elapsed().unwrap_or_default();
+                let due = generated - self.last_report >= 10_000
+                    || (generated > self.last_report
+                        && elapsed.saturating_sub(self.last_line) >= PROGRESS_MIN_GAP);
+                if !due {
+                    return;
+                }
+                eprintln!(
+                    "Generated: {} hands, Produced: {} hands, Time: {:.1}s",
+                    generated,
+                    self.produced,
+                    elapsed.as_secs_f64()
+                );
+                self.last_report = generated;
+                self.last_line = elapsed;
+            }
+        }
+
         impl RunHost for Terminal<'_> {
+            fn progress(
+                &mut self,
+                _phase: Phase,
+                _produced: usize,
+                generated: usize,
+                _target: usize,
+            ) {
+                self.meter(generated);
+            }
+
             fn should_stop(
                 &mut self,
                 phase: Phase,
@@ -1777,14 +1837,7 @@ fn main() {
                 generated: usize,
                 _target: usize,
             ) -> bool {
-                if self.args.progress && generated - self.last_report >= 10_000 {
-                    let elapsed = self.started.elapsed().unwrap_or_default().as_secs_f64();
-                    eprintln!(
-                        "Generated: {} hands, Produced: {} hands, Time: {:.1}s",
-                        generated, self.produced, elapsed
-                    );
-                    self.last_report = generated;
-                }
+                self.meter(generated);
                 let elapsed = self.started.elapsed().unwrap_or_default().as_secs();
                 if let Some(limit) = self.args.timeout {
                     if elapsed >= limit {
@@ -1880,6 +1933,7 @@ fn main() {
             printed_deals: Vec::new(),
             produced: 0,
             last_report: 0,
+            last_line: Duration::ZERO,
             started: start_time,
             timed_out: false,
         };

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -520,16 +520,13 @@ impl Page<'_> {
         let by_clock = seen as f64 * budget / spent;
         (by_deals.min(by_clock).round() as usize).clamp(seen.max(1), goal)
     }
-}
 
-impl RunHost for Page<'_> {
-    fn should_stop(
-        &mut self,
-        phase: Phase,
-        produced: usize,
-        generated: usize,
-        target: usize,
-    ) -> bool {
+    /// Offer the bar a report, throttled by [`Progress`] itself.
+    ///
+    /// Shared by the two hooks that paint: the offer to stop that ends a batch,
+    /// and the reports the engine makes from inside one. They must draw the
+    /// same bar, so they go through the same place.
+    fn paint(&self, phase: Phase, produced: usize, generated: usize, target: usize) {
         let expected = if phase == Phase::Characterizing {
             self.reachable(produced, generated, target)
         } else {
@@ -537,6 +534,34 @@ impl RunHost for Page<'_> {
         };
         self.progress
             .report(phase, produced, generated, target, expected, false);
+    }
+}
+
+impl RunHost for Page<'_> {
+    /// Paint the bar, and nothing else.
+    ///
+    /// The engine offers this from inside a batch — between the chunks a
+    /// solving pass builds its deals in, while it solves the ones that matched,
+    /// and as it hands them over. That is the whole of what a script calling
+    /// `tricks()` on shuffled deals needs to stop looking hung: a batch is at
+    /// least 1024 deals, and at 23 ms a deal the offer to stop that ends one
+    /// arrives half a minute late (#83).
+    ///
+    /// The clock that stops a characterizing pass is deliberately not read
+    /// here. Stopping is `should_stop`'s, still once a batch, so a levelled run
+    /// stops exactly where it did.
+    fn progress(&mut self, phase: Phase, produced: usize, generated: usize, target: usize) {
+        self.paint(phase, produced, generated, target);
+    }
+
+    fn should_stop(
+        &mut self,
+        phase: Phase,
+        produced: usize,
+        generated: usize,
+        target: usize,
+    ) -> bool {
+        self.paint(phase, produced, generated, target);
         if phase == Phase::Characterizing && now_ms() >= self.deadline {
             self.ran_out = true;
             return true;

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -129,6 +129,12 @@
         <p v-if="dealSource === 'library' && pointlessLibrary" class="source-warn">
           {{ pointlessLibrary }}
         </p>
+        <!-- The same question read the other way, and the expensive direction:
+             a script that does ask for double-dummy work, told to shuffle its
+             own deals, solves every one of them here. -->
+        <p v-else-if="dealSource === 'random' && slowRandom" class="source-warn">
+          {{ slowRandom }}
+        </p>
         <p v-else-if="dealSource === 'library'" class="source-note">
           Deals come from Pavlicek's 10,485,760 solved deals, so tricks(), dds() and par() are
           lookups rather than searches. The seed picks where in the library to start. A piece is
@@ -274,7 +280,7 @@ import ScriptViewer from '@/components/ScriptViewer.vue'
 import ResultsPanel from '@/components/ResultsPanel.vue'
 import PrintView from '@/components/PrintView.vue'
 import { ready, generate, usesDoubleDummy, version } from '@/lib/engine.js'
-import { libraryStatusText, pointlessLibraryWarning } from '@/lib/library.js'
+import { libraryStatusText, pointlessLibraryWarning, slowRandomWarning } from '@/lib/library.js'
 import { fetchScenarioScript } from '@/lib/pbsScenarios.js'
 import { downloadText, resultFilename, statisticsText } from '@/lib/download.js'
 import { loadSession, saveSession } from '@/lib/session.js'
@@ -561,6 +567,12 @@ const scriptUsesDoubleDummy = computed(() => {
 
 /// Why pre-solved deals are the wrong choice for this script, if they are.
 const pointlessLibrary = computed(() => pointlessLibraryWarning(scriptUsesDoubleDummy.value))
+
+/// And the other way: why random deals are the expensive choice for a script
+/// that does ask a double-dummy question. The same answer read the other way,
+/// and the costlier of the two mistakes — the first wastes a download, this one
+/// turns a run that would have taken a moment into one that takes minutes.
+const slowRandom = computed(() => slowRandomWarning(scriptUsesDoubleDummy.value, produce.value))
 
 // Ticked for you the first time a script with hand types appears, and left
 // alone afterwards.

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -415,9 +415,18 @@ const progressBars = computed(() =>
             'the deal limit or the time budget will stop it first. ' +
             'The levelling still works; its rarest rate is just less well known.'
           : '',
-        count: target
-          ? `${p.produced.toLocaleString()} / ${target.toLocaleString()}`
-          : p.produced.toLocaleString(),
+        // Deals looked at, beside deals kept. The bar counts what came out,
+        // and for most scripts that climbs steadily enough to be the whole
+        // story. For one that solves a double-dummy table per deal it does
+        // not: a batch is dealt and tested before any of it is handed over, so
+        // the bar can sit at zero for a long time while the run is working
+        // hard. This is the number that moves meanwhile, and it is what `-m`
+        // prints in the terminal for the same reason.
+        count:
+          (target
+            ? `${p.produced.toLocaleString()} / ${target.toLocaleString()}`
+            : p.produced.toLocaleString()) +
+          (p.generated > 0 ? ` · ${p.generated.toLocaleString()} dealt` : ''),
       }
     }),
 )

--- a/web/src/lib/library.js
+++ b/web/src/lib/library.js
@@ -324,3 +324,56 @@ export function pointlessLibraryWarning(usesDoubleDummy) {
     'will be faster.'
   )
 }
+
+/// About how long one double-dummy search takes here, in milliseconds.
+///
+/// Measured through `bridge-solver`, which is what `tricks()`, `dds()` and
+/// `par()` reach. Deliberately a round number: it is an order of magnitude for
+/// someone deciding between a download and a wait, not a promise, and it is
+/// five orders of magnitude above what a deal costs otherwise.
+export const SOLVE_MS = 23
+
+/**
+ * What to say to someone who chose random deals for a script that does ask a
+ * double-dummy question — the costly direction, and the one that said nothing.
+ *
+ * The same `usesDoubleDummy` the warning above reads, read the other way. That
+ * warning wastes a 640 KiB download; this one turns a run that would have taken
+ * a moment into one that takes minutes, so it is worth saying what it costs
+ * rather than only that it is slower.
+ *
+ * `produce` is the floor on the number of searches, not the number: a script
+ * whose call is in the condition solves every deal it *generates*, which is far
+ * more. Hence "at least".
+ *
+ * @param {boolean|undefined} usesDoubleDummy from the engine; `undefined` while
+ *   it is loading or the script does not parse, which is not the same as no
+ * @param {number} produce deals the run has been asked for
+ * @returns {string} empty when there is nothing worth saying
+ */
+export function slowRandomWarning(usesDoubleDummy, produce) {
+  if (usesDoubleDummy !== true) return ''
+  const deals = Number.isFinite(produce) && produce > 0 ? Math.floor(produce) : 0
+  const cost = deals ? ` — at least ${deals} × ${SOLVE_MS} ms, so about ${humanSeconds(deals * SOLVE_MS)}` : ''
+  return (
+    `This script calls tricks(), dds() or par(), so every deal has to be solved here` +
+    `${cost}, and more again if the call is in the condition, where every deal ` +
+    `generated is solved rather than every deal produced. Pre-solved deals arrive with ` +
+    `the answers already in them, so the same questions are lookups.`
+  )
+}
+
+/**
+ * A duration in milliseconds, said the way someone waiting would say it.
+ *
+ * @param {number} ms
+ * @returns {string}
+ */
+function humanSeconds(ms) {
+  const seconds = ms / 1000
+  if (seconds < 1) return 'under a second'
+  if (seconds < 90) return `${Math.round(seconds)} seconds`
+  const minutes = seconds / 60
+  if (minutes < 90) return `${Math.round(minutes)} minutes`
+  return `${(minutes / 60).toFixed(1)} hours`
+}

--- a/web/src/lib/library.test.js
+++ b/web/src/lib/library.test.js
@@ -7,6 +7,7 @@ import {
   learnLibrarySize,
   libraryStatusText,
   pointlessLibraryWarning,
+  slowRandomWarning,
   supplyLibraryPieces,
 } from './library.js'
 
@@ -257,5 +258,43 @@ describe('pointlessLibraryWarning', () => {
 
   it('says nothing when the script could not be read, which is not a no', () => {
     expect(pointlessLibraryWarning(undefined)).toBe('')
+  })
+})
+
+describe('slowRandomWarning', () => {
+  it('warns when a script that solves is told to shuffle its own deals', () => {
+    const said = slowRandomWarning(true, 200)
+    expect(said).toMatch(/calls tricks\(\), dds\(\) or par\(\)/)
+    expect(said).toMatch(/pre-solved/i)
+  })
+
+  it('says what it costs, not just that it is slower', () => {
+    // "Slower" is not a reason to choose differently; five seconds is. 200
+    // deals at 23 ms each is the arithmetic someone can check.
+    const said = slowRandomWarning(true, 200)
+    expect(said).toMatch(/200 × 23 ms/)
+    expect(said).toMatch(/5 seconds/)
+  })
+
+  it('scales with what was asked for', () => {
+    expect(slowRandomWarning(true, 10000)).toMatch(/4 minutes/)
+  })
+
+  it('says a condition costs more again than a produce count', () => {
+    expect(slowRandomWarning(true, 200)).toMatch(/condition/)
+  })
+
+  it('says nothing when the script asks no double-dummy question', () => {
+    expect(slowRandomWarning(false, 200)).toBe('')
+  })
+
+  it('says nothing when the script could not be read, which is not a yes', () => {
+    expect(slowRandomWarning(undefined, 200)).toBe('')
+  })
+
+  it('still warns when the count is missing, without inventing a time', () => {
+    const said = slowRandomWarning(true, NaN)
+    expect(said).toMatch(/every deal has to be solved here/)
+    expect(said).not.toMatch(/ms/)
   })
 })


### PR DESCRIPTION
Closes #83. A double-dummy run on random deals showed no progress at all and
looked hung; and the warning about mismatched deal sources only pointed one way.

## Progress while solving

`should_stop` was the only hook reporting progress, called once per batch, and a
batch is at minimum 1024 deals. At ~23 ms a deal that is **17.8 s of silence**
for a whole-table action, natively on all cores — roughly double in a browser,
for the *first* batch of a long run.

New `RunHost::progress`: same arguments, no return value, default no-op. It
**cannot** end a pass, which is the point — offering `should_stop` more often
would let a run stop where it previously would not, and a characterizing pass
that stops sooner measures less, changing the keeps a levelled run deals with.

Called between chunks of `build_and_test` (the case a `tricks()` in the
*condition* needs, since `produced` only fires for deals that pass the filter),
between chunks of `warm_each`, and every 8th produced deal.

Measured on the CLI over a fixed 12-second window of a solving run:
**main 0 meter lines, this branch 4**, one every ~2 s. An ordinary run's meter
output is byte-identical to before.

`-m` now prints on whichever comes first: dealer.exe's 10,000 deals, or 2
seconds. Also fixes the meter tripping over a levelled run's second pass
counting from zero — an underflow that would have panicked a debug build.

## The 4% this cost before it didn't

The first version cost **~4% of plain generation**. Not the reports — they were
gated behind a boolean false for every run that regressed, so none of them ran.
The cost was the closure *reading* `generated`: a Rust closure captures what it
reads by reference, taking the address, and a variable whose address is taken
cannot stay in a register. `generated` is incremented once per deal, so
borrowing it for a callback that never fires moved the pass's hottest counter
onto the stack for the whole function.

Copying the scalars into locals first fixes it. Best-of-13, interleaved against
`main`:

| single thread, 4M deals | before the fix | after |
|---|---|---|
| `condition hcp(north) >= 20` | +4.5% | **−1.4%** |
| `condition hcp(north) >= 37` (produces ~nothing) | +3.6% | **−0.6%** |

Layout was ruled out with a control adding the same bulk and doing nothing
(−0.27%), so the size of `run_pass` was never it.

**Worth keeping from how this was found:** the original benchmark missed it
because every script in it had a substantial condition. A fixed per-deal cost is
a small share of an expensive deal and a large share of a cheap one — so
`condition hcp(north) >= 20` shows what `Major_Suit_Fit` hides. Worth a cheap
script in whatever we benchmark with in future.

## The warning, the other way

Random deals with a script that *does* call `tricks`, `dds` or `par` now says
so, and says the cost — "at least 200 × 23 ms, so about 5 seconds" — noting that
a call in the *condition* costs more again, since every deal generated is
solved. Same `touches_solver` check as the existing warning, read the other way,
with the same `undefined`-is-not-a-no guard.

## Verification

Browser (Chromium, built app): the bar appears at 3.3 s and moves every 2–3 s
where `main` could not report until a whole batch was tested. A "N dealt" figure
sits beside the count, because a solving *condition* keeps `produced` at zero
for a whole batch and the bar would otherwise appear and sit still.

Every new behaviour broken deliberately and confirmed to fail, including one
test that passed while broken and was tightened until it failed for the right
reason.

Gate: fmt, both clippy flag sets, 45 Rust suites, 22 wasm tests, `verify.mjs`
17/17, `library-check.mjs`, 201 web tests, `build:all`.

## Not changed

A solving run's verbose trailer says `Generated 12 hands` after solving a whole
1024-deal batch, and a `produce 60` double-dummy run still solves far more deals
than it needs because the minimum batch is 1024. Both pre-date this and both
would change run semantics to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)