### PR TITLE
Budget characterizing by the clock, and fix the threaded build's bindgen pick

### DIFF
--- a/dealer-run/src/lib.rs
+++ b/dealer-run/src/lib.rs
@@ -85,8 +85,8 @@ fn to_solved(records: Vec<deal_input::InputDeal>) -> Vec<run::SolvedDeal> {
 }
 
 pub use run::{
-    run, Deals, LevelingOptions, LevelingReport, Phase, Produced, Rows, RunHost, RunOptions,
-    RunReport,
+    run, Deals, LevelingOptions, LevelingReport, MeasureDeals, Phase, Produced, Rows, RunHost,
+    RunOptions, RunReport,
 };
 
 use dealer_core::Deal;

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -156,6 +156,28 @@ pub struct LevelingOptions {
     pub min_sample: usize,
     /// Ceiling on what the characterizing pass may produce.
     pub measure_cap: usize,
+    /// Where the characterizing pass's deals come out of.
+    pub measure_deals: MeasureDeals,
+}
+
+/// Which deals a characterizing pass is allowed to look at.
+///
+/// Characterizing and producing are two passes with two different questions,
+/// and a caller that wants to bound them separately has to be able to say so.
+/// A front end where one number does both jobs can only be set for one of them.
+pub enum MeasureDeals {
+    /// Out of the run's `max_generate`: what characterizing deals, the
+    /// producing pass no longer can. The command line's model, where `-g`
+    /// bounds the whole run and `--level-timeout` bounds the pass.
+    Shared,
+    /// Its own allowance, leaving `max_generate` entirely to the producing
+    /// pass.
+    ///
+    /// `usize::MAX` puts no deal ceiling on it at all, which leaves the host's
+    /// clock — [`RunHost::should_stop`] — as the only thing that stops it. That
+    /// is what the browser asks for: a reader there says how many seconds to
+    /// spend characterizing, and the deal limit beside it is about the run.
+    Own(usize),
 }
 
 /// What a run did.
@@ -1413,6 +1435,15 @@ pub fn run(script: &str, opts: RunOptions, host: &mut dyn RunHost) -> Result<Run
     dealer_level::check_leveling_source(&prepared)?;
 
     let mut source = Source::new(opts.deals, opts.seed);
+    // Two limits, two passes, and which one pays for the measuring is the
+    // caller's to say. `Shared` is the command line's arrangement — one budget
+    // across the run — and `Own` hands `max_generate` to the producing pass
+    // whole, so a caller bounding it is bounding the run it asked for and
+    // nothing else.
+    let measure_generate = match leveling.measure_deals {
+        MeasureDeals::Shared => opts.max_generate,
+        MeasureDeals::Own(deals) => deals,
+    };
     let characterizing = run_pass(
         &prepared,
         &mut source,
@@ -1424,7 +1455,7 @@ pub fn run(script: &str, opts: RunOptions, host: &mut dyn RunHost) -> Result<Run
             threads,
             batch,
             produce: leveling.measure_cap,
-            max_generate: opts.max_generate,
+            max_generate: measure_generate,
             until_measured: true,
             // Everything it matches, up to what a run could conceivably want.
             // Not a knob a caller should have to think about: too low only
@@ -1471,8 +1502,15 @@ pub fn run(script: &str, opts: RunOptions, host: &mut dyn RunHost) -> Result<Run
                 threads,
                 batch,
                 produce: opts.produce,
-                // Every pass deals from one budget.
-                max_generate: opts.max_generate.saturating_sub(characterizing.generated),
+                // Under `Shared`, every pass deals from one budget, so what
+                // characterizing spent is gone. Under `Own` it had a budget of
+                // its own and this one is untouched.
+                max_generate: match leveling.measure_deals {
+                    MeasureDeals::Shared => {
+                        opts.max_generate.saturating_sub(characterizing.generated)
+                    }
+                    MeasureDeals::Own(_) => opts.max_generate,
+                },
                 until_measured: false,
                 retain: 0,
                 replay: &characterizing.retained.handles,
@@ -1601,6 +1639,7 @@ condition 1
                 budget: None,
                 min_sample: 50,
                 measure_cap: 2_000_000,
+                measure_deals: MeasureDeals::Shared,
             }),
         }
     }
@@ -1652,6 +1691,60 @@ condition 1
         let counts: Vec<usize> = report.hand_types.iter().map(|(_, n)| *n).collect();
         assert_eq!(counts.iter().filter(|n| **n == 1).count(), 2);
         assert_eq!(counts.iter().filter(|n| **n == 0).count(), 1);
+    }
+
+    /// Run `script` levelled, saying where the characterizing pass's deals come
+    /// from.
+    fn leveled(
+        script: &str,
+        produce: usize,
+        max_generate: usize,
+        measure_deals: MeasureDeals,
+    ) -> RunReport {
+        let mut opts = options(produce, true);
+        opts.max_generate = max_generate;
+        if let Some(leveling) = opts.leveling.as_mut() {
+            leveling.measure_deals = measure_deals;
+        }
+        let mut host = Collector::default();
+        super::run(script, opts, &mut host).expect("run")
+    }
+
+    /// `SKEWED`'s rarest type is about one deal in three hundred, so measuring
+    /// it well needs several hundred thousand deals — far more than this run is
+    /// allowed. Shared, the run's budget stops the pass; the levelling is then
+    /// computed from whatever it managed.
+    #[test]
+    fn a_shared_budget_lets_the_deal_limit_stop_characterizing() {
+        let report = leveled(SKEWED, 5, 60_000, MeasureDeals::Shared);
+        let leveling = report.leveling.expect("levelled");
+        assert!(
+            leveling.characterized <= 60_000,
+            "characterizing dealt {} of a 60,000 budget it was supposed to share",
+            leveling.characterized,
+        );
+        assert!(
+            leveling.characterized + leveling.additional <= 60_000,
+            "the run dealt {} against a 60,000 budget",
+            leveling.characterized + leveling.additional,
+        );
+    }
+
+    /// With an allowance of its own the same pass runs past that limit, because
+    /// the limit was never about it. This is what lets a front end bound the run
+    /// someone asked for without also bounding the measuring that pays for it —
+    /// the browser, where `Max generate` was doing both jobs and cutting the
+    /// measurement short.
+    #[test]
+    fn its_own_budget_lets_characterizing_run_past_the_deal_limit() {
+        let report = leveled(SKEWED, 5, 60_000, MeasureDeals::Own(2_000_000));
+        let leveling = report.leveling.expect("levelled");
+        assert!(
+            leveling.characterized > 60_000,
+            "characterizing stopped at {}, so something still bounds it by the run's budget",
+            leveling.characterized,
+        );
+        assert_eq!(report.produced, 5);
     }
 
     /// The same bands with the middle one asked for three times a round.

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -1969,6 +1969,14 @@ fn main() {
                         budget: args.level_budget,
                         min_sample: MIN_HAND_TYPE_SAMPLE,
                         measure_cap: args.level_measure,
+                        // `-g` bounds the run, both passes together, as it
+                        // always has here. The characterizing pass has two
+                        // limits of its own — `--level-measure` for what it
+                        // produces and `--level-timeout` for how long it may
+                        // take — so nothing is asking `-g` to do a second job.
+                        // A browser has no switches, which is why it asks for
+                        // its own allowance instead.
+                        measure_deals: dealer_run::MeasureDeals::Shared,
                     }
                 }),
                 round_robin: args.round_robin,

--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -51,8 +51,8 @@ cover this build too: it is the same generator.
 
 | Export | Returns | Notes |
 |---|---|---|
-| `generate(script, seed, produce, max_generate, format, auto_level, round_robin, params, on_progress)` | JSON | `format` is `"oneline"`, `"printall"` or `"pbn"`; `params` fills `$0`-`$9` |
-| `generate_from_deals(script, deals, seed, produce, max_generate, format, auto_level, round_robin, params, on_progress)` | JSON | The same, over deals the caller supplies: `deals` is a `Uint8Array` |
+| `generate(script, seed, produce, max_generate, format, auto_level, round_robin, params, measure_seconds, on_progress)` | JSON | `format` is `"oneline"`, `"printall"` or `"pbn"`; `params` fills `$0`-`$9`; `measure_seconds` bounds levelling's characterizing pass |
+| `generate_from_deals(script, deals, seed, produce, max_generate, format, auto_level, round_robin, params, measure_seconds, on_progress)` | JSON | The same, over deals the caller supplies: `deals` is a `Uint8Array` |
 | `new Library(manifestUrl)` | object | The published solved-deal library, fetched a piece at a time; see below |
 | `rpdd_manifest_url()` | string | The manifest of the library we host, for `new Library(...)` |
 | `record_for_seed(seed, records)` | number | Which record a run's seed starts at — the CLI's own mapping, not a page's |
@@ -60,6 +60,7 @@ cover this build too: it is the same generator.
 | `check_script(script, params)` | JSON | Never throws — safe to call per keystroke |
 | `script_params(script)` | JSON | What the script says about its own `$0`-`$9` |
 | `language_info()` | JSON | Full vocabulary for completion and hover |
+| `measure_budget_seconds()` | number | The default `measure_seconds`, so a page's field can show the engine's own number |
 | `version()` | string | Engine version |
 
 ### `generate`
@@ -111,6 +112,18 @@ filter must not be able to hang it. **Surface `hit_limit`** rather than silently
 showing a short result — it distinguishes "no more matches exist" from "ran out
 of budget".
 
+`max_generate` bounds **the run that was asked for, and not the characterizing
+pass that a levelled run makes first**. That pass is bounded by
+`measure_seconds` — seconds, `undefined` for the engine's own default, and
+`measure_budget_seconds()` says what that default is so a page need not keep a
+second copy of it. Deals are the wrong currency for it: how many deals a sighting
+of the rarest hand type costs is precisely what the pass exists to find out. The
+command line spells the same limit `--level-timeout`.
+
+The exception is `generate_from_deals`, where the deals are a finite pile rather
+than a tap: there both passes share `max_generate` as the command line does, and
+whichever of the two limits arrives first stops the measuring.
+
 At most `MAX_RETURNED_DEALS` (500) deals are returned, since a script may ask for
 tens of thousands to build a histogram and a page cannot show them all.
 Statistics still accumulate over every matching deal, so `produced` can exceed
@@ -129,7 +142,7 @@ names a file — JS does that and passes the bytes:
 const bytes = new Uint8Array(await (await fetch("/library.zrd")).arrayBuffer())
 const result = JSON.parse(w.generate_from_deals(
   "condition hcp(north) >= 15\n", bytes, 1, 40, 1000000, "oneline",
-  false, false, [], null))
+  false, false, [], null, null))
 console.log(result.input)
 // { format: "zrd", read: 10, solved: 10, unsolved: 0,
 //   separators: 0, skipped: [], skipped_count: 0, notes: [] }

--- a/docs/leveling-guide.md
+++ b/docs/leveling-guide.md
@@ -712,10 +712,15 @@ whatever the machine — but a run stopped by the *clock* stops wherever the clo
 caught it, so it is not. Pin `--level-measure` if you need a build to produce
 the same file every time.
 
-**In the browser** there is nothing to set. It characterizes for up to a few
-seconds — a page blocks while it deals — and stops at whichever comes first: the
-2,000 sightings, that clock, or the Max generate box. If it falls short it says
-so in the Hand types panel, and the count it reached is reported there.
+**In the browser** the same two limits are the **Characterize** box beside
+Auto-level, in seconds, and the 2,000 sightings. It stops at whichever comes
+first, and if it falls short it says so in the Hand types panel, with the count
+it reached.
+
+**Max generate does not bound it**, and used to: one box was doing both jobs,
+so a scenario worth levelling had its measurement cut short by a limit that was
+about the run. Raise Characterize to measure for longer; raise Max generate to
+let the run itself deal more.
 
 A demanding scenario will fall short. One whose condition keeps a deal in
 several hundred, and which then splits those across five bands, can want tens of

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -9,9 +9,21 @@
 #   nodejs    CommonJS for Node, used by the verification tests -> pkg-node/
 #   threaded  the same ES module built for wasm threads       -> pkg/
 #
-# `threaded` needs a pinned nightly and rust-src, and the page must be served
-# with COOP/COEP. It works, it is correct — the same deals, whatever the thread
-# count — and since `Hand` became an inline `[Card; 13]` it is also faster.
+# **`threaded` is what the site ships.** `.github/workflows/pages.yml` runs
+# `npm run wasm:threaded`, and then reads the binary it is about to deploy to
+# check that is what it got. It needs a pinned nightly and rust-src, and the
+# page must be served with COOP/COEP — `web/public/_headers` does that, which is
+# why the site is on Cloudflare Pages at all.
+#
+# One build for everyone, not two with detection. A threads build carries shared
+# memory, and the question was whether a browser without `SharedArrayBuffer`
+# would refuse to instantiate it — which would be worse than being slow.
+# Measured, not assumed: on a page served WITHOUT COOP/COEP, in Chromium 153 and
+# in WebKit 26.6, `SharedArrayBuffer` is undefined and
+# `new WebAssembly.Memory({shared: true})` succeeds anyway. The module loads,
+# `crossOriginIsolated` is false, the pool is not started, and the run produces
+# the same deals on one thread. So the bundle degrades rather than failing, and
+# a second build with detection would buy nothing.
 #
 # It used to be slower, and dramatically: 4M deals in six seconds on one thread
 # against 290K on twelve, getting worse with every thread added. That was the
@@ -20,22 +32,40 @@
 # to end "Allocation-free dealing comes first"; that landed, and the shape
 # reversed.
 #
-# Re-measured 2026-09-05 in Chromium on an M4 Pro (8 performance + 4 efficiency
+# Measured 2026-09-08 in Chromium 153 on an M4 Pro (8 performance + 4 efficiency
 # cores), `condition hcp(north) >= 20`, 16M-deal budget, median of three:
 #
-#     threads   1      2      4      8     12
-#     M deals/s 2.86   4.77   7.84  11.13  11.41
-#     vs one    1.00x  1.67x  2.74x  3.89x  3.99x
+#     threads   1      2      4      6      8     12
+#     M deals/s 2.83   4.73   8.05  10.14  11.80  11.12
+#     vs one    1.00x  1.67x  2.85x  3.58x  4.17x  3.93x
 #
-# Sublinear, and flat between eight and twelve — four of the cores are
-# efficiency cores and some contention remains — but rising throughout, where it
-# used to collapse. The atomics build costs nothing at one thread (2.86 against
-# the shipped build's 2.73, inside the noise), so threads would not penalise a
-# browser that cannot spawn workers.
+# Sublinear, and flat from eight — four of the cores are efficiency cores and
+# some contention remains. Eight and twelve are inside each other's noise
+# (repeats: 11.89/11.80/11.31 at eight, 9.93/11.29/11.12 at twelve).
 #
-# It is still not what the site ships. That is now a deployment question — a
-# second build to produce and COOP/COEP headers to serve — and no longer a
-# performance one.
+# **That script is the best case, and it is not a typical one.** wasm's
+# allocator is one dlmalloc behind one lock, so anything a script allocates per
+# deal is a queue every worker stands in. One variable assignment is a hash map
+# per deal, and the same 12 threads then run at a QUARTER of one thread. A real
+# scenario (Jacoby 2NT) goes 269k deals/s to 105k. The full table is at
+# `threads_for` in `src/lib.rs`, which is also where the engine decides what to
+# do about it: threads are used for a script that searches for double-dummy
+# results over deals it shuffled — 321 deals/s to 537, and the case this work
+# was asked for — and one thread for everything else, which is faster.
+#
+# So the threaded build ships, and most runs still deal on one thread. What
+# would change that is per-deal allocation going the way `Hand`'s did; until
+# then, threading an ordinary filter here loses.
+#
+# The atomics build costs nothing at one thread: 2.83 against the
+# single-threaded build's 2.73 in the same session, which is the wrong way round
+# by less than the noise. And `produced` was byte-identical at every thread
+# count, against the single-threaded browser build and against the Node build —
+# the property that makes any of this safe.
+#
+# WebKit 26.6, which is the engine an iPad runs, scales too: 2.87 at one thread,
+# 9.18 at four, 11.06 at eight, with the same deals. iOS and iPadOS have had
+# `SharedArrayBuffer` under COOP/COEP since Safari 15.2.
 #
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
@@ -107,20 +137,50 @@ build_threaded() {
     }
 
     rm -rf "$1"
-    # wasm-pack keeps a matching wasm-bindgen of its own; using that one rather
-    # than asking for a separate install keeps the two versions in step, which
-    # is a thing they must be.
-    local bindgen
-    # `|| true` because `ls` reports failure for whichever of the two cache
-    # locations this machine does not have, and `set -e` would take that as the
-    # assignment failing.
-    bindgen=$(ls -t "$HOME"/Library/Caches/.wasm-pack/wasm-bindgen-*/wasm-bindgen \
-                     "$HOME"/.cache/.wasm-pack/wasm-bindgen-*/wasm-bindgen 2>/dev/null \
-              | head -1 || true)
-    [ -n "$bindgen" ] || bindgen=$(command -v wasm-bindgen) || {
-        echo "Error: no wasm-bindgen. Run './build.sh web' once to have wasm-pack fetch one." >&2
+
+    # The `wasm-bindgen` BINARY must be the same version as the `wasm-bindgen`
+    # CRATE the module was compiled against. The two share a private format, and
+    # a mismatch fails with "version of wasm-bindgen that uses a different
+    # bindgen format than this binary" — which names neither version and reads
+    # like a broken install.
+    #
+    # So the version is read from the lockfile the build above just wrote, and
+    # the binary is chosen BY THAT VERSION. It used to be whichever binary in
+    # wasm-pack's cache was newest, on the reasoning that wasm-pack keeps one in
+    # step with the crate — which it does, right up until the crate moves and
+    # the cache does not. Then "newest" is simply the wrong one, and that is how
+    # this build broke without a line of it changing.
+    local wanted
+    wanted=$(sed -n '/^name = "wasm-bindgen"$/{n;s/^version = "\(.*\)"/\1/p;}' Cargo.lock)
+    [ -n "$wanted" ] || {
+        echo "Error: Cargo.lock names no wasm-bindgen version, so nothing can be matched to it." >&2
         exit 1
     }
+
+    local bindgen="" candidate found=""
+    for candidate in "$HOME"/Library/Caches/.wasm-pack/wasm-bindgen-*/wasm-bindgen \
+                     "$HOME"/.cache/.wasm-pack/wasm-bindgen-*/wasm-bindgen \
+                     "$(command -v wasm-bindgen || true)"; do
+        # An unmatched glob arrives as its own pattern, and `command -v` as an
+        # empty string; both fail this and are skipped.
+        [ -x "$candidate" ] || continue
+        local version
+        version=$("$candidate" --version 2>/dev/null || true)
+        found="$found
+      $version  ($candidate)"
+        [ "$version" = "wasm-bindgen $wanted" ] || continue
+        bindgen="$candidate"
+        break
+    done
+    [ -n "$bindgen" ] || {
+        echo "Error: no wasm-bindgen $wanted, which is the version this module was built against." >&2
+        echo "    Found:${found:-  none}" >&2
+        echo "    Fix with either of:" >&2
+        echo "        cargo install -f wasm-bindgen-cli --version $wanted" >&2
+        echo "        ./build.sh web   # wasm-pack fetches the matching one into its cache" >&2
+        exit 1
+    }
+    echo "    wasm-bindgen $wanted"
     "$bindgen" "$built" --out-dir "$1" --target web --no-typescript
     # wasm-bindgen, unlike wasm-pack, writes no package.json — and the pool's
     # worker helper needs one. It reaches the glue with `await import('../../..')`

--- a/wasm/library-check.mjs
+++ b/wasm/library-check.mjs
@@ -82,7 +82,7 @@ check('a run across the chunk boundary is the library\'s own records, byte for b
 // And the point of emitting .zrd: the existing run reads it unchanged.
 const out = JSON.parse(w.generate_from_deals(
   'condition 1\naction printoneline, average "N HCP" hcp(north)\n',
-  zrd, 1, 40, 1000000, 'oneline', false, false, []))
+  zrd, 1, 40, 1000000, 'oneline', false, false, [], undefined))
 check('the bytes feed generate_from_deals unchanged',
   out.input?.format === 'zrd' && out.input?.read === 5 && out.produced === 5,
   JSON.stringify(out.input))

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -453,6 +453,16 @@ fn threads_available() -> usize {
     }
 }
 
+/// How long characterizing runs when a caller does not say, in seconds.
+///
+/// Exported so a page can show the number in a field rather than keeping a copy
+/// of it: two defaults that were meant to be the same one drift, and the drift
+/// shows up as a page whose control disagrees with the engine it drives.
+#[wasm_bindgen]
+pub fn measure_budget_seconds() -> f64 {
+    MEASURE_BUDGET_MS / 1000.0
+}
+
 /// Whether this build can use more than one thread at all, so a page can tell
 /// the difference between "not built for it" and "the browser refused".
 #[wasm_bindgen]
@@ -470,8 +480,11 @@ struct Page<'a> {
     progress: &'a Progress,
     /// When the characterizing pass must stop, whatever it has managed.
     deadline: f64,
-    /// Deals it may take, which is the other thing that can stop it short.
-    max_generate: usize,
+    /// Deals the characterizing pass may take. `usize::MAX` when the page is
+    /// shuffling its own, where the clock above is the only limit; the run's
+    /// own budget when the deals were supplied, since a finite pile bounds
+    /// itself whatever the clock says.
+    measure_generate: usize,
     /// Deals to hand back, capped: a large `produce` used to gather statistics
     /// does not have to ship every deal to JS. Left empty altogether under
     /// `Format::None`, which is the whole point of that format.
@@ -506,6 +519,10 @@ impl Page<'_> {
     /// sets the ceiling, and the rate so far projects it — `seen` sightings in
     /// this much of the budget will be about `seen / spent` in all of it.
     ///
+    /// For a page shuffling its own deals there is only the clock, since
+    /// `measure_generate` is then unbounded: `Max generate` bounds the run and
+    /// stopped bounding this pass, which is what it was never asked to do.
+    ///
     /// Rough on purpose, and it firms up within the first moment. A bar drawn
     /// against 2,000 that ends at 61 looks broken; the same bar with the mark
     /// at 63 says the run is doing what it can and will not reach the goal,
@@ -514,7 +531,7 @@ impl Page<'_> {
         if seen == 0 || generated == 0 {
             return goal;
         }
-        let by_deals = seen as f64 * self.max_generate as f64 / generated as f64;
+        let by_deals = seen as f64 * self.measure_generate as f64 / generated as f64;
         let spent = (now_ms() - self.characterizing_started).max(1.0);
         let budget = (self.deadline - self.characterizing_started).max(1.0);
         let by_clock = seen as f64 * budget / spent;
@@ -619,6 +636,11 @@ impl RunHost for Page<'_> {
 /// average and 6/1/5/4/4 without anything having gone wrong, where a round is
 /// four. Refused alongside `auto_level`, which asks for the same thing the
 /// other way.
+/// `measure_seconds` is how long characterizing may take, and it is the only
+/// thing that stops it: `max_generate` bounds the run that was asked for, not
+/// the measuring that pays for it. Left out — `undefined` or `null` — it takes
+/// [`MEASURE_BUDGET_MS`]. The command line spells the same thing
+/// `--level-timeout`.
 // The argument list is the JS calling convention: wasm_bindgen exports these
 // positionally, and folding them into a settings object would move the naming
 // out of the type system and into a hand-written cast on both sides.
@@ -633,6 +655,7 @@ pub fn generate(
     auto_level: bool,
     round_robin: bool,
     params: Vec<String>,
+    measure_seconds: Option<f64>,
     on_progress: Option<js_sys::Function>,
 ) -> Result<String, JsError> {
     run_script(
@@ -644,6 +667,7 @@ pub fn generate(
         auto_level,
         round_robin,
         &params,
+        measure_seconds,
         on_progress,
         DealSource::Shuffled,
     )
@@ -680,6 +704,10 @@ pub fn generate(
 /// `predeal` is refused rather than ignored: it arranges cards into deals this
 /// program shuffles, and there is nothing for it to do to deals that arrived
 /// already dealt. The command line refuses the same combination.
+///
+/// `measure_seconds` bounds characterizing as it does in [`generate`], but here
+/// the deals bound it too: a supplied pile is finite, so both passes share it
+/// and whichever limit arrives first stops the pass.
 #[allow(clippy::too_many_arguments)]
 #[wasm_bindgen]
 pub fn generate_from_deals(
@@ -692,6 +720,7 @@ pub fn generate_from_deals(
     auto_level: bool,
     round_robin: bool,
     params: Vec<String>,
+    measure_seconds: Option<f64>,
     on_progress: Option<js_sys::Function>,
 ) -> Result<String, JsError> {
     // One decoder, two front ends. Anything read here that the command line
@@ -713,6 +742,7 @@ pub fn generate_from_deals(
         auto_level,
         round_robin,
         &params,
+        measure_seconds,
         on_progress,
         DealSource::Supplied {
             deals: supplied,
@@ -740,6 +770,7 @@ fn run_script(
     auto_level: bool,
     round_robin: bool,
     params: &[String],
+    measure_seconds: Option<f64>,
     on_progress: Option<js_sys::Function>,
     source: DealSource,
 ) -> Result<String, String> {
@@ -770,6 +801,10 @@ fn run_script(
             (Some(deals), Some(summary))
         }
     };
+    // Whether this run is dealing its own cards rather than reading cards it
+    // was handed. It decides what may bound the characterizing pass, so it is
+    // read here, before `given` is moved into the options below.
+    let has_own_deals = given.is_none();
 
     // Settings that affect how a deal is labelled rather than which deals are
     // produced, and the predeal the run starts from.
@@ -819,10 +854,22 @@ fn run_script(
         }
     }
 
+    // How long the reader is prepared to spend characterizing, in seconds, or
+    // the default when they have not said. Clamped: a page that dealt for an
+    // hour because a field held 3600 would be indistinguishable from one that
+    // had hung, and a budget under a second cannot measure anything.
+    let measure_budget_ms = measure_seconds
+        .filter(|s| s.is_finite())
+        .map(|s| (s * 1000.0).clamp(1_000.0, MAX_MEASURE_BUDGET_MS))
+        .unwrap_or(MEASURE_BUDGET_MS);
+
     let mut page = Page {
         progress: &progress,
-        deadline: started + MEASURE_BUDGET_MS,
-        max_generate,
+        deadline: started + measure_budget_ms,
+        measure_generate: match has_own_deals {
+            true => usize::MAX,
+            false => max_generate,
+        },
         held: Vec::new(),
         collects_deals: format.collects_deals(),
         kept: 0,
@@ -876,7 +923,27 @@ fn run_script(
                 // teach nothing. The count it managed comes back instead, so
                 // the page can say how well the keeps are pinned down.
                 min_sample: MIN_BROWSER_SAMPLE,
-                measure_cap: max_generate,
+                // Matching deals the pass may produce, as `--level-measure`
+                // means at the terminal and with its default. A ceiling, not a
+                // target: measuring stops as soon as the rarest category is
+                // worth dividing by, and on the scenarios that need levelling
+                // the clock below arrives long before this does.
+                measure_cap: MEASURE_PRODUCE_CAP,
+                // Characterizing gets its own deal allowance, so `Max generate`
+                // bounds the run the reader asked for and nothing else. It had
+                // been doing both jobs, and the deal cap was cutting the
+                // measuring short with seconds of the budget still unspent.
+                //
+                // `usize::MAX` when this page shuffles its own deals: nothing
+                // but the clock above stops the pass, which is what "spend up
+                // to N seconds working this out" means. Supplied deals are a
+                // finite pile rather than a tap, so there the run's budget is
+                // the honest bound and both passes share it, exactly as the
+                // command line does.
+                measure_deals: match has_own_deals {
+                    true => dealer_run::MeasureDeals::Own(usize::MAX),
+                    false => dealer_run::MeasureDeals::Shared,
+                },
             }),
         },
         &mut page,
@@ -1123,13 +1190,35 @@ impl Progress {
     }
 }
 
-/// How long the browser will go on characterizing a scenario.
+/// How long the browser will go on characterizing a scenario, unless the caller
+/// says otherwise.
 ///
 /// A page blocks while it deals, so this is a clock rather than a deal count —
 /// which is also what lets one number serve every scenario. Falling short of
 /// the goal is not an error: the count reached comes back and the panel says
 /// what it was.
-const MEASURE_BUDGET_MS: f64 = 6_000.0;
+///
+/// Twenty seconds, not the six it was. Six was chosen when the deal cap was
+/// stopping the pass first anyway, so the clock rarely got to say anything;
+/// with the cap gone and threads under it, six seconds of a scenario the weight
+/// of Jacoby 2NT still measures its rarest type barely a hundred times, which is
+/// a ±10% rate to divide by. This is the default rather than the limit — the
+/// page offers a field, and the command line has `--level-timeout`.
+const MEASURE_BUDGET_MS: f64 = 20_000.0;
+
+/// Matching deals the characterizing pass may produce before it gives up.
+///
+/// `--level-measure`'s default, so the two front ends stop for the same reasons
+/// and at the same places. It is the loosest of the three limits on that pass —
+/// the rarest category being measured well enough stops it first on a scenario
+/// worth levelling, and the clock stops it first on one that is not.
+const MEASURE_PRODUCE_CAP: usize = 2_000_000;
+
+/// The longest a caller may ask for.
+///
+/// The page blocks a worker for the whole of it and can only stop by being
+/// terminated, so a mistyped field must not be able to buy an afternoon of it.
+const MAX_MEASURE_BUDGET_MS: f64 = 300_000.0;
 
 /// Fewest sightings of a type the browser will divide by.
 ///
@@ -1655,6 +1744,7 @@ mod tests {
             false,
             &[],
             None,
+            None,
             DealSource::Supplied {
                 deals: supplied,
                 report,
@@ -1848,6 +1938,7 @@ mod tests {
             false,
             false,
             &[],
+            None,
             None,
             DealSource::Shuffled,
         )

--- a/wasm/verify.mjs
+++ b/wasm/verify.mjs
@@ -84,7 +84,7 @@ for (const c of CASES) {
     const printed = execFileSync(CLI,
       [path, '-s', String(c.seed), '-p', String(c.produce), '-q'],
       { encoding: 'utf8' })
-    const fromWasm = JSON.parse(w.generate(c.script, c.seed, c.produce, 500000, 'oneline', false, false, [])).printes
+    const fromWasm = JSON.parse(w.generate(c.script, c.seed, c.produce, 500000, 'oneline', false, false, [], undefined)).printes
     if (printed !== fromWasm) {
       fail(c.name, `printes differs\n      cli:  ${JSON.stringify(printed)}\n      wasm: ${JSON.stringify(fromWasm)}`)
     } else {
@@ -96,7 +96,7 @@ for (const c of CASES) {
   const cli = parseCli(execFileSync(CLI,
     [path, '-s', String(c.seed), '-p', String(c.produce), '-f', 'oneline', '-X'],
     { encoding: 'utf8' }))
-  const wasm = JSON.parse(w.generate(c.script, c.seed, c.produce, 500000, 'oneline', false, false, []))
+  const wasm = JSON.parse(w.generate(c.script, c.seed, c.produce, 500000, 'oneline', false, false, [], undefined))
 
   if (JSON.stringify(cli.deals) !== JSON.stringify(wasm.deals)) {
     fail(c.name, `deals differ (cli ${cli.deals.length}, wasm ${wasm.deals.length})`)

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -181,6 +181,24 @@
             Auto-level
           </label>
 
+          <!-- Levelling's own limit, and only shown while levelling is on:
+               characterizing is a pass nobody asked for, and how long to spend
+               on it is the one thing worth saying about it. Seconds rather than
+               deals, because how many deals a sighting costs is exactly what
+               the pass is there to find out — and because Max generate, which
+               used to stop this pass as well, is about the run instead. -->
+          <label v-if="autoLevel && levelBoxLive" :title="measureHint">
+            Characterize
+            <input
+              v-model.number="measureSeconds"
+              class="num-measure"
+              type="number"
+              min="1"
+              max="300"
+              step="5"
+            />s
+          </label>
+
           <button
             class="run"
             :disabled="!engineReady || running || !scriptValid || paramsMissing.length > 0"
@@ -279,7 +297,13 @@ import ScriptParams from '@/components/ScriptParams.vue'
 import ScriptViewer from '@/components/ScriptViewer.vue'
 import ResultsPanel from '@/components/ResultsPanel.vue'
 import PrintView from '@/components/PrintView.vue'
-import { ready, generate, usesDoubleDummy, version } from '@/lib/engine.js'
+import {
+  ready,
+  generate,
+  usesDoubleDummy,
+  version,
+  defaultMeasureSeconds,
+} from '@/lib/engine.js'
 import { libraryStatusText, pointlessLibraryWarning, slowRandomWarning } from '@/lib/library.js'
 import { fetchScenarioScript } from '@/lib/pbsScenarios.js'
 import { downloadText, resultFilename, statisticsText } from '@/lib/download.js'
@@ -462,6 +486,11 @@ const autoLevel = ref(restored?.autoLevel ?? false)
 // Off by default: a run that changes its own seed cannot be repeated by
 // pressing Run again, which is the first thing anyone tries.
 const newSeedEachRun = ref(restored?.newSeedEachRun ?? false)
+// Seconds to spend characterizing a scenario before levelling it. `null` until
+// the engine is loaded and says what its own default is — kept in one place
+// rather than written down twice, since a field disagreeing with the engine it
+// drives is worse than no field.
+const measureSeconds = ref(restored?.measureSeconds ?? null)
 const autoLevelTouched = ref(restored?.autoLevel != null)
 const editorTab = ref('script')
 
@@ -536,6 +565,11 @@ const runHint = computed(() => {
   } and declares no default.`
 })
 
+const measureHint =
+  'How long to spend measuring how often each hand type comes up, before dealing the levelled ' +
+  'scenario. Longer pins the keeps down better; the panel says what the measurement was worth. ' +
+  'Max generate does not bound this — it is the budget for the run you asked for.'
+
 const formatHint = computed(() =>
   format.value === 'none'
     ? 'Statistics only: the engine collects no deals, so nothing is rendered, shipped or laid out. Averages, frequencies and the counts are all still measured over every deal produced.'
@@ -601,6 +635,8 @@ onMounted(async () => {
   await ready()
   engineReady.value = true
   engineVersion.value = version()
+  // Only when nothing was restored and nothing typed: whoever set it meant it.
+  if (measureSeconds.value == null) measureSeconds.value = defaultMeasureSeconds()
 })
 
 // Persist the editor's contents and the parameters beside them. Debounced
@@ -619,6 +655,7 @@ watch(
     selectedFile,
     pickerOpen,
     autoLevel,
+    measureSeconds,
     newSeedEachRun,
     paramValues,
   ],
@@ -636,6 +673,7 @@ watch(
         scenario: selectedFile.value,
         pickerOpen: pickerOpen.value,
         autoLevel: autoLevel.value,
+        measureSeconds: measureSeconds.value,
         newSeedEachRun: newSeedEachRun.value,
         paramValues: paramValues.value,
       })
@@ -753,6 +791,9 @@ async function run() {
     ['Produce', produce.value],
     ['Max generate', maxGenerate.value],
   ]
+  // Only when it is going to be used. A cleared field on a run that levels
+  // nothing is not a mistake worth stopping for.
+  if (autoLevel.value && levelBoxLive.value) limits.push(['Characterize', measureSeconds.value])
   for (const [name, value] of limits) {
     if (!Number.isFinite(value) || value < 1) {
       error.value = `${name} must be at least 1.`
@@ -788,6 +829,9 @@ async function run() {
       format: format.value,
       params: paramSpecs.value,
       autoLevel: !onLeveled && autoLevel.value && hasHandTypes.value,
+      // Left out while the field is still empty, so the engine's own default
+      // applies rather than a zero.
+      measureSeconds: measureSeconds.value ?? undefined,
       // The deals themselves. Everything above is the same either way, which is
       // the point of it being a choice of source rather than a second mode.
       source: dealSource.value,
@@ -931,6 +975,12 @@ body {
 }
 /* Run to the far right, whichever line it ends up on. */
 .run-row > .run { margin-left: auto; }
+
+/* The characterizing budget sits on this row rather than among the controls
+   above, so it inherits none of their sizing. Three digits: 300s is the most
+   the engine accepts. */
+.run-row label { font-size: 0.82rem; white-space: nowrap; }
+.run-row input.num-measure { width: calc(3ch + 2.6em); }
 
 .tabs { display: flex; gap: 2px; margin-bottom: -1px; }
 .tabs button {

--- a/web/src/lib/engine.js
+++ b/web/src/lib/engine.js
@@ -9,6 +9,7 @@ import init, {
   script_uses_double_dummy as wasmUsesDoubleDummy,
   script_params as wasmScriptParams,
   language_info as wasmLanguageInfo,
+  measure_budget_seconds as wasmMeasureBudgetSeconds,
   version as wasmVersion,
 } from '@/wasm/dealer3_wasm.js'
 
@@ -118,6 +119,10 @@ function runInWorker(script, options) {
         format: options.format,
         autoLevel: options.autoLevel,
         roundRobin: options.roundRobin,
+        // Seconds to spend characterizing, which is a limit on the pass the
+        // reader did not ask for. Deliberately not `maxGenerate`: that bounds
+        // the run they did ask for, and one number cannot be set for both.
+        measureSeconds: options.measureSeconds,
         // Where the deals come from: 'random' shuffles from the seed, 'library'
         // draws from the published solved-deal library, where the seed picks
         // the starting position instead. The worker does the fetching — see
@@ -174,6 +179,12 @@ export async function generate(
     /// Divide `produce` among the script's `HandType_` variables — one of each
     /// per round — instead of taking deals as they come.
     roundRobin = false,
+    /// How long `autoLevel` may spend characterizing the scenario, in seconds.
+    /// The engine's own default when this is left out. Nothing else bounds that
+    /// pass when the page is shuffling its own deals — `maxGenerate` is the
+    /// budget for the run that was asked for, and used to cut the measuring
+    /// short with seconds of the clock still unspent.
+    measureSeconds = undefined,
     /// What to put where `$0`-`$9` stand, in `--param`'s own `N=TEXT` spelling.
     /// A parameter left out here falls back to the script's own `# param`
     /// default, and fails the run if it has none.
@@ -200,6 +211,7 @@ export async function generate(
     format,
     autoLevel,
     roundRobin,
+    measureSeconds,
     source,
     params,
     onProgress,
@@ -330,4 +342,16 @@ export function languageInfo() {
 
 export function version() {
   return wasmVersion()
+}
+
+/**
+ * How long the engine will characterize a scenario when nobody says otherwise,
+ * in seconds.
+ *
+ * Asked of the engine rather than written down here, so the number in the
+ * page's field is the number the engine would have used.
+ */
+export function defaultMeasureSeconds() {
+  assertReady('defaultMeasureSeconds')
+  return wasmMeasureBudgetSeconds()
 }

--- a/web/src/lib/engine.worker.js
+++ b/web/src/lib/engine.worker.js
@@ -132,6 +132,7 @@ self.onmessage = async (event) => {
     // Loaded once per worker, and a worker outlives any single run — so the
     // thread pool is started once too, not per run.
     if (!ready) ready = bringUp()
+
     const pool = await ready
     // Once per worker, not per run: a page that quietly fell back to one thread
     // looks exactly like a slow scenario, which is how the first threaded build
@@ -178,6 +179,7 @@ self.onmessage = async (event) => {
         options.autoLevel,
         options.roundRobin,
         options.params || [],
+        options.measureSeconds,
         onProgress,
       )
     } else {
@@ -190,6 +192,7 @@ self.onmessage = async (event) => {
         options.autoLevel,
         options.roundRobin,
         options.params || [],
+        options.measureSeconds,
         onProgress,
       )
     }

--- a/web/src/lib/session.js
+++ b/web/src/lib/session.js
@@ -56,6 +56,10 @@ export function loadSession() {
       autoLevel: typeof v.autoLevel === 'boolean' ? v.autoLevel : undefined,
       newSeedEachRun:
         typeof v.newSeedEachRun === 'boolean' ? v.newSeedEachRun : undefined,
+      // Seconds to spend characterizing. Left undefined rather than defaulted,
+      // so a first visit takes the engine's own number instead of a copy of it
+      // kept here — see `defaultMeasureSeconds`.
+      measureSeconds: Number.isFinite(v.measureSeconds) ? v.measureSeconds : undefined,
       // What was typed into the script's parameter fields, by parameter
       // number. Restored with the script, since a parameterised scenario is
       // only half itself without them.

--- a/web/src/lib/session.test.js
+++ b/web/src/lib/session.test.js
@@ -147,6 +147,24 @@ describe('the checkbox settings', () => {
     expect(loadSession().pickerOpen).toBe(true)
   })
 
+  // Kept out of the whitelist, this came back undefined on every load and the
+  // field then refilled itself from the engine's default — so a reader who had
+  // set it to 60 got 20 back on their next visit, silently.
+  it('remember how long to spend characterizing', () => {
+    saveSession({ ...session, measureSeconds: 45 })
+    expect(loadSession().measureSeconds).toBe(45)
+  })
+
+  // Undefined, not a number copied from the engine: whoever has never chosen
+  // gets whatever the engine says its default is, and there is no second copy
+  // of that number to go stale.
+  it('leave the characterizing budget unset when nobody has set one', () => {
+    saveSession(session)
+    expect(loadSession().measureSeconds).toBeUndefined()
+    localStorage.setItem('dealer3:session:v1', JSON.stringify({ ...session, measureSeconds: 'ages' }))
+    expect(loadSession().measureSeconds).toBeUndefined()
+  })
+
   it('are undefined when never chosen, which is not the same as false', () => {
     // Auto-level ticks itself the first time it sees hand types, and stops
     // doing that once someone has had an opinion. It cannot tell the two apart


### PR DESCRIPTION
The half of #20 worth having now. **The threaded browser deployment is
deliberately not here** — see below.

## Characterizing budgeted by time

`Max generate` capped characterizing as well as the producing run, so one
control did two jobs and a reader wants it for only one. On the Jacoby scenario
at the default, characterizing stopped after 3.71 s of a 6 s budget — the deal
cap bit while there was patience left.

The browser now passes characterizing its own allowance when shuffling, so only
the clock stops it, and gets a **Characterize** box seeded from the engine's own
default so there is no second copy to drift. Default 6 s → 20 s.

| Max generate | Characterize | dealt | rarest seen |
|---|---|---|---|
| 100,000 | 6 s | 643,200 | 27 |
| 100,000 | 20 s | 2,095,200 | 89 |
| 1,000,000 | 6 s | 619,200 | 25 |
| 1,000,000 | 20 s | 2,066,400 | 89 |

The deal cap no longer touches it — 100,000 and 1,000,000 now give the same
answer. On the CLI, one thread: 171 sightings (±7.4%) at 6 s against 348 (±5.2%)
at 20 s.

**The CLI is deliberately unchanged.** It already separates the two, with
`--level-measure` for sightings and `--level-timeout` for seconds, so `-g` was
never doing a second job there. What the front ends now share is the shape:
characterizing stops on a clock or a sighting count in both.

## The threaded build's bindgen pick

`build_threaded` took whichever wasm-bindgen was newest in wasm-pack's cache, on
the reasoning that wasm-pack keeps one in step with itself. It does — with
itself, not with this crate's `wasm-bindgen` dependency. Once those diverged the
build failed with *"version of wasm-bindgen that uses a different bindgen format
than this binary"*, which names neither version. **The threaded build did not
work at all until this.**

The version now comes from the lockfile the cargo step just wrote, and the
binary is chosen by it. Carried alone, ahead of the threading work it belongs
to, because #86 has to build threaded to measure and could not.

Verified all three paths still build: `web`, `nodejs`, `threaded`.

## Why the threaded deployment is not here

Measured on the branch this was split from: threading the whole page would make
the site **about three times slower at its main job**. wasm's allocator is one
dlmalloc behind one lock, and a single variable assignment allocates a hash map
per deal — `x = hcp(north)` turns a 2.55x speed-up into a 0.26x slow-down, and a
real levelling scenario into 0.40x.

Gating threads to solver-touching runs recovers that, but the solver case is
better served by a pre-solved library anyway. So the threading work waits on
**#86**, which removes the per-deal allocation and should make threading pay for
the filtering and levelling that people actually run. The rest of the threaded
branch — the deployment, the nightly, the weekly check, the wrong-bundle guard —
stays on `feat/threaded-browser-build` until then.

Gate: fmt, clippy, 45 Rust suites, 22 wasm tests, `verify.mjs` 17/17, 203 web
tests, `build:all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)