### PR TITLE
Lend a deal's contexts one scratch instead of building a cache in each (#86)

### DIFF
--- a/dealer-eval/src/lib.rs
+++ b/dealer-eval/src/lib.rs
@@ -314,18 +314,134 @@ impl std::fmt::Display for EvalError {
 
 impl std::error::Error for EvalError {}
 
+/// Scratch space for the variable values worked out on one deal.
+///
+/// Hoisted out of the context because building it there allocated. An empty
+/// `FxHashMap` does not allocate, but the first insert does — so **any** script
+/// with a variable in it allocated at least once per deal, and a deal builds
+/// several contexts. On wasm that is fatal to threading: the allocator is one
+/// dlmalloc behind one lock, so twelve threads queue on it and a script with a
+/// single variable ran four times *slower* threaded than serial (#85, #86).
+///
+/// A caller keeps one of these per thread and lends it to each deal in turn.
+/// [`HashMap::clear`](std::collections::HashMap::clear) keeps the capacity, so
+/// after the first deal on a thread there is no allocation left to pay for.
+///
+/// # The deal boundary
+///
+/// A value cached for one deal is wrong for the next, and wrong *plausibly* —
+/// every count would still add up. So the only way to get the shared reference
+/// a context is built from is [`VarCache::start_deal`], which takes `&mut self`
+/// and empties it first. The borrow checker does the rest: the `&mut` reborrow
+/// keeps every context built from one deal's loan alive for exactly as long as
+/// that loan, so a second `start_deal` cannot be called while a stale context
+/// still exists, and a context cannot exist without a `start_deal` having
+/// cleared the scratch. Forgetting to clear is a compile error rather than a
+/// wrong answer.
+pub struct VarCache<'v> {
+    /// `RefCell` because `eval` takes `&self` all the way down.
+    ///
+    /// Keys are `&str` borrowed from the script's own variable names, so an
+    /// insert clones nothing.
+    values: RefCell<FxHashMap<&'v str, i32>>,
+}
+
+impl Default for VarCache<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'v> VarCache<'v> {
+    /// An empty scratch, which has not allocated yet.
+    #[inline]
+    pub fn new() -> Self {
+        VarCache {
+            values: RefCell::new(FxHashMap::default()),
+        }
+    }
+
+    /// Empty it, and lend it to one deal's contexts.
+    ///
+    /// Every context built from what this returns shares one cache, so a value
+    /// the condition worked out is not worked out again for the hand-type pick
+    /// or the `average`s. Taking `&mut self` and handing back a shared borrow
+    /// is what ties that sharing to one deal: see the type's own note.
+    ///
+    /// `#[inline]` because this workspace does not link with LTO, so without it
+    /// every deal makes a cross-crate call to empty a map that is usually
+    /// already empty — worth about 2% of a bare condition, which is a script
+    /// with no variables and so nothing here to do at all.
+    #[inline]
+    pub fn start_deal(&mut self) -> &Self {
+        self.values.get_mut().clear();
+        self
+    }
+
+    /// What is cached for `name` on the deal in hand.
+    #[inline]
+    fn get(&self, name: &str) -> Option<i32> {
+        self.values.borrow().get(name).copied()
+    }
+
+    /// Remember `value` for `name` until the deal changes.
+    ///
+    /// `expected` is how many variables the script has, and it is used once —
+    /// on the insert that finds the scratch still unallocated — to size it in
+    /// one go. Growing into it instead costs an allocation per doubling, and
+    /// the corpus reaches 205 variables in one script, so that is seven
+    /// allocations rather than one every time a worker starts a fresh piece of
+    /// a batch. On wasm those are seven turns at a single lock.
+    #[inline]
+    fn put(&self, name: &'v str, value: i32, expected: usize) {
+        let mut values = self.values.borrow_mut();
+        if values.capacity() == 0 {
+            values.reserve(expected.max(1));
+        }
+        values.insert(name, value);
+    }
+}
+
+/// Where a context's variable values live.
+///
+/// The hot path lends one scratch to a whole deal; the convenience
+/// constructors — a bare expression, a test — have nobody to lend them one and
+/// keep their own. One predictable branch per variable lookup, against a hash
+/// lookup that was going to happen anyway.
+enum Cache<'d, 'v> {
+    /// This context's own, for a caller with no scratch to lend.
+    Owned(VarCache<'v>),
+    /// One deal's scratch, shared with every other context over that deal.
+    Shared(&'d VarCache<'v>),
+}
+
+impl<'v> Cache<'_, 'v> {
+    #[inline]
+    fn get(&self) -> &VarCache<'v> {
+        match self {
+            Cache::Owned(cache) => cache,
+            Cache::Shared(cache) => cache,
+        }
+    }
+}
+
 /// Evaluation context - holds the deal being evaluated and variable bindings
-pub struct EvalContext<'a> {
-    pub deal: &'a Deal,
+///
+/// Two lifetimes, because the two halves live for different lengths of time.
+/// `'d` is one deal — the cards, what is known about them double-dummy, and the
+/// loan of the scratch they are worked out in. `'v` is the script — its
+/// variables, their names, and the point counts it redefined — which outlives
+/// every deal the run makes. The scratch's keys borrow from the script, so it
+/// is a `'v` thing lent for a `'d`; collapsing the two would force the deal to
+/// live as long as the script, which a freshly shuffled one cannot.
+pub struct EvalContext<'d, 'v> {
+    pub deal: &'d Deal,
     /// Variable name -> Expression tree reference mapping
     /// Variables store references to expression trees (no cloning needed)
     /// FxHashMap uses a faster (non-cryptographic) hash function
-    pub variables: &'a Variables<'a>,
-    /// Cache of evaluated variable values (per-deal)
-    /// Using RefCell for interior mutability since eval takes &self
-    /// Keys are &str references to avoid String cloning on cache insert
-    /// FxHashMap uses a faster (non-cryptographic) hash function
-    cache: RefCell<FxHashMap<&'a str, i32>>,
+    pub variables: &'v Variables<'v>,
+    /// Where the values worked out for this deal are kept.
+    cache: Cache<'d, 'v>,
     /// The stream `rnd()` draws from, seeded from the deal on first use.
     ///
     /// One per context rather than one per deal, so a `rnd()` in a `condition`
@@ -337,7 +453,7 @@ pub struct EvalContext<'a> {
     /// `None` is the ordinary case — no script in the 1,076-script corpus uses
     /// either statement — and it means the hardcoded counts run exactly as they
     /// did before. Only a script that redefines something pays for the table.
-    counts: Option<&'a PointCounts>,
+    counts: Option<&'v PointCounts>,
     /// Which side is vulnerable, for `par()`.
     ///
     /// `Vulnerability::None` unless a run says otherwise, which is what a
@@ -357,7 +473,7 @@ pub struct EvalContext<'a> {
     /// difference between a lookup and a hundred milliseconds. Empty is not a
     /// failure: it is what a freshly dealt deal looks like, and it is solved on
     /// demand.
-    dd_tricks: &'a dealer_dds::DealTricks,
+    dd_tricks: &'d dealer_dds::DealTricks,
 }
 
 /// Can evaluating `expr` reach a call to `rnd()`?
@@ -436,13 +552,13 @@ fn reaches_rnd_memo<'a>(
 static EMPTY_VARIABLES: std::sync::LazyLock<Variables<'static>> =
     std::sync::LazyLock::new(Variables::default);
 
-impl<'a> EvalContext<'a> {
+impl<'d, 'v> EvalContext<'d, 'v> {
     /// Create a context without any variables (for simple expressions)
-    pub fn new(deal: &'a Deal) -> Self {
+    pub fn new(deal: &'d Deal) -> Self {
         EvalContext {
             deal,
             variables: &EMPTY_VARIABLES,
-            cache: RefCell::new(FxHashMap::default()),
+            cache: Cache::Owned(VarCache::new()),
             rnd: RefCell::new(None),
             counts: None,
             vulnerability: dealer_core::Vulnerability::default(),
@@ -451,11 +567,11 @@ impl<'a> EvalContext<'a> {
     }
 
     /// Create a context with pre-defined variable references
-    pub fn with_variables(deal: &'a Deal, variables: &'a Variables<'a>) -> Self {
+    pub fn with_variables(deal: &'d Deal, variables: &'v Variables<'v>) -> Self {
         EvalContext {
             deal,
             variables,
-            cache: RefCell::new(FxHashMap::default()),
+            cache: Cache::Owned(VarCache::new()),
             rnd: RefCell::new(None),
             counts: None,
             vulnerability: dealer_core::Vulnerability::default(),
@@ -483,17 +599,25 @@ impl<'a> EvalContext<'a> {
     /// so every number stays right and the run is merely slow.
     ///
     /// Taking both as arguments makes leaving one out a compile error.
+    ///
+    /// `cache` is there for the same reason, and is the one argument that
+    /// cannot be got wrong even in principle: the only way to have a
+    /// `&VarCache` at all is [`VarCache::start_deal`], which empties it. A
+    /// caller keeps one per thread rather than one per deal, which is what
+    /// took the per-deal allocation out of every script with a variable in it
+    /// (#86).
     pub fn for_deal(
-        deal: &'a Deal,
-        variables: &'a Variables<'a>,
-        counts: Option<&'a PointCounts>,
+        deal: &'d Deal,
+        variables: &'v Variables<'v>,
+        counts: Option<&'v PointCounts>,
         vulnerability: dealer_core::Vulnerability,
-        dd_tricks: &'a dealer_dds::DealTricks,
+        dd_tricks: &'d dealer_dds::DealTricks,
+        cache: &'d VarCache<'v>,
     ) -> Self {
         EvalContext {
             deal,
             variables,
-            cache: RefCell::new(FxHashMap::default()),
+            cache: Cache::Shared(cache),
             rnd: RefCell::new(None),
             counts,
             vulnerability,
@@ -502,7 +626,7 @@ impl<'a> EvalContext<'a> {
     }
 
     /// What is already known about this deal's double-dummy results.
-    pub fn dd_tricks(&self) -> &'a dealer_dds::DealTricks {
+    pub fn dd_tricks(&self) -> &'d dealer_dds::DealTricks {
         self.dd_tricks
     }
 
@@ -532,14 +656,14 @@ impl<'a> EvalContext<'a> {
     /// `extract_point_counts` returns exactly that — so the ordinary path keeps
     /// running the hardcoded counts.
     pub fn with_counts(
-        deal: &'a Deal,
-        variables: &'a Variables<'a>,
-        counts: Option<&'a PointCounts>,
+        deal: &'d Deal,
+        variables: &'v Variables<'v>,
+        counts: Option<&'v PointCounts>,
     ) -> Self {
         EvalContext {
             deal,
             variables,
-            cache: RefCell::new(FxHashMap::default()),
+            cache: Cache::Owned(VarCache::new()),
             rnd: RefCell::new(None),
             counts,
             vulnerability: dealer_core::Vulnerability::default(),
@@ -717,33 +841,45 @@ pub fn eval_program(program: &Program, deal: &Deal) -> Result<i32, EvalError> {
     eval_with_context(constraint, &variables, deal)
 }
 
+/// The value of the variable `name` on this context's deal.
+///
+/// The same thing `eval` does for an `Expr::Variable`, without one: `pick`
+/// classifies a deal by asking for `HandType_1`, `HandType_2` and so on by
+/// name, and building an `Expr::Variable` to ask with allocated a `String` per
+/// category per deal — on the levelling path, which is the one that builds the
+/// most contexts already.
+pub fn eval_variable(name: &str, ctx: &EvalContext) -> Result<i32, EvalError> {
+    // Check the deal's scratch first (a &str lookup, so nothing is allocated).
+    if let Some(cached_value) = ctx.cache.get().get(name) {
+        return Ok(cached_value);
+    }
+
+    // Look up variable and evaluate its stored expression tree.
+    // `get_key_value` hands back the key with the script's lifetime, which is
+    // what lets the scratch borrow the name instead of cloning it.
+    match ctx.variables.get_key_value(name) {
+        Some((key, var_expr)) => {
+            let value = eval(var_expr, ctx)?;
+            // Cache the computed value using the key reference (no clone!)
+            // — unless the variable can reach `rnd()`, whose whole point
+            // is to answer differently each time it is asked.
+            if !ctx.variables.is_volatile(key.as_str()) {
+                ctx.cache
+                    .get()
+                    .put(key.as_str(), value, ctx.variables.len());
+            }
+            Ok(value)
+        }
+        None => Err(EvalError::UndefinedVariable(name.to_string())),
+    }
+}
+
 /// Evaluate an expression against a deal
 pub fn eval(expr: &Expr, ctx: &EvalContext) -> Result<i32, EvalError> {
     match expr {
         Expr::Literal(value) => Ok(*value),
 
-        Expr::Variable(name) => {
-            // Check cache first (use &str for lookup to avoid allocation)
-            if let Some(&cached_value) = ctx.cache.borrow().get(name.as_str()) {
-                return Ok(cached_value);
-            }
-
-            // Look up variable and evaluate its stored expression tree
-            // Use get_key_value to get the key with lifetime 'a for cache insertion
-            match ctx.variables.get_key_value(name) {
-                Some((key, var_expr)) => {
-                    let value = eval(var_expr, ctx)?;
-                    // Cache the computed value using the key reference (no clone!)
-                    // — unless the variable can reach `rnd()`, whose whole point
-                    // is to answer differently each time it is asked.
-                    if !ctx.variables.is_volatile(key.as_str()) {
-                        ctx.cache.borrow_mut().insert(key.as_str(), value);
-                    }
-                    Ok(value)
-                }
-                None => Err(EvalError::UndefinedVariable(name.clone())),
-            }
-        }
+        Expr::Variable(name) => eval_variable(name, ctx),
 
         Expr::Position(pos) => {
             // Check if this position name is actually a variable override
@@ -756,15 +892,18 @@ pub fn eval(expr: &Expr, ctx: &EvalContext) -> Result<i32, EvalError> {
             };
 
             // Check cache first for the single-letter variable
-            if let Some(&cached_value) = ctx.cache.borrow().get(pos_name) {
+            if let Some(cached_value) = ctx.cache.get().get(pos_name) {
                 return Ok(cached_value);
             }
 
             // Check if variable is defined - if so, use it instead of position
-            // Use get_key_value to get the key with proper lifetime for cache insertion
+            // Use get_key_value to get the key with the script's lifetime, so
+            // the cache borrows the name rather than cloning it.
             if let Some((key, var_expr)) = ctx.variables.get_key_value(pos_name) {
                 let value = eval(var_expr, ctx)?;
-                ctx.cache.borrow_mut().insert(key.as_str(), value);
+                ctx.cache
+                    .get()
+                    .put(key.as_str(), value, ctx.variables.len());
                 return Ok(value);
             }
 
@@ -1035,10 +1174,12 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
             if args.len() == 2 {
                 let suit = eval_suit_arg(&args[1])?;
                 Ok(counted(ctx, hand, CountRow::Hcp, Some(suit), || {
-                    hand.cards_in_suit(suit)
-                        .iter()
-                        .map(|c| c.hcp() as i32)
-                        .sum()
+                    // Over the hand, filtering, rather than `cards_in_suit` —
+                    // which builds a `Vec` and so allocates once per call, on
+                    // every deal. See `VarCache` for why that matters: it is the
+                    // same lock, and a scenario asking about four suits in four
+                    // seats reaches here a dozen times a deal (#86).
+                    cards_in(hand, suit).map(|c| c.hcp() as i32).sum()
                 }))
             } else {
                 Ok(counted(ctx, hand, CountRow::Hcp, None, || {
@@ -1080,8 +1221,7 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
             if args.len() == 2 {
                 let suit = eval_suit_arg(&args[1])?;
                 Ok(counted(ctx, hand, CountRow::Controls, Some(suit), || {
-                    hand.cards_in_suit(suit)
-                        .iter()
+                    cards_in(hand, suit)
                         .map(|c| match c.rank {
                             dealer_core::Rank::Ace => 2,
                             dealer_core::Rank::King => 1,
@@ -1475,6 +1615,16 @@ fn eval_function(function: &Function, args: &[Expr], ctx: &EvalContext) -> Resul
             Ok(if north_south { score_ns } else { -score_ns })
         }
     }
+}
+
+/// One hand's cards in `suit`, without collecting them.
+///
+/// `Hand::cards_in_suit` returns a `Vec`, which is an allocation per call — and
+/// these are called per deal, from a worker thread, where wasm's single-locked
+/// allocator turns one into a queue. Nothing here needs the cards in a
+/// collection; it needs to add something up.
+fn cards_in(hand: &dealer_core::Hand, suit: Suit) -> impl Iterator<Item = &Card> {
+    hand.cards().iter().filter(move |c| c.suit == suit)
 }
 
 /// Evaluate an argument that should be a position
@@ -2950,6 +3100,142 @@ mod tests {
             };
             assert!(refused, "`{}` should not be read as a contract", word);
         }
+    }
+
+    /// A value worked out for one deal must not be read back on the next.
+    ///
+    /// The scratch a context evaluates variables in is now the caller's, kept
+    /// across deals so that a script with variables in it stops allocating per
+    /// deal (#86). That is exactly the shape of failure this project is worst
+    /// at noticing: a stale entry crossing a deal boundary answers plausibly,
+    /// every count still adds up, and every other test stays green.
+    ///
+    /// So: two deals in a row, the same variable name, different values, one
+    /// scratch. The second answer must be the second deal's.
+    #[test]
+    fn a_reused_scratch_does_not_carry_a_value_across_a_deal() {
+        use dealer_parser::parse_program;
+
+        let program = parse_program("x = hcp(north)\ncondition x > 0\n").expect("should parse");
+        let variables = extract_variables(&program);
+        let expr = Expr::Variable("x".to_string());
+
+        // Two deals in a row whose North hands are worth different amounts, so
+        // that carrying the first value into the second is visible.
+        let mut generator = FastDealGenerator::new(20260908);
+        let first = generator.next_deal();
+        let second = loop {
+            let deal = generator.next_deal();
+            if deal.hand(Position::North).hcp() != first.hand(Position::North).hcp() {
+                break deal;
+            }
+        };
+
+        let mut scratch = VarCache::new();
+
+        let first_value = {
+            let ctx = EvalContext::for_deal(
+                &first,
+                &variables,
+                None,
+                dealer_core::Vulnerability::default(),
+                &dealer_dds::NOTHING_KNOWN,
+                scratch.start_deal(),
+            );
+            eval(&expr, &ctx).expect("first")
+        };
+        let second_value = {
+            let ctx = EvalContext::for_deal(
+                &second,
+                &variables,
+                None,
+                dealer_core::Vulnerability::default(),
+                &dealer_dds::NOTHING_KNOWN,
+                scratch.start_deal(),
+            );
+            eval(&expr, &ctx).expect("second")
+        };
+
+        // What each deal is worth on its own, with nothing carried at all.
+        let alone = |deal: &Deal| {
+            let ctx = EvalContext::with_variables(deal, &variables);
+            eval(&expr, &ctx).expect("alone")
+        };
+
+        assert_ne!(
+            alone(&first),
+            alone(&second),
+            "the two deals must disagree, or the test cannot fail"
+        );
+        assert_eq!(first_value, alone(&first));
+        assert_eq!(
+            second_value,
+            alone(&second),
+            "the second deal read the first deal's cached value"
+        );
+    }
+
+    /// The other half of the same guarantee: within one deal the scratch is
+    /// shared, so a value is worked out once however many contexts ask.
+    ///
+    /// Which is the point of sharing it — a levelled run evaluates the same
+    /// variables for the condition, the hand-type pick, the levelling pick and
+    /// the statistics — and it is only safe because a non-volatile variable is
+    /// a pure function of its deal.
+    #[test]
+    fn one_deal_s_contexts_share_what_they_work_out() {
+        use dealer_parser::parse_program;
+
+        let program = parse_program("x = hcp(north)\ncondition x > 0\n").expect("should parse");
+        let variables = extract_variables(&program);
+        let expr = Expr::Variable("x".to_string());
+        let deal = reference_deal();
+        let mut scratch = VarCache::new();
+        let lent = scratch.start_deal();
+
+        let mut answers = Vec::new();
+        for _ in 0..3 {
+            let ctx = EvalContext::for_deal(
+                &deal,
+                &variables,
+                None,
+                dealer_core::Vulnerability::default(),
+                &dealer_dds::NOTHING_KNOWN,
+                lent,
+            );
+            answers.push(eval(&expr, &ctx).expect("value"));
+        }
+        assert_eq!(answers, vec![answers[0]; 3]);
+        assert_eq!(answers[0], deal.hand(Position::North).hcp() as i32);
+    }
+
+    /// `rnd()` is the one thing a deal's scratch must not remember, and
+    /// sharing one across a deal's contexts must not start remembering it.
+    #[test]
+    fn a_volatile_variable_is_still_drawn_afresh_from_a_shared_scratch() {
+        use dealer_parser::parse_program;
+
+        let program = parse_program("r = rnd(1000000)\ncondition r >= 0\n").expect("should parse");
+        let variables = extract_variables(&program);
+        let expr = Expr::Variable("r".to_string());
+        let deal = reference_deal();
+        let mut scratch = VarCache::new();
+        let lent = scratch.start_deal();
+
+        let ctx = EvalContext::for_deal(
+            &deal,
+            &variables,
+            None,
+            dealer_core::Vulnerability::default(),
+            &dealer_dds::NOTHING_KNOWN,
+            lent,
+        );
+        let draws: Vec<i32> = (0..8).map(|_| eval(&expr, &ctx).expect("draw")).collect();
+        assert!(
+            draws.iter().any(|d| *d != draws[0]),
+            "a shared scratch cached a volatile variable: {:?}",
+            draws
+        );
     }
 
     /// The cycle guard in `reaches_rnd`. A variable referring to itself cannot

--- a/dealer-run/src/lib.rs
+++ b/dealer-run/src/lib.rs
@@ -494,15 +494,25 @@ impl<'a> RunAccumulator<'a> {
     /// an `average` and a `HandType_` draws them the other way round from the
     /// same deal. `--round-robin` is a new mode with nothing to be compatible
     /// with, where a plain `-p` has dealer.exe behind it.
-    pub fn observe<'d>(
+    ///
+    /// `cache` is the caller's per-thread scratch, and the reason this takes
+    /// it rather than making one: a context that builds its own allocates, and
+    /// this builds up to three of them per produced deal. Emptied here, once,
+    /// so the three share what they work out — a value the `average`s need is
+    /// not worked out again for the hand types — and so nothing a previous deal
+    /// left behind can be read. `&mut` is what makes that a compile-time fact
+    /// rather than a discipline: see [`dealer_eval::VarCache`].
+    pub fn observe<'d, 'v>(
         &mut self,
         deal: &'d Deal,
-        variables: &'d Variables<'d>,
-        counts: Option<&'d PointCounts>,
+        variables: &'v Variables<'v>,
+        counts: Option<&'v PointCounts>,
         dd_tricks: &'d dealer_dds::DealTricks,
+        cache: &'d mut dealer_eval::VarCache<'v>,
     ) -> Result<Observed, RunError> {
+        let cache = cache.start_deal();
         if let Some(plan) = self.round_robin.clone() {
-            let hand_type = self.pick_hand_type(deal, variables, counts, dd_tricks)?;
+            let hand_type = self.pick_hand_type(deal, variables, counts, dd_tricks, cache)?;
             // Untyped deals are not wanted either: a round robin is a statement
             // about the categories, and a deal in none of them is in no round.
             //
@@ -530,8 +540,9 @@ impl<'a> RunAccumulator<'a> {
                     taken: false,
                 });
             }
-            let level_type = self.pick_level_type(hand_type, deal, variables, counts, dd_tricks)?;
-            self.accumulate_statistics(deal, variables, counts, dd_tricks)?;
+            let level_type =
+                self.pick_level_type(hand_type, deal, variables, counts, dd_tricks, cache)?;
+            self.accumulate_statistics(deal, variables, counts, dd_tricks, cache)?;
             self.count(hand_type, level_type);
             return Ok(Observed {
                 matched: Matched {
@@ -542,9 +553,10 @@ impl<'a> RunAccumulator<'a> {
             });
         }
 
-        self.accumulate_statistics(deal, variables, counts, dd_tricks)?;
-        let hand_type = self.pick_hand_type(deal, variables, counts, dd_tricks)?;
-        let level_type = self.pick_level_type(hand_type, deal, variables, counts, dd_tricks)?;
+        self.accumulate_statistics(deal, variables, counts, dd_tricks, cache)?;
+        let hand_type = self.pick_hand_type(deal, variables, counts, dd_tricks, cache)?;
+        let level_type =
+            self.pick_level_type(hand_type, deal, variables, counts, dd_tricks, cache)?;
         self.count(hand_type, level_type);
         Ok(Observed {
             matched: Matched {
@@ -556,17 +568,25 @@ impl<'a> RunAccumulator<'a> {
     }
 
     /// The `average` and `frequency` statements, over one taken deal.
-    fn accumulate_statistics<'d>(
+    fn accumulate_statistics<'d, 'v>(
         &mut self,
         deal: &'d Deal,
-        variables: &'d Variables<'d>,
-        counts: Option<&'d PointCounts>,
+        variables: &'v Variables<'v>,
+        counts: Option<&'v PointCounts>,
         dd_tricks: &'d dealer_dds::DealTricks,
+        cache: &'d dealer_eval::VarCache<'v>,
     ) -> Result<(), RunError> {
         if self.averages.is_empty() && self.frequencies.is_empty() {
             return Ok(());
         }
-        let ctx = EvalContext::for_deal(deal, variables, counts, self.vulnerability, dd_tricks);
+        let ctx = EvalContext::for_deal(
+            deal,
+            variables,
+            counts,
+            self.vulnerability,
+            dd_tricks,
+            cache,
+        );
         for average in self.averages.iter_mut() {
             let value = eval(average.expr, &ctx).map_err(|e| RunError::Eval {
                 what: "Average evaluation error".to_string(),
@@ -601,34 +621,50 @@ impl<'a> RunAccumulator<'a> {
         Ok(())
     }
 
-    fn pick_hand_type<'d>(
+    fn pick_hand_type<'d, 'v>(
         &self,
         deal: &'d Deal,
-        variables: &'d Variables<'d>,
-        counts: Option<&'d PointCounts>,
+        variables: &'v Variables<'v>,
+        counts: Option<&'v PointCounts>,
         dd_tricks: &'d dealer_dds::DealTricks,
+        cache: &'d dealer_eval::VarCache<'v>,
     ) -> Result<Option<usize>, RunError> {
         if self.hand_type_names.is_empty() {
             return Ok(None);
         }
-        let ctx = EvalContext::for_deal(deal, variables, counts, self.vulnerability, dd_tricks);
+        let ctx = EvalContext::for_deal(
+            deal,
+            variables,
+            counts,
+            self.vulnerability,
+            dd_tricks,
+            cache,
+        );
         pick(&self.hand_type_names, &ctx, deal, "Hand")
     }
 
     /// The levelling decomposition, which is usually the hand types — and then
     /// their counts serve for both, rather than classifying twice.
-    fn pick_level_type<'d>(
+    fn pick_level_type<'d, 'v>(
         &self,
         hand_type: Option<usize>,
         deal: &'d Deal,
-        variables: &'d Variables<'d>,
-        counts: Option<&'d PointCounts>,
+        variables: &'v Variables<'v>,
+        counts: Option<&'v PointCounts>,
         dd_tricks: &'d dealer_dds::DealTricks,
+        cache: &'d dealer_eval::VarCache<'v>,
     ) -> Result<Option<usize>, RunError> {
         if self.level_type_names.is_empty() {
             return Ok(hand_type);
         }
-        let ctx = EvalContext::for_deal(deal, variables, counts, self.vulnerability, dd_tricks);
+        let ctx = EvalContext::for_deal(
+            deal,
+            variables,
+            counts,
+            self.vulnerability,
+            dd_tricks,
+            cache,
+        );
         pick(&self.level_type_names, &ctx, deal, "Level")
     }
 
@@ -798,11 +834,10 @@ fn pick(
 ) -> Result<Option<usize>, RunError> {
     let mut matched: Option<usize> = None;
     for (i, name) in names.iter().enumerate() {
-        let value =
-            eval(&Expr::Variable((*name).to_string()), ctx).map_err(|e| RunError::Eval {
-                what: format!("{} type `{}` could not be evaluated", kind, name),
-                message: e.to_string(),
-            })?;
+        let value = dealer_eval::eval_variable(name, ctx).map_err(|e| RunError::Eval {
+            what: format!("{} type `{}` could not be evaluated", kind, name),
+            message: e.to_string(),
+        })?;
         if value != 0 {
             if let Some(first) = matched {
                 return Err(RunError::Overlap {
@@ -836,13 +871,20 @@ mod tests {
         let mut acc = RunAccumulator::new(program, stop, dealer_core::Vulnerability::default())
             .expect("accumulator");
         let mut generator = FastDealGenerator::new(20260829);
+        let mut cache = dealer_eval::VarCache::new();
         let mut matched = Vec::new();
         for _ in 0..count {
             let deal = generator.next_deal();
             matched.push(
-                acc.observe(&deal, &variables, None, &dealer_dds::NOTHING_KNOWN)
-                    .expect("observe")
-                    .matched,
+                acc.observe(
+                    &deal,
+                    &variables,
+                    None,
+                    &dealer_dds::NOTHING_KNOWN,
+                    &mut cache,
+                )
+                .expect("observe")
+                .matched,
             );
         }
         (acc, matched)
@@ -865,6 +907,79 @@ condition 1
         assert!(!stop.satisfied(&[]), "a script naming no categories");
         assert!(!stop.satisfied(&[5, 5, 1]), "one category still short");
         assert!(stop.satisfied(&[2, 9, 2]), "every category at the goal");
+    }
+
+    /// One scratch across a run must record exactly what a fresh one per deal
+    /// would.
+    ///
+    /// `observe` builds up to three contexts per deal and they now share one
+    /// cache, kept across deals so that classifying a levelled scenario stops
+    /// allocating per deal (#86). Getting the deal boundary wrong there would
+    /// not crash or even look odd: the counts would still add up, the
+    /// categories would still partition, and only the answers would be another
+    /// deal's. So this runs the same deals both ways and demands the same
+    /// numbers.
+    #[test]
+    fn one_scratch_across_deals_records_what_a_fresh_one_would() {
+        // Variables in all three places a deal's contexts read them: the hand
+        // types, the levelling types and the statistics.
+        let program = parse(
+            "\
+strength = hcp(north)
+shapely = shape(north, any 5431) + shape(north, any 4441)
+HandType_Weak = strength <= 9
+HandType_Middling = strength >= 10 and strength <= 14
+HandType_Strong = strength >= 15
+LevelType_Flat = shapely == 0
+LevelType_Odd = shapely > 0
+average \"strength\" strength
+frequency \"band\" (strength, 0, 37)
+condition 1
+",
+        );
+        let variables = extract_variables(&program);
+
+        let run = |per_deal: bool| {
+            let mut acc = RunAccumulator::new(
+                &program,
+                MeasureStop::standard(),
+                dealer_core::Vulnerability::default(),
+            )
+            .expect("accumulator");
+            let mut generator = FastDealGenerator::new(20260829);
+            let mut kept = dealer_eval::VarCache::new();
+            let mut matched = Vec::new();
+            for _ in 0..300 {
+                let deal = generator.next_deal();
+                let mut fresh = dealer_eval::VarCache::new();
+                let cache = if per_deal { &mut fresh } else { &mut kept };
+                matched.push(
+                    acc.observe(&deal, &variables, None, &dealer_dds::NOTHING_KNOWN, cache)
+                        .expect("observe")
+                        .matched,
+                );
+            }
+            let hand_types = acc.hand_type_counts().to_vec();
+            let levels = acc.leveling_counts().to_vec();
+            (matched, hand_types, levels, acc.finish())
+        };
+
+        let shared = run(false);
+        let fresh = run(true);
+        assert_eq!(shared.0, fresh.0, "a deal was classified differently");
+        assert_eq!(shared.1, fresh.1, "the hand-type counts differ");
+        assert_eq!(shared.2, fresh.2, "the levelling counts differ");
+        assert_eq!(
+            format!("{:?}", shared.3),
+            format!("{:?}", fresh.3),
+            "the averages or frequencies differ"
+        );
+        // And the deals really do disagree with each other, or none of the
+        // above could have failed.
+        assert!(
+            shared.1.iter().filter(|n| **n > 0).count() > 1,
+            "every deal landed in one band, so nothing was being compared"
+        );
     }
 
     #[test]
@@ -902,10 +1017,17 @@ condition 1
         )
         .expect("accumulator");
         let mut generator = FastDealGenerator::new(20260829);
+        let mut cache = dealer_eval::VarCache::new();
 
         let error = loop {
             let deal = generator.next_deal();
-            if let Err(e) = acc.observe(&deal, &variables, None, &dealer_dds::NOTHING_KNOWN) {
+            if let Err(e) = acc.observe(
+                &deal,
+                &variables,
+                None,
+                &dealer_dds::NOTHING_KNOWN,
+                &mut cache,
+            ) {
                 break e;
             }
         };
@@ -942,10 +1064,17 @@ condition 1
         )
         .expect("accumulator");
         let mut generator = FastDealGenerator::new(20260829);
+        let mut cache = dealer_eval::VarCache::new();
         while !acc.measure_satisfied() {
             let deal = generator.next_deal();
-            acc.observe(&deal, &variables, None, &dealer_dds::NOTHING_KNOWN)
-                .expect("observe");
+            acc.observe(
+                &deal,
+                &variables,
+                None,
+                &dealer_dds::NOTHING_KNOWN,
+                &mut cache,
+            )
+            .expect("observe");
             assert!(
                 acc.produced() < 10_000,
                 "should have stopped long before now"
@@ -1040,8 +1169,15 @@ condition 1
         let mut acc = RunAccumulator::new(program, MeasureStop::standard(), vulnerability)
             .expect("accumulator");
         let deal = one_suit_each();
-        acc.observe(&deal, &variables, None, &dealer_dds::NOTHING_KNOWN)
-            .expect("observe");
+        let mut cache = dealer_eval::VarCache::new();
+        acc.observe(
+            &deal,
+            &variables,
+            None,
+            &dealer_dds::NOTHING_KNOWN,
+            &mut cache,
+        )
+        .expect("observe");
         acc.finish().averages[0].value
     }
 

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -32,7 +32,7 @@ use dealer_core::{
     generate_deal_from_seed, generate_deal_from_seed_no_predeal, Deal, FastDealConfig,
     FastDealGenerator, SwapMode,
 };
-use dealer_eval::EvalError;
+use dealer_eval::{EvalError, VarCache};
 
 /// Which pass a progress report belongs to.
 ///
@@ -336,6 +336,20 @@ pub trait RunHost {
     fn produced(&mut self, deal: &Produced) -> Result<(), String>;
 }
 
+/// What one batch of dealing and testing is: how many deals, how many of them
+/// at a time, and how many variables a deal's scratch may have to hold.
+///
+/// Three numbers rather than three arguments, and the third is the odd one:
+/// it is not about the work but about the scratch that does it — zero means no
+/// script variable is ever cached, so nothing in a batch ever allocates and
+/// rayon is left to split it however it likes. See [`Workers::build_and_test`].
+#[derive(Clone, Copy)]
+struct Batch {
+    count: usize,
+    chunk: usize,
+    variables: usize,
+}
+
 /// The engine's threads, and how it maps work over a batch.
 ///
 /// A pool of its own where one can be had: rayon's global pool can only be
@@ -390,18 +404,26 @@ impl Workers {
     /// `tricks()` in a condition reaches the action that asks the same
     /// question later on the main thread: the answer travels with its deal
     /// rather than being looked up in a store keyed by cards (#61).
-    fn build_and_test(
+    ///
+    /// `test` is handed the scratch its context is built in, one per worker
+    /// rather than one per deal. A context that makes its own allocates the
+    /// moment a script mentions a variable, and on wasm — one dlmalloc behind
+    /// one lock — that allocation is what turned twelve threads into a
+    /// slow-down (#86). Emptied here, between the deal that was tested and the
+    /// next one, which is what a deal boundary means.
+    fn build_and_test<'v>(
         &self,
         start: usize,
         count: usize,
+        variables: usize,
         build: &(dyn Fn(usize) -> Deal + Sync),
-        test: &(dyn Fn(usize, &Deal) -> Result<bool, EvalError> + Sync),
+        test: &(dyn Fn(usize, &Deal, &VarCache<'v>) -> Result<bool, EvalError> + Sync),
         harvest: bool,
     ) -> Vec<Tested> {
-        let one = |offset: usize| {
+        let one = |cache: &mut VarCache<'v>, offset: usize| {
             let index = start + offset;
             let deal = build(index);
-            let passed = test(index, &deal);
+            let passed = test(index, &deal, cache.start_deal());
             let known = if harvest {
                 dealer_dds::learned(&deal)
             } else {
@@ -416,14 +438,51 @@ impl Workers {
         #[cfg(feature = "parallel")]
         {
             use rayon::prelude::*;
+            // `map_init` rather than `map`: rayon calls the initialiser once
+            // per piece of work it splits off, not once per item, so a piece
+            // builds one scratch and every deal in it re-uses that.
+            //
+            // With `with_min_len` to say how small a piece may get, and that is
+            // not a detail. Rayon splits adaptively: every steal lets it halve
+            // again, and deals are cheap enough that twelve workers steal
+            // constantly — measured on wasm, an unbounded split cut a batch of
+            // 2,400 into pieces of one or two, so a scratch was built about as
+            // often as a context used to be and the allocation came straight
+            // back: a one-variable script ran at 2.5M deals/s on twelve threads
+            // with no floor and 8.1M with one. Eight pieces per worker is
+            // enough to keep them fed — a batch's deals all cost the same, and
+            // the one pass whose deals do not comes through here 32 at a time,
+            // where this works out at 1.
+            let floor = || {
+                if variables == 0 {
+                    // Nothing is ever put in the scratch, so it never
+                    // allocates, so there is nothing to spread — and rayon's
+                    // own splitting balances a batch better than any floor. A
+                    // bare condition measured 29% slower on twelve wasm threads
+                    // with a floor it had no use for.
+                    return 1;
+                }
+                (count / (rayon::current_num_threads() * 8)).max(1)
+            };
             if let Some(pool) = &self.pool {
-                return pool.install(|| (0..count).into_par_iter().map(one).collect());
+                return pool.install(|| {
+                    (0..count)
+                        .into_par_iter()
+                        .with_min_len(floor())
+                        .map_init(VarCache::new, one)
+                        .collect()
+                });
             }
             if self.global {
-                return (0..count).into_par_iter().map(one).collect();
+                return (0..count)
+                    .into_par_iter()
+                    .with_min_len(floor())
+                    .map_init(VarCache::new, one)
+                    .collect();
             }
         }
-        (0..count).map(one).collect()
+        let mut cache = VarCache::new();
+        (0..count).map(|offset| one(&mut cache, offset)).collect()
     }
 
     /// The same, offered to a caller in pieces of `chunk`, with `between`
@@ -446,20 +505,31 @@ impl Workers {
     /// It cannot change what comes out: the work is a map from index to deal,
     /// collected in the order the indices were drawn, so where the pieces are
     /// cut changes when the threads are handed their work and nothing else.
-    fn build_and_test_in_chunks(
+    fn build_and_test_in_chunks<'v>(
         &self,
-        count: usize,
-        chunk: usize,
+        batch: Batch,
         build: &(dyn Fn(usize) -> Deal + Sync),
-        test: &(dyn Fn(usize, &Deal) -> Result<bool, EvalError> + Sync),
+        test: &(dyn Fn(usize, &Deal, &VarCache<'v>) -> Result<bool, EvalError> + Sync),
         harvest: bool,
         between: &mut dyn FnMut(usize),
     ) -> Vec<Tested> {
-        let mut built = self.build_and_test(0, chunk.min(count), build, test, harvest);
+        let Batch {
+            count,
+            chunk,
+            variables,
+        } = batch;
+        let mut built = self.build_and_test(0, chunk.min(count), variables, build, test, harvest);
         while built.len() < count {
             between(built.len());
             let from = built.len();
-            built.extend(self.build_and_test(from, chunk.min(count - from), build, test, harvest));
+            built.extend(self.build_and_test(
+                from,
+                chunk.min(count - from),
+                variables,
+                build,
+                test,
+                harvest,
+            ));
         }
         built
     }
@@ -511,6 +581,14 @@ pub struct Produced<'a> {
     /// categories do not cover every deal it produces.
     pub hand_type: Option<usize>,
     variables: &'a dealer_eval::Variables<'a>,
+    /// Scratch for the contexts this deal's reports are evaluated in.
+    ///
+    /// One per produced deal rather than one per context: a produced deal is
+    /// rare next to a generated one — a characterizing pass emits none at all —
+    /// so this is not the allocation #86 is about, and holding it here means
+    /// `printes` and `printrpt` over the same deal work a variable out once
+    /// between them.
+    cache: dealer_eval::VarCache<'a>,
     point_counts: Option<&'a dealer_eval::PointCounts>,
     reports: &'a Reports,
     vulnerability: dealer_core::Vulnerability,
@@ -539,19 +617,24 @@ pub struct Rows {
     pub csv: Vec<String>,
 }
 
-impl Produced<'_> {
+impl<'a> Produced<'a> {
     /// A fresh context over this deal, for a caller's own per-deal work.
     ///
     /// Fresh rather than shared for the reason contexts are built where they
     /// are everywhere else: where their boundaries fall is what a `rnd()` in
-    /// one draws against a `rnd()` in another.
-    pub fn context(&self) -> dealer_eval::EvalContext<'_> {
+    /// one draws against a `rnd()` in another. That is the `rnd()` stream,
+    /// which is still one per context. The variable values are this deal's
+    /// scratch, shared with every other context over the same deal — which
+    /// cannot move a `rnd()`, since a variable that can reach one is never
+    /// cached at all.
+    pub fn context(&self) -> dealer_eval::EvalContext<'_, 'a> {
         dealer_eval::EvalContext::for_deal(
             self.deal,
             self.variables,
             self.point_counts,
             self.vulnerability,
             self.dd_tricks,
+            &self.cache,
         )
     }
 
@@ -953,6 +1036,38 @@ fn pass_numbers(
     }
 }
 
+/// The condition, ready to be evaluated over a deal on any worker.
+///
+/// A function rather than a closure written where it is used, because the
+/// scratch's lifetime has to be *named*. `VarCache` is invariant in the
+/// lifetime of the names it caches, so a closure parameter written
+/// `cache: &VarCache` binds that lifetime higher-ranked along with the
+/// reference's — and a cache good for every lifetime is one whose script has to
+/// live for `'static`. Naming it here binds it to the script and leaves only
+/// the borrow itself per-call, which is what a worker lending its scratch one
+/// deal at a time needs.
+fn condition_tester<'v>(
+    constraint: Option<&'v dealer_parser::Expr>,
+    variables: &'v dealer_eval::Variables<'v>,
+    point_counts: Option<&'v dealer_eval::PointCounts>,
+    vulnerability: dealer_core::Vulnerability,
+) -> impl Fn(&dealer_dds::DealTricks, &Deal, &VarCache<'v>) -> Result<bool, EvalError> + Sync {
+    move |known: &dealer_dds::DealTricks, deal: &Deal, cache: &VarCache<'v>| match constraint {
+        Some(expr) => {
+            let ctx = dealer_eval::EvalContext::for_deal(
+                deal,
+                variables,
+                point_counts,
+                vulnerability,
+                known,
+                cache,
+            );
+            dealer_eval::eval(expr, &ctx).map(|value| value != 0)
+        }
+        None => Ok(true),
+    }
+}
+
 /// Deals a solving pass builds, tests or warms between progress reports.
 ///
 /// Chosen against the clock rather than the cache: a deal needing a
@@ -1054,21 +1169,17 @@ fn run_pass(
     // `index` is into the batch's handles, which is how a deal's table is found:
     // a supplied deal may have arrived already solved, and the condition should
     // read that rather than search for what the file already knew.
-    let test = |known: &dealer_dds::DealTricks, deal: &Deal| match constraint {
-        Some(expr) => {
-            let ctx = dealer_eval::EvalContext::for_deal(
-                deal,
-                &variables,
-                point_counts,
-                opts.vulnerability,
-                known,
-            );
-            dealer_eval::eval(expr, &ctx).map(|value| value != 0)
-        }
-        None => Ok(true),
-    };
+    // `cache` is the worker's scratch, emptied for this deal by
+    // `Workers::build_and_test` — see [`dealer_eval::VarCache`] for why holding
+    // one per worker rather than building one per context is the whole point.
+    let test = condition_tester(constraint, &variables, point_counts, opts.vulnerability);
 
     let workers = Workers::new(opts.threads);
+    // This thread's scratch for the contexts a produced deal is classified and
+    // counted in. One for the pass, not one per deal: `observe` empties it for
+    // each deal it is given, which is the only way to get at it. See
+    // [`dealer_eval::VarCache`].
+    let mut record_cache = VarCache::new();
     let mut retained = Retained::new(opts.retain);
     let mut produced = 0usize;
     let mut generated = 0usize;
@@ -1164,10 +1275,13 @@ fn run_pass(
         let batch_from_stream = from_stream;
         let phase = opts.phase;
         let built = workers.build_and_test_in_chunks(
-            handles.len(),
-            chunk,
+            Batch {
+                count: handles.len(),
+                chunk,
+                variables: variables.len(),
+            },
             &|index| source.build(handles[index]),
-            &|index, deal| test(known_at(&carried, index), deal),
+            &|index, deal, cache| test(known_at(&carried, index), deal, cache),
             dd_in_play,
             &mut |built_so_far| {
                 let so_far = if batch_from_stream {
@@ -1270,8 +1384,13 @@ fn run_pass(
             if !matched {
                 continue;
             }
-            let observed =
-                accumulator.observe(deal, &variables, point_counts, known_at(&known, index))?;
+            let observed = accumulator.observe(
+                deal,
+                &variables,
+                point_counts,
+                known_at(&known, index),
+                &mut record_cache,
+            )?;
             // Where the main thread does its own solving: an `average` over
             // `tricks()`, or an action asking for a cell the warm could not
             // read off the script, is searched right here, one deal at a time.
@@ -1312,6 +1431,7 @@ fn run_pass(
                     deal,
                     hand_type,
                     variables: &variables,
+                    cache: dealer_eval::VarCache::new(),
                     point_counts,
                     reports: &reports,
                     vulnerability: opts.vulnerability,


### PR DESCRIPTION
Closes #86. **This is what makes threading the browser worth doing** — and it
makes the command line 1.4–1.6x faster on real scripts along the way.

## The problem

`EvalContext` owned `cache: RefCell<FxHashMap<&str, i32>>`, built fresh in
`for_deal` and allocating on the first variable insert. A deal builds up to five
contexts, so a script with variables allocated repeatedly per deal — and on wasm
the allocator is one dlmalloc behind one lock, so threads queued on it.

## The result

**wasm, 12 threads against 1** (Chromium, COOP/COEP):

| script | main | this branch |
|---|---|---|
| `condition hcp(north) >= 20` | 4.07x | 3.97x |
| `x = hcp(north)` | **0.27x** | **3.49x** |
| Jacoby 2NT, a real scenario | **0.41x** | **5.81x** |

Every script now gains from threads; nothing loses. The gating rule #85 needed
would no longer be necessary — but nothing was removed here, that is #20's
business.

**CLI**, best-of-9 interleaved, measured independently of the agent that wrote
it:

| | main | branch | |
|---|---|---|---|
| bare condition, 3M deals | 0.454s | 0.451s | **1.00x** |
| Major_Suit_Fit (165 vars) | 0.159s | 0.113s | **1.41x** |
| Drury (121 vars) | 1.830s | 1.143s | **1.60x** |

The cheap script is flat, which is the one that had to be.

## The deal boundary is enforced by the compiler

The only way to obtain a `&VarCache` is `start_deal(&mut self) -> &Self`, which
clears first. The `&mut` reborrow keeps every context built from one deal's loan
alive exactly as long as that loan, so a second `start_deal` cannot happen while
a stale context exists, and no context can exist without one having cleared.
**Forgetting to clear is a compile error**, not a discipline.

That matters because the failure it prevents is silent: a stale entry crossing a
deal boundary gives plausible wrong answers with every other test green.
Verified by hand — removing the `clear()` fails
`a_reused_scratch_does_not_carry_a_value_across_a_deal` and nothing else.

Output is byte-identical to `main` across 9 combinations of script and thread
count, checked independently, plus the 27 comparisons the implementing agent ran.

## Two more per-deal allocations found by measuring

- **Rayon splits adaptively**, and cheap deals mean constant stealing — an
  unbounded split cut a 2,400-deal batch into pieces of one or two, rebuilding
  the scratch about as often as the old code rebuilt the context. A floor of 8
  pieces per worker took 2.5M deals/s to 8.1M on 12 wasm threads. The floor is
  lifted when a script has no variables, which measured 29% slower with a floor
  it could not use.
- **`Hand::cards_in_suit` returned a `Vec`**, and `hcp(pos, suit)` called it per
  deal. Summing over the hand instead took Jacoby 2NT from 0.58 to 2.16 M/s at
  12 threads, and barely moved one thread — which is the whole story about the
  lock.

## Left for later

Resolving variable names to indices at parse time and making the scratch a flat
`Vec`, as #86 describes. Not done, deliberately. `VarCache` owns its
representation and nothing outside it looks in, so that becomes a change to one
type plus the parser.

Gate: fmt, clippy both flag sets, 45 Rust suites, 22 wasm tests, `verify.mjs`
17/17 against the CLI, `library-check.mjs`, 201 web tests, `build:all`, and
`build.sh threaded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)