### PR TITLE
Solve what the run asked for, not what the batch happened to hold

### DIFF
--- a/dealer-run/src/dd_demand.rs
+++ b/dealer-run/src/dd_demand.rs
@@ -126,6 +126,22 @@ impl DdDemand {
 /// Used to keep the carrying off the hot path entirely: for the great majority
 /// of scripts, which never mention double-dummy, there is nothing to carry and
 /// this says so once for the whole run rather than forty bytes a deal.
+/// Does testing a deal against this program's condition reach the solver?
+///
+/// Narrower than [`touches_solver`], and it answers a different question: not
+/// "will this run solve" but "does each deal cost a search *before* we know
+/// whether it matched". A `tricks()` in an action is paid only by deals that
+/// matched, and can be warmed on the pool in whatever quantity is wanted; a
+/// `tricks()` in the condition is paid by every deal built, which is what makes
+/// the size of a batch matter.
+pub fn condition_touches_solver(program: &Program) -> bool {
+    let mut demand = DdDemand::None;
+    if let Some(constraint) = dealer_eval::extract_constraint(program) {
+        walk(constraint, program, &mut demand, &mut HashSet::new());
+    }
+    !demand.is_none()
+}
+
 pub fn touches_solver(program: &Program) -> bool {
     let mut demand = DdDemand::None;
     if let Some(constraint) = dealer_eval::extract_constraint(program) {

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -1343,6 +1343,26 @@ fn run_pass(
         // read. That exclusion is invisible in the output, since the solver
         // agrees with what is already known, so it shows up only as time.
         if !dd_demand.is_none() {
+            // Only as many as this pass can still use. A batch is at least
+            // 1024 deals and 200 a thread, so a run asking for a hundred builds
+            // two thousand four hundred — fine when a deal costs a microsecond,
+            // and the difference between two seconds and twenty when each one
+            // is a double-dummy search. The deals past the target are never
+            // walked, so solving them buys nothing at all.
+            //
+            // Only a plain producing pass has a target to count against.
+            // Characterizing runs until it has seen enough or the clock stops
+            // it. And a round robin turns matches away when their round is
+            // full, so `produced` is behind the number of matches this batch
+            // will walk — capping by it would leave the rest to be solved one
+            // at a time on this thread, which is slower than solving too many
+            // on the pool.
+            let counts_every_match = !opts.until_measured && opts.round_robin.is_none();
+            let still_wanted = if counts_every_match {
+                opts.produce.saturating_sub(produced)
+            } else {
+                usize::MAX
+            };
             let wanted: Vec<usize> = built
                 .iter()
                 .enumerate()
@@ -1350,6 +1370,7 @@ fn run_pass(
                     matches!(tested.passed, Ok(true)) && !dd_demand.satisfied_by(&known[*index])
                 })
                 .map(|(index, _)| index)
+                .take(still_wanted)
                 .collect();
             if wanted.len() > 1 {
                 // A chunk at a time while the pass is solving, for the reason
@@ -1488,12 +1509,42 @@ fn run_pass(
 ///
 /// With `produce` at zero nothing is dealt from the levelling, which is what a
 /// caller writing the scenario out and stopping there wants.
+/// Does this script's condition reach the solver, so far as can be told before
+/// the run proper parses it?
+///
+/// Only the batch size depends on this, and only as a choice between two
+/// reasonable sizes — so a script that will not parse answers `false` and takes
+/// the ordinary batch. The parse that matters happens below and reports the
+/// error properly; failing here would report it twice, in the wrong words.
+fn condition_solves(script: &str, params: &dealer_parser::ScriptParams) -> bool {
+    dealer_parser::preprocess_all(script, params)
+        .ok()
+        .and_then(|text| dealer_parser::parse_program(&text).ok())
+        .is_some_and(|program| crate::dd_demand::condition_touches_solver(&program))
+}
+
 pub fn run(script: &str, opts: RunOptions, host: &mut dyn RunHost) -> Result<RunReport, RunError> {
     let threads = resolve_threads(opts.threads);
     // Enough work per hand-off that the hand-off is not the expensive part, and
     // little enough that a caller answering to a clock is asked often.
+    //
+    // Both halves of that assume a deal is cheap. When the *condition* solves,
+    // one is about five orders of magnitude dearer — hundreds of nanoseconds
+    // becomes tens of milliseconds — and a batch sized for the cheap case
+    // solves two thousand four hundred deals to answer `produce 5`. The
+    // handles are drawn before any of them is tested, so the surplus cannot be
+    // abandoned once enough have matched: that would skip deals the next batch
+    // should have seen, and change which deals a seed produces.
+    //
+    // So the batch is drawn small instead. At tens of milliseconds a deal the
+    // hand-off is free by comparison, and a selective filter simply takes more
+    // batches — each one still spread across every thread.
     let batch = if opts.batch == 0 {
-        (200 * threads).clamp(1024, 65_536)
+        if condition_solves(script, &opts.params) {
+            (2 * threads).clamp(16, 256)
+        } else {
+            (200 * threads).clamp(1024, 65_536)
+        }
     } else {
         opts.batch
     };

--- a/dealer-run/tests/dd_answers_travel.rs
+++ b/dealer-run/tests/dd_answers_travel.rs
@@ -10,6 +10,19 @@
 //! for this.
 
 use dealer_core::Deal;
+use std::sync::{Mutex, MutexGuard};
+
+/// `dealer_dds::searches()` is one counter for the process, and cargo runs
+/// these tests on threads of the same process — so a bracket around one test
+/// counts another's searches too. Every test here takes this first.
+///
+/// Found the hard way: adding a third test made an existing one fail while
+/// each passed alone.
+static ONE_AT_A_TIME: Mutex<()> = Mutex::new(());
+
+fn alone() -> MutexGuard<'static, ()> {
+    ONE_AT_A_TIME.lock().unwrap_or_else(|e| e.into_inner())
+}
 use dealer_run::{Deals, Produced, RunHost, RunOptions};
 
 /// Keeps what `printrpt` rendered, which is where the trick counts appear.
@@ -68,6 +81,7 @@ fn run(deals: Vec<dealer_run::run::SolvedDeal>) -> (Vec<String>, usize) {
 
 #[test]
 fn a_supplied_table_is_read_rather_than_solved() {
+    let _alone = alone();
     let deals = deals();
 
     // Solved straight through `bridge_solver`, so these searches are not
@@ -112,6 +126,7 @@ fn a_supplied_table_is_read_rather_than_solved() {
 /// must cost one search, not two.
 #[test]
 fn an_answer_found_testing_a_deal_is_not_searched_for_again() {
+    let _alone = alone();
     const DEALS: usize = 16;
 
     let before = dealer_dds::searches();
@@ -145,5 +160,59 @@ fn an_answer_found_testing_a_deal_is_not_searched_for_again() {
         DEALS,
         "one search a deal: {searched} means the answer was found {} times over",
         searched as f64 / DEALS as f64
+    );
+}
+
+/// A run asking for a few deals must not solve a batch of them.
+///
+/// The batch is at least 1024 deals and 200 a thread, which is right when a
+/// deal costs a microsecond and absurd when it costs twenty milliseconds: a
+/// `produce 5` used to solve two thousand four hundred boards to hand back
+/// five. Nothing in the output says so — the five are correct either way — so
+/// the witness is the search counter.
+#[test]
+fn a_small_run_does_not_solve_a_whole_batch() {
+    let _alone = alone();
+    struct Sink;
+    impl RunHost for Sink {
+        fn produced(&mut self, _: &Produced) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    // The action solves, so every deal taken needs one answer and no deal
+    // beyond the target needs any.
+    let script = "condition 1\naction average \"t\" tricks(north, notrump)\n";
+    let before = dealer_dds::searches();
+    let report = dealer_run::run(
+        script,
+        RunOptions {
+            vulnerability: dealer_core::Vulnerability::None,
+            seed: 1,
+            produce: 4,
+            max_generate: 1_000_000,
+            deals: Deals::Shuffled {
+                predeal: dealer_core::FastDealConfig::new(),
+                swap: dealer_core::SwapMode::None,
+            },
+            leveling: None,
+            round_robin: false,
+            threads: 1,
+            batch: 0,
+            params: Default::default(),
+        },
+        &mut Sink,
+    )
+    .expect("run");
+    let searched = dealer_dds::searches() - before;
+
+    assert_eq!(
+        report.produced, 4,
+        "the run should still produce what it was asked for"
+    );
+    assert!(
+        searched <= 16,
+        "asking for 4 deals searched {searched} times — a batch's worth rather \
+         than a run's"
     );
 }


### PR DESCRIPTION
`produce 100` on the demo double-dummy script took **19 seconds** in the browser
where the warning promised two. The warning was not wrong about what a solve
costs — it was wrong about how many the engine would do.

## What was happening

A batch is at least 1024 deals and 200 a thread, sized for a deal costing about
a microsecond, which is right for almost every script. A deal needing a
double-dummy table costs about **twenty milliseconds** — five orders of
magnitude more — and the batch does not know. So on twelve threads `produce 100`
solved 2,400 boards to hand back a hundred, and `produce 5` solved 2,400 to hand
back five.

Measured on `main`, which shows the shape of a cost that has nothing to do with
what was asked:

| produce | 100 | 500 | 1024 | 2048 |
|---|---|---|---|---|
| time | 12.32s | 12.34s | 12.30s | 12.30s |

## Two changes, because the two shapes fail differently

**A solving action** — warm only as many matched deals as the pass can still
take. Deals past the target are never walked, so solving them buys nothing.

| produce | main | branch | |
|---|---|---|---|
| 100 | 12.32s | **0.36s** | 34x |
| 500 | 12.34s | 2.29s | 5.4x |
| 2048 | 12.30s | 10.62s | 1.16x |
| 5000 | 36.21s | 24.99s | 1.45x |

The gain shrinks to nothing as the request approaches a batch, which is right.

Not applied when characterizing, which has no target and takes every match; nor
under a round robin, which turns matches away when their round is full, so
`produced` lags the number this batch will walk — capping there would leave the
rest to be solved one at a time on the main thread, slower than solving too many
on the pool.

**A solving condition** — draw a smaller batch. The cap cannot help here: the
handles are drawn *before* any deal is tested, and the surplus cannot be
abandoned once enough have matched, because that would skip deals the next batch
should have seen and change which deals a seed produces. At tens of milliseconds
a deal the hand-off is free, so a solving condition takes 2 deals a thread
rather than 200 and a selective filter simply takes more batches.

`produce 5` on a `tricks()` condition: **9.09s → 0.09s**.

## Nothing else moves

A plain script over three million deals: 0.233s against 0.223s. Output
byte-identical across both script shapes, thread counts 1/4/12, and a levelled
run.

## The test

On `dealer_dds::searches()`, because nothing in the output shows this — the
deals are right either way and only the clock knows. Remove the cap and it says
`asking for 4 deals searched 1024 times`, taking 153 seconds to do it.

It also needed a mutex around the three tests in that file: the search counter is
one per process and cargo runs them on threads of it, so adding a third test made
an existing one fail while each passed alone.

Gate: fmt, clippy both flag sets, 45 Rust suites, 22 wasm tests, `verify.mjs`
17/17, `library-check.mjs`, 208 web tests, `build:all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)