### PR TITLE
Deploy on any engine change, and let the weekly check reach its build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'dealer-core/**'
-      - 'dealer-parser/**'
-      - 'dealer-eval/**'
-      - 'dealer-pbn/**'
-      - 'dealer-dds/**'
+      # Every workspace crate, by glob rather than by name. The list used to be
+      # written out, and it was missing `dealer-run` — the crate that owns the
+      # generate loop, and so the one the site depends on most. An engine change
+      # would pass CI, merge, and never reach the site; the deploy was not
+      # failing, it was not running, which is far quieter. A glob cannot fall
+      # behind a crate nobody remembered to add.
+      - 'dealer*/**'
       - 'wasm/**'
       - 'web/**'
       - 'Cargo.toml'

--- a/.github/workflows/threaded-build.yml
+++ b/.github/workflows/threaded-build.yml
@@ -93,6 +93,21 @@ jobs:
         with:
           workspaces: wasm
 
+      # `build.sh` drives `wasm-pack`, so the runner needs one. This step was
+      # missing when the workflow was written — it took the wasm-bindgen step
+      # from `pages.yml` and not the one below it — and the first scheduled run
+      # died on "wasm-pack not found" before reaching anything it was built to
+      # check.
+      #
+      # PINNED, not `latest`, for the reason spelled out in `pages.yml`: the
+      # action resolves `latest` through the GitHub API and, when that call
+      # fails, quietly falls back to v0.9.1, whose wasm-opt cannot parse what
+      # wasm-bindgen emits.
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'v0.15.0'
+
       # Failure here is the build itself: the crate, the standard library
       # rebuild, or the bindgen step refusing what the toolchain emitted.
       - name: Build it


### PR DESCRIPTION
Two CI guards that were not guarding. Both surfaced today.

## The site did not deploy #91

`pages.yml`'s `on.push.paths` listed workspace crates by name, and the list was four short:

| | |
|---|---|
| ✓ | `dealer-core` `dealer-parser` `dealer-pbn` `dealer-eval` `dealer-dds` |
| ✗ | `dealer-level` `dealer-run` `dealer` |

`dealer-run` owns the generate loop — per CLAUDE.md it is the crate both front ends run on, so it is the one the site depends on most. #91 changed only `dealer-run/`, so the deploy never fired and the live page kept the old batch sizing. Every engine-only change since that filter was written has been in the same position.

This is the failure mode this repo keeps producing: nothing went red. There was no failed deploy to notice, only an absent one, and it was caught by hand because the fix was visibly missing from the page.

Replaced with `dealer*/**`, which matches all eight crates today and any crate added later.

## The weekly threaded check never got to the build

`threaded-build.yml` was written by lifting the wasm-bindgen setup out of `pages.yml`, and stopped one step too early — `pages.yml` installs `wasm-pack` right after, and `build.sh` drives `wasm-pack`. The first scheduled run failed at:

```
Error: wasm-pack not found.
```

before reaching either of the two kinds of rot the workflow exists to catch. Added the install, pinned to `v0.15.0` for the reason `pages.yml` already documents at length.

## Verification

- Both files parse.
- `dealer*/**` checked against all eight workspace crate directories.
- The threaded workflow is run manually on this branch once merged; the Pages deploy for `5fb1104` was already forced through by `workflow_dispatch` so the site is current in the meantime.

No source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)