### PR TITLE
Fetch a round's library pieces together, not one after another

### DIFF
--- a/web/src/lib/library.js
+++ b/web/src/lib/library.js
@@ -29,7 +29,7 @@
 /// Versioned in the name so a change of shape is a new store rather than a
 /// migration. A piece never changes — `rpdd-042.zdd` is the same 640 KiB
 /// forever — so nothing here expires.
-export const CACHE_NAME = 'dealer3-library-v1'
+export const CACHE_NAME = "dealer3-library-v1";
 
 /// The most deals one run will ask the library for.
 ///
@@ -41,13 +41,13 @@ export const CACHE_NAME = 'dealer3-library-v1'
 /// It bounds how selective a filter the library can satisfy, and the run report
 /// says how many deals were actually read, so a script that filters harder than
 /// this can see that it ran out of deals rather than out of matches.
-export const MAX_LIBRARY_DEALS = 65536
+export const MAX_LIBRARY_DEALS = 65536;
 
 /// Pieces held in memory at once, beyond which the oldest is dropped.
 ///
 /// Each is 640 KiB of tables. The browser's cache still has them, so dropping
 /// one costs a cache read rather than a fetch.
-const MEMORY_PIECES = 8
+const MEMORY_PIECES = 8;
 
 /// How many ask/supply rounds before something is wrong.
 ///
@@ -55,7 +55,7 @@ const MEMORY_PIECES = 8
 /// slack; a fourth means the library is asking for something it is never
 /// satisfied by, and looping for ever on a network resource is worse than
 /// failing.
-const MAX_ROUNDS = 4
+const MAX_ROUNDS = 4;
 
 /**
  * How many deals to ask the library for.
@@ -68,9 +68,17 @@ const MAX_ROUNDS = 4
  * At least `produce`, so that asking for more deals than the budget is a short
  * run reported honestly rather than a request refused.
  */
-export function dealsToRequest({ produce = 1, maxGenerate = 0, totalDeals = 0 } = {}) {
-  const wanted = Math.max(1, Math.min(maxGenerate || MAX_LIBRARY_DEALS, MAX_LIBRARY_DEALS), produce)
-  return totalDeals > 0 ? Math.min(wanted, totalDeals) : wanted
+export function dealsToRequest({
+  produce = 1,
+  maxGenerate = 0,
+  totalDeals = 0,
+} = {}) {
+  const wanted = Math.max(
+    1,
+    Math.min(maxGenerate || MAX_LIBRARY_DEALS, MAX_LIBRARY_DEALS),
+    produce,
+  );
+  return totalDeals > 0 ? Math.min(wanted, totalDeals) : wanted;
 }
 
 /**
@@ -95,71 +103,73 @@ export function dealsToRequest({ produce = 1, maxGenerate = 0, totalDeals = 0 } 
  * @returns {(url: string) => Promise<Uint8Array>}
  */
 export function createLibraryFetcher({
-  manifestUrl = '',
+  manifestUrl = "",
   fetchImpl = undefined,
   cacheStorage = undefined,
   cacheName = CACHE_NAME,
 } = {}) {
-  const doFetch = fetchImpl || ((url) => globalThis.fetch(url))
-  const storage = cacheStorage === undefined ? globalThis.caches : cacheStorage
-  const memory = new Map()
-  let opening = null
+  const doFetch = fetchImpl || ((url) => globalThis.fetch(url));
+  const storage = cacheStorage === undefined ? globalThis.caches : cacheStorage;
+  const memory = new Map();
+  let opening = null;
 
   // Opened once and never re-attempted: a browser that refuses the cache once
   // refuses it every time, and asking again per piece would be a rejected
   // promise per fetch.
   const store = () => {
-    if (!storage) return Promise.resolve(null)
-    if (!opening) opening = Promise.resolve(storage.open(cacheName)).catch(() => null)
-    return opening
-  }
+    if (!storage) return Promise.resolve(null);
+    if (!opening)
+      opening = Promise.resolve(storage.open(cacheName)).catch(() => null);
+    return opening;
+  };
 
   const remember = (url, bytes) => {
-    memory.set(url, bytes)
+    memory.set(url, bytes);
     while (memory.size > MEMORY_PIECES) {
-      const oldest = memory.keys().next().value
-      if (oldest === undefined) break
-      memory.delete(oldest)
+      const oldest = memory.keys().next().value;
+      if (oldest === undefined) break;
+      memory.delete(oldest);
     }
-    return bytes
-  }
+    return bytes;
+  };
 
   return async function piece(url) {
-    const held = memory.get(url)
-    if (held) return held
+    const held = memory.get(url);
+    if (held) return held;
 
-    const persist = url !== manifestUrl
-    const cache = persist ? await store() : null
+    const persist = url !== manifestUrl;
+    const cache = persist ? await store() : null;
     if (cache) {
-      const hit = await cache.match(url).catch(() => null)
-      if (hit && hit.ok) return remember(url, new Uint8Array(await hit.arrayBuffer()))
+      const hit = await cache.match(url).catch(() => null);
+      if (hit && hit.ok)
+        return remember(url, new Uint8Array(await hit.arrayBuffer()));
     }
 
-    let response
+    let response;
     try {
-      response = await doFetch(url)
+      response = await doFetch(url);
     } catch (e) {
       // A network failure reads as "Failed to fetch", which says nothing about
       // what was being fetched or why the page wanted it.
       throw new Error(
         `Could not reach the solved-deal library at ${url} (${e?.message || e}). ` +
-          'Check the connection, or switch back to random deals.',
-      )
+          "Check the connection, or switch back to random deals.",
+      );
     }
     if (!response.ok) {
       throw new Error(
         `The solved-deal library answered HTTP ${response.status} for ${url}. ` +
-          'Switch back to random deals, or try again.',
-      )
+          "Switch back to random deals, or try again.",
+      );
     }
-    const buffer = await response.arrayBuffer()
+    const buffer = await response.arrayBuffer();
     if (cache) {
       // Failing to cache is not failing to fetch: a full quota should cost a
       // refetch next time, not the run.
-      await cache.put(url, new Response(buffer)).catch(() => {})
+      await cache.put(url, new Response(buffer)).catch(() => {});
     }
-    return remember(url, new Uint8Array(buffer))
-  }
+    return remember(url, new Uint8Array(buffer));
+  };
 }
 
 /**
@@ -177,18 +187,22 @@ export function createLibraryFetcher({
  * @returns {Promise<number>} how many deals the library holds
  */
 export async function learnLibrarySize(lib, fetchPiece, onProgress) {
-  for (let round = 0; lib.total_deals === undefined && round < MAX_ROUNDS; round++) {
-    const [url] = lib.needs(0, 1)
-    if (!url) break
-    onProgress?.({ stage: 'manifest', done: 0, total: 1, url })
-    lib.supply(url, await fetchPiece(url))
+  for (
+    let round = 0;
+    lib.total_deals === undefined && round < MAX_ROUNDS;
+    round++
+  ) {
+    const [url] = lib.needs(0, 1);
+    if (!url) break;
+    onProgress?.({ stage: "manifest", done: 0, total: 1, url });
+    lib.supply(url, await fetchPiece(url));
   }
   if (lib.total_deals === undefined) {
     throw new Error(
       `The library at ${lib.manifest_url} did not say how many deals it holds.`,
-    )
+    );
   }
-  return lib.total_deals
+  return lib.total_deals;
 }
 
 /**
@@ -197,29 +211,57 @@ export async function learnLibrarySize(lib, fetchPiece, onProgress) {
  * The loop is the protocol from `docs/WASM.md`: ask what is missing, fetch it,
  * hand it back, ask again. A piece already held — from an earlier run, or from
  * the cache — is not asked for, which is what makes a second run over the same
- * region free.
+ * region free. What a round asks for, it fetches all at once; the rounds are
+ * sequential because each depends on the last, but the pieces within one do
+ * not depend on each other.
  *
  * @returns {Promise<{fetched: number}>} how many pieces this call had to get
  */
-export async function supplyLibraryPieces(lib, firstDeal, count, { fetchPiece, onProgress } = {}) {
-  let fetched = 0
+export async function supplyLibraryPieces(
+  lib,
+  firstDeal,
+  count,
+  { fetchPiece, onProgress } = {},
+) {
+  let fetched = 0;
   for (let round = 0; round < MAX_ROUNDS; round++) {
-    const needed = lib.needs(firstDeal, count)
-    if (!needed.length) return { fetched }
-    for (let i = 0; i < needed.length; i++) {
-      onProgress?.({ stage: 'pieces', done: i, total: needed.length, url: needed[i] })
-      lib.supply(needed[i], await fetchPiece(needed[i]))
-      fetched++
-    }
-    onProgress?.({ stage: 'pieces', done: needed.length, total: needed.length })
+    const needed = lib.needs(firstDeal, count);
+    if (!needed.length) return { fetched };
+
+    // Together, not one after another. The round already knows every URL it
+    // wants before it asks for any of them, so awaiting them in turn spends a
+    // round trip per piece for nothing — and this is never one piece: a run of
+    // 100,000 deals is more than the 65,536 a piece holds, so it always
+    // straddles a boundary, and a cold fetch was paying both waits end to end.
+    let done = 0;
+    onProgress?.({ stage: "pieces", done, total: needed.length });
+    const arrived = await Promise.all(
+      needed.map(async (url) => {
+        const bytes = await fetchPiece(url);
+        // Counted as they land, so the count still only goes up even though
+        // the pieces may arrive in any order.
+        onProgress?.({
+          stage: "pieces",
+          done: ++done,
+          total: needed.length,
+          url,
+        });
+        return bytes;
+      }),
+    );
+
+    // Handed over in the order asked for rather than the order they arrived,
+    // so what the library is given does not depend on what the network did.
+    needed.forEach((url, i) => lib.supply(url, arrived[i]));
+    fetched += needed.length;
   }
   throw new Error(
-    'The solved-deal library kept asking for more pieces than it could use; ' +
-      'nothing was read. This is a bug — please report it.',
-  )
+    "The solved-deal library kept asking for more pieces than it could use; " +
+      "nothing was read. This is a bug — please report it.",
+  );
 }
 
-const count = (n) => Number(n || 0).toLocaleString()
+const count = (n) => Number(n || 0).toLocaleString();
 
 /**
  * What to say about the deals a run read.
@@ -235,57 +277,57 @@ const count = (n) => Number(n || 0).toLocaleString()
  * @returns {{summary: string, warnings: string[]}}
  */
 export function describeInput(input, library = null) {
-  if (!input) return { summary: '', warnings: [] }
+  if (!input) return { summary: "", warnings: [] };
 
-  const solved = input.solved || 0
-  const read = input.read || 0
+  const solved = input.solved || 0;
+  const read = input.read || 0;
   const where =
     library && library.totalDeals
       ? ` from the solved-deal library, starting at deal ${count(library.firstDeal)} of ${count(
           library.totalDeals,
         )}`
-      : ''
+      : "";
   const tables =
     read > 0 && solved === read
-      ? ' Every one arrived with its double-dummy table, so tricks(), dds() and par() were lookups rather than searches.'
+      ? " Every one arrived with its double-dummy table, so tricks(), dds() and par() were lookups rather than searches."
       : solved > 0
         ? ` ${count(solved)} of them arrived with double-dummy tables.`
-        : ' None of them came with double-dummy tables.'
-  const summary = `Read ${count(read)} deal${read === 1 ? '' : 's'}${where}.${tables}`
+        : " None of them came with double-dummy tables.";
+  const summary = `Read ${count(read)} deal${read === 1 ? "" : "s"}${where}.${tables}`;
 
-  const warnings = []
-  const requested = library?.requested
+  const warnings = [];
+  const requested = library?.requested;
   if (requested && read < requested) {
     warnings.push(
       `Asked for ${count(requested)} deals and read ${count(read)}. ` +
-        'The run had fewer deals to filter than it expected, so a short result here ' +
-        'is not necessarily a selective condition.',
-    )
+        "The run had fewer deals to filter than it expected, so a short result here " +
+        "is not necessarily a selective condition.",
+    );
   }
   if (input.unsolved) {
     warnings.push(
-      `${count(input.unsolved)} deal${input.unsolved === 1 ? '' : 's'} arrived without a ` +
-        'double-dummy table and will be solved on demand, which is the slow path this ' +
-        'library exists to avoid.',
-    )
+      `${count(input.unsolved)} deal${input.unsolved === 1 ? "" : "s"} arrived without a ` +
+        "double-dummy table and will be solved on demand, which is the slow path this " +
+        "library exists to avoid.",
+    );
   }
   if (library?.totalDeals && requested >= library.totalDeals) {
     warnings.push(
       `This run read the whole library (${count(library.totalDeals)} deals). ` +
-        'A longer one would come round to deals it has already seen, and average and ' +
-        'frequency would count them twice.',
-    )
+        "A longer one would come round to deals it has already seen, and average and " +
+        "frequency would count them twice.",
+    );
   }
   if (input.skipped_count) {
-    const reasons = (input.skipped || []).slice(0, 3).join('; ')
+    const reasons = (input.skipped || []).slice(0, 3).join("; ");
     warnings.push(
-      `${count(input.skipped_count)} record${input.skipped_count === 1 ? '' : 's'} could not ` +
-        `be read${reasons ? `: ${reasons}` : ''}. The deals around them were still read.`,
-    )
+      `${count(input.skipped_count)} record${input.skipped_count === 1 ? "" : "s"} could not ` +
+        `be read${reasons ? `: ${reasons}` : ""}. The deals around them were still read.`,
+    );
   }
-  for (const note of input.notes || []) warnings.push(note)
+  for (const note of input.notes || []) warnings.push(note);
 
-  return { summary, warnings }
+  return { summary, warnings };
 }
 
 /**
@@ -299,10 +341,12 @@ export function describeInput(input, library = null) {
  * @returns {string} empty once there is nothing left to fetch
  */
 export function libraryStatusText(status) {
-  if (!status) return ''
-  if (status.stage === 'manifest') return "Reading the solved-deal library's index…"
-  if (status.done >= status.total) return 'Running the script over the library\u2019s deals…'
-  return `Fetching the solved-deal library — piece ${status.done + 1} of ${status.total}…`
+  if (!status) return "";
+  if (status.stage === "manifest")
+    return "Reading the solved-deal library's index…";
+  if (status.done >= status.total)
+    return "Running the script over the library\u2019s deals…";
+  return `Fetching the solved-deal library — piece ${status.done + 1} of ${status.total}…`;
 }
 
 /**
@@ -317,12 +361,12 @@ export function libraryStatusText(status) {
  * @returns {string} empty when there is nothing worth saying
  */
 export function pointlessLibraryWarning(usesDoubleDummy) {
-  if (usesDoubleDummy !== false) return ''
+  if (usesDoubleDummy !== false) return "";
   return (
-    'This script never calls tricks(), dds() or par(), so pre-solved deals buy it ' +
-    'nothing — it will download the library and use none of the answers. Random deals ' +
-    'will be faster.'
-  )
+    "This script never calls tricks(), dds() or par(), so pre-solved deals buy it " +
+    "nothing — it will download the library and use none of the answers. Random deals " +
+    "will be faster."
+  );
 }
 
 /// About how long one double-dummy search takes here, in milliseconds.
@@ -331,7 +375,7 @@ export function pointlessLibraryWarning(usesDoubleDummy) {
 /// `par()` reach. Deliberately a round number: it is an order of magnitude for
 /// someone deciding between a download and a wait, not a promise, and it is
 /// five orders of magnitude above what a deal costs otherwise.
-export const SOLVE_MS = 23
+export const SOLVE_MS = 23;
 
 /**
  * What to say to someone who chose random deals for a script that does ask a
@@ -352,15 +396,18 @@ export const SOLVE_MS = 23
  * @returns {string} empty when there is nothing worth saying
  */
 export function slowRandomWarning(usesDoubleDummy, produce) {
-  if (usesDoubleDummy !== true) return ''
-  const deals = Number.isFinite(produce) && produce > 0 ? Math.floor(produce) : 0
-  const cost = deals ? ` — at least ${deals} × ${SOLVE_MS} ms, so about ${humanSeconds(deals * SOLVE_MS)}` : ''
+  if (usesDoubleDummy !== true) return "";
+  const deals =
+    Number.isFinite(produce) && produce > 0 ? Math.floor(produce) : 0;
+  const cost = deals
+    ? ` — at least ${deals} × ${SOLVE_MS} ms, so about ${humanSeconds(deals * SOLVE_MS)}`
+    : "";
   return (
     `This script calls tricks(), dds() or par(), so every deal has to be solved here` +
     `${cost}, and more again if the call is in the condition, where every deal ` +
     `generated is solved rather than every deal produced. Pre-solved deals arrive with ` +
     `the answers already in them, so the same questions are lookups.`
-  )
+  );
 }
 
 /**
@@ -370,10 +417,10 @@ export function slowRandomWarning(usesDoubleDummy, produce) {
  * @returns {string}
  */
 function humanSeconds(ms) {
-  const seconds = ms / 1000
-  if (seconds < 1) return 'under a second'
-  if (seconds < 90) return `${Math.round(seconds)} seconds`
-  const minutes = seconds / 60
-  if (minutes < 90) return `${Math.round(minutes)} minutes`
-  return `${(minutes / 60).toFixed(1)} hours`
+  const seconds = ms / 1000;
+  if (seconds < 1) return "under a second";
+  if (seconds < 90) return `${Math.round(seconds)} seconds`;
+  const minutes = seconds / 60;
+  if (minutes < 90) return `${Math.round(minutes)} minutes`;
+  return `${(minutes / 60).toFixed(1)} hours`;
 }

--- a/web/src/lib/library.test.js
+++ b/web/src/lib/library.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi } from "vitest";
 import {
   MAX_LIBRARY_DEALS,
   createLibraryFetcher,
@@ -9,292 +9,425 @@ import {
   pointlessLibraryWarning,
   slowRandomWarning,
   supplyLibraryPieces,
-} from './library.js'
+} from "./library.js";
 
-const MANIFEST = 'https://example.test/data/manifest.json'
-const PIECE = (n) => `https://example.test/data/zdd/rpdd-00${n}.zdd`
+const MANIFEST = "https://example.test/data/manifest.json";
+const PIECE = (n) => `https://example.test/data/zdd/rpdd-00${n}.zdd`;
 
 /// A stand-in for the wasm `Library`, with the same ask/supply protocol: the
 /// manifest first, then the pieces a run crosses. Nothing here is the real
 /// arithmetic — which piece holds which deal is Rust's, and tested there — only
 /// the shape of the conversation the page has to hold up its end of.
 function fakeLibrary({ dealsPerChunk = 10, totalDeals = 100 } = {}) {
-  const held = new Set()
-  let manifestIn = false
+  const held = new Set();
+  let manifestIn = false;
   return {
     manifest_url: MANIFEST,
     get total_deals() {
-      return manifestIn ? totalDeals : undefined
+      return manifestIn ? totalDeals : undefined;
     },
     needs(firstDeal, count) {
-      if (!manifestIn) return [MANIFEST]
-      const wanted = []
-      const first = Math.floor(firstDeal / dealsPerChunk)
-      const last = Math.floor((firstDeal + count - 1) / dealsPerChunk)
-      for (let n = first; n <= last; n++) if (!held.has(n)) wanted.push(PIECE(n))
-      return wanted
+      if (!manifestIn) return [MANIFEST];
+      const wanted = [];
+      const first = Math.floor(firstDeal / dealsPerChunk);
+      const last = Math.floor((firstDeal + count - 1) / dealsPerChunk);
+      for (let n = first; n <= last; n++)
+        if (!held.has(n)) wanted.push(PIECE(n));
+      return wanted;
     },
     supply(url) {
-      if (url === MANIFEST) manifestIn = true
-      else held.add(Number(url.match(/rpdd-0*(\d+)\.zdd$/)[1]))
+      if (url === MANIFEST) manifestIn = true;
+      else held.add(Number(url.match(/rpdd-0*(\d+)\.zdd$/)[1]));
     },
     held,
-  }
+  };
 }
 
-describe('dealsToRequest', () => {
-  it('asks for as much as the run is allowed to look at', () => {
-    expect(dealsToRequest({ produce: 20, maxGenerate: 5000, totalDeals: 10485760 })).toBe(5000)
-  })
+describe("dealsToRequest", () => {
+  it("asks for as much as the run is allowed to look at", () => {
+    expect(
+      dealsToRequest({ produce: 20, maxGenerate: 5000, totalDeals: 10485760 }),
+    ).toBe(5000);
+  });
 
-  it('never asks for more than the download budget', () => {
-    expect(dealsToRequest({ produce: 20, maxGenerate: 1000000, totalDeals: 10485760 })).toBe(
-      MAX_LIBRARY_DEALS,
-    )
-  })
+  it("never asks for more than the download budget", () => {
+    expect(
+      dealsToRequest({
+        produce: 20,
+        maxGenerate: 1000000,
+        totalDeals: 10485760,
+      }),
+    ).toBe(MAX_LIBRARY_DEALS);
+  });
 
-  it('never asks for more than the library holds, which would repeat deals', () => {
-    expect(dealsToRequest({ produce: 20, maxGenerate: 1000000, totalDeals: 10 })).toBe(10)
-  })
+  it("never asks for more than the library holds, which would repeat deals", () => {
+    expect(
+      dealsToRequest({ produce: 20, maxGenerate: 1000000, totalDeals: 10 }),
+    ).toBe(10);
+  });
 
-  it('still asks for as many as the run must produce', () => {
-    expect(dealsToRequest({ produce: 400, maxGenerate: 10, totalDeals: 10485760 })).toBe(400)
-  })
-})
+  it("still asks for as many as the run must produce", () => {
+    expect(
+      dealsToRequest({ produce: 400, maxGenerate: 10, totalDeals: 10485760 }),
+    ).toBe(400);
+  });
+});
 
-describe('learnLibrarySize', () => {
-  it('fetches the manifest and no piece, because the seed cannot pick one yet', async () => {
-    const lib = fakeLibrary()
-    const asked = []
+describe("learnLibrarySize", () => {
+  it("fetches the manifest and no piece, because the seed cannot pick one yet", async () => {
+    const lib = fakeLibrary();
+    const asked = [];
     const fetchPiece = vi.fn(async (url) => {
-      asked.push(url)
-      return new Uint8Array()
-    })
-    expect(await learnLibrarySize(lib, fetchPiece)).toBe(100)
-    expect(asked).toEqual([MANIFEST])
-  })
+      asked.push(url);
+      return new Uint8Array();
+    });
+    expect(await learnLibrarySize(lib, fetchPiece)).toBe(100);
+    expect(asked).toEqual([MANIFEST]);
+  });
 
-  it('says so when a library never announces its size', async () => {
-    const lib = { total_deals: undefined, manifest_url: MANIFEST, needs: () => [], supply() {} }
-    await expect(learnLibrarySize(lib, async () => new Uint8Array())).rejects.toThrow(
-      /did not say how many deals/,
-    )
-  })
-})
+  it("says so when a library never announces its size", async () => {
+    const lib = {
+      total_deals: undefined,
+      manifest_url: MANIFEST,
+      needs: () => [],
+      supply() {},
+    };
+    await expect(
+      learnLibrarySize(lib, async () => new Uint8Array()),
+    ).rejects.toThrow(/did not say how many deals/);
+  });
+});
 
-describe('supplyLibraryPieces', () => {
-  it('fetches every piece the run crosses, and then stops asking', async () => {
-    const lib = fakeLibrary({ dealsPerChunk: 10 })
-    lib.supply(MANIFEST)
-    const asked = []
+describe("supplyLibraryPieces", () => {
+  it("fetches every piece the run crosses, and then stops asking", async () => {
+    const lib = fakeLibrary({ dealsPerChunk: 10 });
+    lib.supply(MANIFEST);
+    const asked = [];
     const fetchPiece = async (url) => {
-      asked.push(url)
-      return new Uint8Array()
-    }
-    const { fetched } = await supplyLibraryPieces(lib, 8, 5, { fetchPiece })
-    expect(asked).toEqual([PIECE(0), PIECE(1)])
-    expect(fetched).toBe(2)
-    expect(lib.needs(8, 5)).toEqual([])
-  })
+      asked.push(url);
+      return new Uint8Array();
+    };
+    const { fetched } = await supplyLibraryPieces(lib, 8, 5, { fetchPiece });
+    expect(asked).toEqual([PIECE(0), PIECE(1)]);
+    expect(fetched).toBe(2);
+    expect(lib.needs(8, 5)).toEqual([]);
+  });
 
-  it('fetches nothing for a region already held, which is what makes a re-run free', async () => {
-    const lib = fakeLibrary()
-    lib.supply(MANIFEST)
-    const fetchPiece = vi.fn(async () => new Uint8Array())
-    await supplyLibraryPieces(lib, 0, 5, { fetchPiece })
-    expect(fetchPiece).toHaveBeenCalledTimes(1)
-    await supplyLibraryPieces(lib, 0, 5, { fetchPiece })
-    expect(fetchPiece).toHaveBeenCalledTimes(1)
-  })
+  it("fetches nothing for a region already held, which is what makes a re-run free", async () => {
+    const lib = fakeLibrary();
+    lib.supply(MANIFEST);
+    const fetchPiece = vi.fn(async () => new Uint8Array());
+    await supplyLibraryPieces(lib, 0, 5, { fetchPiece });
+    expect(fetchPiece).toHaveBeenCalledTimes(1);
+    await supplyLibraryPieces(lib, 0, 5, { fetchPiece });
+    expect(fetchPiece).toHaveBeenCalledTimes(1);
+  });
 
-  it('reports each piece as it goes, so a 640 KiB wait is not a frozen page', async () => {
-    const lib = fakeLibrary({ dealsPerChunk: 10 })
-    lib.supply(MANIFEST)
-    const seen = []
+  it("reports each piece as it goes, so a 640 KiB wait is not a frozen page", async () => {
+    const lib = fakeLibrary({ dealsPerChunk: 10 });
+    lib.supply(MANIFEST);
+    const seen = [];
     await supplyLibraryPieces(lib, 8, 5, {
       fetchPiece: async () => new Uint8Array(),
       onProgress: (status) => seen.push(`${status.done}/${status.total}`),
-    })
-    expect(seen).toEqual(['0/2', '1/2', '2/2'])
-  })
+    });
+    expect(seen).toEqual(["0/2", "1/2", "2/2"]);
+  });
 
-  it('gives up rather than looping for ever on a library it cannot satisfy', async () => {
+  it("asks for a round's pieces at once, rather than a round trip each", async () => {
+    const lib = fakeLibrary({ dealsPerChunk: 10 });
+    lib.supply(MANIFEST);
+    // The first piece is held open, and the question is whether the second was
+    // asked for anyway. Awaiting each fetch in turn — which is what this used
+    // to do, and what every other test in this file was happy with — leaves
+    // the second unasked until the first answers, and a cold run pays both
+    // waits end to end instead of the longer of the two.
+    let answerFirst;
+    const held = new Promise((resolve) => {
+      answerFirst = resolve;
+    });
+    const asked = [];
+    const fetchPiece = vi.fn(async (url) => {
+      asked.push(url);
+      if (asked.length === 1) await held;
+      return new Uint8Array();
+    });
+
+    const running = supplyLibraryPieces(lib, 8, 5, { fetchPiece });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(asked).toEqual([PIECE(0), PIECE(1)]);
+
+    answerFirst();
+    await running;
+  });
+
+  it("supplies pieces in the order asked for, whatever order they arrive in", async () => {
+    const lib = fakeLibrary({ dealsPerChunk: 10 });
+    lib.supply(MANIFEST);
+    const supplied = [];
+    const realSupply = lib.supply.bind(lib);
+    lib.supply = (url, bytes) => {
+      supplied.push(url);
+      return realSupply(url, bytes);
+    };
+    // The second piece answers immediately, the first takes a turn of the
+    // event loop, so they arrive backwards.
+    const fetchPiece = vi.fn(async (url) => {
+      if (url === PIECE(0)) await Promise.resolve();
+      return new Uint8Array();
+    });
+    await supplyLibraryPieces(lib, 8, 5, { fetchPiece });
+    expect(supplied).toEqual([PIECE(0), PIECE(1)]);
+  });
+
+  it("gives up rather than looping for ever on a library it cannot satisfy", async () => {
     const insatiable = {
       manifest_url: MANIFEST,
       total_deals: 100,
       needs: () => [PIECE(0)],
       supply() {},
-    }
+    };
     await expect(
-      supplyLibraryPieces(insatiable, 0, 5, { fetchPiece: async () => new Uint8Array() }),
-    ).rejects.toThrow(/kept asking/)
-  })
-})
+      supplyLibraryPieces(insatiable, 0, 5, {
+        fetchPiece: async () => new Uint8Array(),
+      }),
+    ).rejects.toThrow(/kept asking/);
+  });
+});
 
-describe('createLibraryFetcher', () => {
-  const bytes = (n) => new Uint8Array([n, n, n])
-  const respond = (body) => ({ ok: true, status: 200, arrayBuffer: async () => body.buffer })
+describe("createLibraryFetcher", () => {
+  const bytes = (n) => new Uint8Array([n, n, n]);
+  const respond = (body) => ({
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => body.buffer,
+  });
 
-  it('fetches once and remembers, so changing the script does not refetch', async () => {
-    const fetchImpl = vi.fn(async () => respond(bytes(1)))
-    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage: null })
-    expect(Array.from(await piece(PIECE(0)))).toEqual([1, 1, 1])
-    await piece(PIECE(0))
-    expect(fetchImpl).toHaveBeenCalledTimes(1)
-  })
+  it("fetches once and remembers, so changing the script does not refetch", async () => {
+    const fetchImpl = vi.fn(async () => respond(bytes(1)));
+    const piece = createLibraryFetcher({
+      manifestUrl: MANIFEST,
+      fetchImpl,
+      cacheStorage: null,
+    });
+    expect(Array.from(await piece(PIECE(0)))).toEqual([1, 1, 1]);
+    await piece(PIECE(0));
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
 
-  it('writes pieces to the browser cache but not the manifest, which can change', async () => {
-    const put = vi.fn(async () => {})
-    const cacheStorage = { open: async () => ({ match: async () => null, put }) }
-    const fetchImpl = vi.fn(async () => respond(bytes(2)))
-    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage })
-    await piece(MANIFEST)
-    expect(put).not.toHaveBeenCalled()
-    await piece(PIECE(0))
-    expect(put).toHaveBeenCalledTimes(1)
-  })
+  it("writes pieces to the browser cache but not the manifest, which can change", async () => {
+    const put = vi.fn(async () => {});
+    const cacheStorage = {
+      open: async () => ({ match: async () => null, put }),
+    };
+    const fetchImpl = vi.fn(async () => respond(bytes(2)));
+    const piece = createLibraryFetcher({
+      manifestUrl: MANIFEST,
+      fetchImpl,
+      cacheStorage,
+    });
+    await piece(MANIFEST);
+    expect(put).not.toHaveBeenCalled();
+    await piece(PIECE(0));
+    expect(put).toHaveBeenCalledTimes(1);
+  });
 
-  it('reads a piece back from the cache without touching the network', async () => {
-    const cached = { ok: true, arrayBuffer: async () => bytes(3).buffer }
-    const cacheStorage = { open: async () => ({ match: async () => cached, put: async () => {} }) }
-    const fetchImpl = vi.fn()
-    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage })
-    expect(Array.from(await piece(PIECE(0)))).toEqual([3, 3, 3])
-    expect(fetchImpl).not.toHaveBeenCalled()
-  })
+  it("reads a piece back from the cache without touching the network", async () => {
+    const cached = { ok: true, arrayBuffer: async () => bytes(3).buffer };
+    const cacheStorage = {
+      open: async () => ({ match: async () => cached, put: async () => {} }),
+    };
+    const fetchImpl = vi.fn();
+    const piece = createLibraryFetcher({
+      manifestUrl: MANIFEST,
+      fetchImpl,
+      cacheStorage,
+    });
+    expect(Array.from(await piece(PIECE(0)))).toEqual([3, 3, 3]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 
-  it('works where the cache is refused, which is a private window not a failure', async () => {
-    const cacheStorage = { open: async () => { throw new Error('denied') } }
-    const fetchImpl = vi.fn(async () => respond(bytes(4)))
-    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage })
-    expect(Array.from(await piece(PIECE(0)))).toEqual([4, 4, 4])
-  })
+  it("works where the cache is refused, which is a private window not a failure", async () => {
+    const cacheStorage = {
+      open: async () => {
+        throw new Error("denied");
+      },
+    };
+    const fetchImpl = vi.fn(async () => respond(bytes(4)));
+    const piece = createLibraryFetcher({
+      manifestUrl: MANIFEST,
+      fetchImpl,
+      cacheStorage,
+    });
+    expect(Array.from(await piece(PIECE(0)))).toEqual([4, 4, 4]);
+  });
 
   it('names the library in a network failure, where "Failed to fetch" does not', async () => {
     const fetchImpl = async () => {
-      throw new TypeError('Failed to fetch')
-    }
-    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage: null })
-    await expect(piece(PIECE(0))).rejects.toThrow(/solved-deal library.*rpdd-000\.zdd/s)
-  })
+      throw new TypeError("Failed to fetch");
+    };
+    const piece = createLibraryFetcher({
+      manifestUrl: MANIFEST,
+      fetchImpl,
+      cacheStorage: null,
+    });
+    await expect(piece(PIECE(0))).rejects.toThrow(
+      /solved-deal library.*rpdd-000\.zdd/s,
+    );
+  });
 
-  it('reports an HTTP failure rather than reading an error page as tables', async () => {
-    const fetchImpl = async () => ({ ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) })
-    const piece = createLibraryFetcher({ manifestUrl: MANIFEST, fetchImpl, cacheStorage: null })
-    await expect(piece(PIECE(0))).rejects.toThrow(/HTTP 404/)
-  })
-})
+  it("reports an HTTP failure rather than reading an error page as tables", async () => {
+    const fetchImpl = async () => ({
+      ok: false,
+      status: 404,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+    const piece = createLibraryFetcher({
+      manifestUrl: MANIFEST,
+      fetchImpl,
+      cacheStorage: null,
+    });
+    await expect(piece(PIECE(0))).rejects.toThrow(/HTTP 404/);
+  });
+});
 
-describe('describeInput', () => {
-  const solved = { format: 'zrd', read: 500, solved: 500, unsolved: 0, skipped_count: 0, notes: [] }
-  const library = { firstDeal: 4192003, totalDeals: 10485760, requested: 500 }
+describe("describeInput", () => {
+  const solved = {
+    format: "zrd",
+    read: 500,
+    solved: 500,
+    unsolved: 0,
+    skipped_count: 0,
+    notes: [],
+  };
+  const library = { firstDeal: 4192003, totalDeals: 10485760, requested: 500 };
 
-  it('says how many deals arrived and that they came with tables', () => {
-    const { summary, warnings } = describeInput(solved, library)
-    expect(summary).toContain('Read 500 deals')
-    expect(summary).toContain('4,192,003 of 10,485,760')
-    expect(summary).toMatch(/Every one arrived with its double-dummy table/)
-    expect(warnings).toEqual([])
-  })
+  it("says how many deals arrived and that they came with tables", () => {
+    const { summary, warnings } = describeInput(solved, library);
+    expect(summary).toContain("Read 500 deals");
+    expect(summary).toContain("4,192,003 of 10,485,760");
+    expect(summary).toMatch(/Every one arrived with its double-dummy table/);
+    expect(warnings).toEqual([]);
+  });
 
-  it('warns when fewer deals arrived than were asked for', () => {
-    const short = describeInput({ ...solved, read: 40, solved: 40 }, library)
-    expect(short.warnings.join(' ')).toMatch(/Asked for 500 deals and read 40/)
-  })
+  it("warns when fewer deals arrived than were asked for", () => {
+    const short = describeInput({ ...solved, read: 40, solved: 40 }, library);
+    expect(short.warnings.join(" ")).toMatch(/Asked for 500 deals and read 40/);
+  });
 
-  it('warns when deals arrived unsolved, which is the slow path this avoids', () => {
-    const { warnings } = describeInput({ ...solved, solved: 400, unsolved: 100 }, library)
-    expect(warnings.join(' ')).toMatch(/100 deals arrived without a double-dummy table/)
-  })
-
-  it('warns when a run reads the whole library, because repeats would be counted twice', () => {
-    const whole = { firstDeal: 3, totalDeals: 500, requested: 500 }
-    const { warnings } = describeInput(solved, whole)
-    expect(warnings.join(' ')).toMatch(/come round to deals it has already seen/)
-  })
-
-  it('names records that could not be read, and passes the reader notes on', () => {
+  it("warns when deals arrived unsolved, which is the slow path this avoids", () => {
     const { warnings } = describeInput(
-      { ...solved, skipped_count: 2, skipped: ['record 3: short'], notes: ['a note'] },
+      { ...solved, solved: 400, unsolved: 100 },
       library,
-    )
-    expect(warnings.join(' ')).toMatch(/2 records could not be read: record 3: short/)
-    expect(warnings).toContain('a note')
-  })
+    );
+    expect(warnings.join(" ")).toMatch(
+      /100 deals arrived without a double-dummy table/,
+    );
+  });
 
-  it('has nothing to say about a run that read nothing', () => {
-    expect(describeInput(null)).toEqual({ summary: '', warnings: [] })
-  })
-})
+  it("warns when a run reads the whole library, because repeats would be counted twice", () => {
+    const whole = { firstDeal: 3, totalDeals: 500, requested: 500 };
+    const { warnings } = describeInput(solved, whole);
+    expect(warnings.join(" ")).toMatch(
+      /come round to deals it has already seen/,
+    );
+  });
 
-describe('libraryStatusText', () => {
-  it('names the piece being fetched, since a network wait shows nothing else', () => {
-    expect(libraryStatusText({ stage: 'pieces', done: 0, total: 2 })).toBe(
-      'Fetching the solved-deal library — piece 1 of 2…',
-    )
-  })
+  it("names records that could not be read, and passes the reader notes on", () => {
+    const { warnings } = describeInput(
+      {
+        ...solved,
+        skipped_count: 2,
+        skipped: ["record 3: short"],
+        notes: ["a note"],
+      },
+      library,
+    );
+    expect(warnings.join(" ")).toMatch(
+      /2 records could not be read: record 3: short/,
+    );
+    expect(warnings).toContain("a note");
+  });
 
-  it('says what is happening while the index is read', () => {
-    expect(libraryStatusText({ stage: 'manifest', done: 0, total: 1 })).toMatch(/index/)
-  })
+  it("has nothing to say about a run that read nothing", () => {
+    expect(describeInput(null)).toEqual({ summary: "", warnings: [] });
+  });
+});
 
-  it('moves on once every piece is in, rather than sitting on the last one', () => {
-    expect(libraryStatusText({ stage: 'pieces', done: 2, total: 2 })).toMatch(/Running the script/)
-  })
+describe("libraryStatusText", () => {
+  it("names the piece being fetched, since a network wait shows nothing else", () => {
+    expect(libraryStatusText({ stage: "pieces", done: 0, total: 2 })).toBe(
+      "Fetching the solved-deal library — piece 1 of 2…",
+    );
+  });
 
-  it('has nothing to say when nothing is being fetched', () => {
-    expect(libraryStatusText(null)).toBe('')
-  })
-})
+  it("says what is happening while the index is read", () => {
+    expect(libraryStatusText({ stage: "manifest", done: 0, total: 1 })).toMatch(
+      /index/,
+    );
+  });
 
-describe('pointlessLibraryWarning', () => {
-  it('warns when a script asks no double-dummy question', () => {
-    expect(pointlessLibraryWarning(false)).toMatch(/never calls tricks\(\), dds\(\) or par\(\)/)
-  })
+  it("moves on once every piece is in, rather than sitting on the last one", () => {
+    expect(libraryStatusText({ stage: "pieces", done: 2, total: 2 })).toMatch(
+      /Running the script/,
+    );
+  });
 
-  it('says nothing when the script does ask one', () => {
-    expect(pointlessLibraryWarning(true)).toBe('')
-  })
+  it("has nothing to say when nothing is being fetched", () => {
+    expect(libraryStatusText(null)).toBe("");
+  });
+});
 
-  it('says nothing when the script could not be read, which is not a no', () => {
-    expect(pointlessLibraryWarning(undefined)).toBe('')
-  })
-})
+describe("pointlessLibraryWarning", () => {
+  it("warns when a script asks no double-dummy question", () => {
+    expect(pointlessLibraryWarning(false)).toMatch(
+      /never calls tricks\(\), dds\(\) or par\(\)/,
+    );
+  });
 
-describe('slowRandomWarning', () => {
-  it('warns when a script that solves is told to shuffle its own deals', () => {
-    const said = slowRandomWarning(true, 200)
-    expect(said).toMatch(/calls tricks\(\), dds\(\) or par\(\)/)
-    expect(said).toMatch(/pre-solved/i)
-  })
+  it("says nothing when the script does ask one", () => {
+    expect(pointlessLibraryWarning(true)).toBe("");
+  });
 
-  it('says what it costs, not just that it is slower', () => {
+  it("says nothing when the script could not be read, which is not a no", () => {
+    expect(pointlessLibraryWarning(undefined)).toBe("");
+  });
+});
+
+describe("slowRandomWarning", () => {
+  it("warns when a script that solves is told to shuffle its own deals", () => {
+    const said = slowRandomWarning(true, 200);
+    expect(said).toMatch(/calls tricks\(\), dds\(\) or par\(\)/);
+    expect(said).toMatch(/pre-solved/i);
+  });
+
+  it("says what it costs, not just that it is slower", () => {
     // "Slower" is not a reason to choose differently; five seconds is. 200
     // deals at 23 ms each is the arithmetic someone can check.
-    const said = slowRandomWarning(true, 200)
-    expect(said).toMatch(/200 × 23 ms/)
-    expect(said).toMatch(/5 seconds/)
-  })
+    const said = slowRandomWarning(true, 200);
+    expect(said).toMatch(/200 × 23 ms/);
+    expect(said).toMatch(/5 seconds/);
+  });
 
-  it('scales with what was asked for', () => {
-    expect(slowRandomWarning(true, 10000)).toMatch(/4 minutes/)
-  })
+  it("scales with what was asked for", () => {
+    expect(slowRandomWarning(true, 10000)).toMatch(/4 minutes/);
+  });
 
-  it('says a condition costs more again than a produce count', () => {
-    expect(slowRandomWarning(true, 200)).toMatch(/condition/)
-  })
+  it("says a condition costs more again than a produce count", () => {
+    expect(slowRandomWarning(true, 200)).toMatch(/condition/);
+  });
 
-  it('says nothing when the script asks no double-dummy question', () => {
-    expect(slowRandomWarning(false, 200)).toBe('')
-  })
+  it("says nothing when the script asks no double-dummy question", () => {
+    expect(slowRandomWarning(false, 200)).toBe("");
+  });
 
-  it('says nothing when the script could not be read, which is not a yes', () => {
-    expect(slowRandomWarning(undefined, 200)).toBe('')
-  })
+  it("says nothing when the script could not be read, which is not a yes", () => {
+    expect(slowRandomWarning(undefined, 200)).toBe("");
+  });
 
-  it('still warns when the count is missing, without inventing a time', () => {
-    const said = slowRandomWarning(true, NaN)
-    expect(said).toMatch(/every deal has to be solved here/)
-    expect(said).not.toMatch(/ms/)
-  })
-})
+  it("still warns when the count is missing, without inventing a time", () => {
+    const said = slowRandomWarning(true, NaN);
+    expect(said).toMatch(/every deal has to be solved here/);
+    expect(said).not.toMatch(/ms/);
+  });
+});


### PR DESCRIPTION
Follow-on from a timing question about the 100,000-deal notrump script on the site.

## What the numbers say

Same script, same 100,000 deals, three measurements from the browser:

| | library | engine |
|---|---|---|
| cold (new seed, nothing cached) | 2.384 s | 0.046 s |
| warm (same seed, pieces cached) | 0.300 s | 0.042 s |

So the download is ~2.08 s — about 85% of a cold run — and rebuilding 100,000 deals from their indexes, which the same figure covers and which no cache can help, is at most 0.300 s. The unranking optimisation left open as rpdd-library#2 would buy almost nothing; the fetch is the whole cost.

## The change

`supplyLibraryPieces` awaited each piece in turn. The rounds must stay sequential — each depends on what the last supplied — but the pieces inside a round are independent and the round knows all their URLs up front. Now they go out together.

This is never a one-piece run in practice: a piece holds 65,536 deals, so anything over that straddles a boundary. The featured 100,000-deal script always fetches two, sometimes three, and was paying both waits end to end.

Pieces are still handed to the library in the order asked for, not the order they land, so the run does not depend on what the network did.

## Tests

Two added. The one that matters holds the first fetch open and asserts the second was asked for anyway:

```
× asks for a round's pieces at once, rather than a round trip each
  → expected [ Array(1) ] to deeply equal [ …(2) ]
```

Verified against the old implementation — it fails there in 6 ms, and **every other test in the file passes against the serial loop**. That is the recurring shape in this repo: the old code was correct, just slower, and nothing that only checks answers can see it.

`npm test` 210 passed, `npm run build:all` clean, prettier clean.

## Not in this PR

The pieces are served from `raw.githubusercontent.com`, a source host rather than a content one — no edge caching, and about 600 KB/s. Moving them to a Cloudflare Pages project deployed from rpdd-library is the larger win and is being done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)