### PR TITLE
One entry point taking a run envelope, instead of ten positional arguments

### DIFF
--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -100,8 +100,15 @@ list there was no name to misspell, and with a permissive parse there would be
 no complaint — the run would take a default and return numbers for a run nobody
 asked for. `"autolevel"` gets an error naming `autolevel`.
 
-This is the same envelope intended for share links, export files and bundled
-demo scripts, so a new setting is added in one place rather than four.
+**The seed is a definite number.** "Roll a new one each run" is resolved by
+whoever is driving, before the call: a run whose seed the engine invented would
+not be reproducible, and the report does not say which one it used.
+
+This is the **engine's** half of a run. A share link, an export file or a demo
+entry describes more — which deal source to draw from, whether to reseed each
+run — and those are the caller's business. A saved document is this plus those,
+and narrows to this by dropping them; since unknown fields are refused, a
+document cannot be handed to `run_json` whole.
 
 ### `generate`
 

--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -17,7 +17,7 @@ Requires [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) and the
 
 Current size: **~1400 KB raw, ~500 KB gzipped**, including `bridge-solver`,
 which `tricks()` reaches through `dealer-dds`. The solver is about 11 KB
-gzipped of that, and the readers behind `generate_from_deals` — ZRD, PBN and the
+gzipped of that, and the readers behind a supplied-deals run — ZRD, PBN and the
 line-oriented layouts — about 22 KB gzipped: measured by building without that
 entry point, which comes to 1351 KB raw and 478 KB gzipped.
 
@@ -39,7 +39,10 @@ printf 'condition hcp(north) >= 12\n' > /tmp/v.dlr
 ../target/release/dealer /tmp/v.dlr -s 7 -p 5 -f oneline | sed 's/[[:space:]]*$//' > /tmp/native.txt
 node -e '
   const w = require("./pkg-node/dealer3_wasm.js");
-  console.log(JSON.parse(w.generate("condition hcp(north) >= 12\n",7,5,100000,"oneline")).deals.join("\n"));
+  const envelope = JSON.stringify({ v: 1, script: "condition hcp(north) >= 12\n",
+    settings: { seed: 7, produce: 5, maxGenerate: 100000, format: "oneline",
+                autoLevel: false, roundRobin: false } });
+  console.log(JSON.parse(w.run_json(envelope)).deals.join("\n"));
 ' > /tmp/wasm.txt
 diff /tmp/native.txt /tmp/wasm.txt && echo identical
 ```
@@ -51,8 +54,7 @@ cover this build too: it is the same generator.
 
 | Export | Returns | Notes |
 |---|---|---|
-| `generate(script, seed, produce, max_generate, format, auto_level, round_robin, params, measure_seconds, on_progress)` | JSON | `format` is `"oneline"`, `"printall"` or `"pbn"`; `params` fills `$0`-`$9`; `measure_seconds` bounds levelling's characterizing pass |
-| `generate_from_deals(script, deals, seed, produce, max_generate, format, auto_level, round_robin, params, measure_seconds, on_progress)` | JSON | The same, over deals the caller supplies: `deals` is a `Uint8Array` |
+| `run_json(envelope, deals, on_progress)` | JSON | The one way to run a script. `envelope` is the JSON below; `deals` is a `Uint8Array` to run over, or `undefined` to shuffle |
 | `new Library(manifestUrl)` | object | The published solved-deal library, fetched a piece at a time; see below |
 | `rpdd_manifest_url()` | string | The manifest of the library we host, for `new Library(...)` |
 | `record_for_seed(seed, records)` | number | Which record a run's seed starts at — the CLI's own mapping, not a page's |
@@ -64,6 +66,42 @@ cover this build too: it is the same generator.
 | `supports_threads()` | bool | Whether this build can deal on more than one thread at all |
 | `start_threads(n)` | Promise | Threaded build only: start the pool. Needs a cross-origin isolated page |
 | `version()` | string | Engine version |
+
+### The run envelope
+
+`run_json` takes one JSON string rather than a list of arguments. Fields are
+camelCase, because every caller is JavaScript.
+
+```json
+{
+  "v": 1,
+  "script": "condition hcp(north) >= 15\n",
+  "settings": {
+    "seed": 1,
+    "produce": 40,
+    "maxGenerate": 1000000,
+    "format": "oneline",
+    "autoLevel": false,
+    "roundRobin": false,
+    "params": [],
+    "measureSeconds": 2.5
+  }
+}
+```
+
+`format` is `"oneline"`, `"printall"`, `"pbn"` or `"none"`. `params` fills
+`$0`-`$9` and may be left out. `measureSeconds` bounds levelling's
+characterizing pass and may be left out, in which case
+`measure_budget_seconds()` is used. Everything else is required.
+
+**Unknown fields are refused by name, and so is an unknown `v`.** A misspelled
+setting is the mistake this shape exists to catch: with a positional argument
+list there was no name to misspell, and with a permissive parse there would be
+no complaint — the run would take a default and return numbers for a run nobody
+asked for. `"autolevel"` gets an error naming `autolevel`.
+
+This is the same envelope intended for share links, export files and bundled
+demo scripts, so a new setting is added in one place rather than four.
 
 ### `generate`
 
@@ -122,7 +160,7 @@ second copy of it. Deals are the wrong currency for it: how many deals a sightin
 of the rarest hand type costs is precisely what the pass exists to find out. The
 command line spells the same limit `--level-timeout`.
 
-The exception is `generate_from_deals`, where the deals are a finite pile rather
+The exception is a run over supplied deals, where they are a finite pile rather
 than a tap: there both passes share `max_generate` as the command line does, and
 whichever of the two limits arrives first stops the measuring.
 
@@ -131,20 +169,22 @@ tens of thousands to build a histogram and a page cannot show them all.
 Statistics still accumulate over every matching deal, so `produced` can exceed
 `deals.length`.
 
-### `generate_from_deals`
+### Running over supplied deals
 
-Runs the script over deals the caller hands over, rather than dealing any. Same
-arguments as `generate` with the file's bytes inserted second, and the same JSON
-back with one field added.
+Pass bytes as the second argument and the engine runs over those instead of
+dealing any. Same envelope, same JSON back with one field added — `deals` is the
+only thing that decides where a run's deals come from.
 
 **The browser is the HTTP client.** Nothing in the engine fetches, opens or
 names a file — JS does that and passes the bytes:
 
 ```js
 const bytes = new Uint8Array(await (await fetch("/library.zrd")).arrayBuffer())
-const result = JSON.parse(w.generate_from_deals(
-  "condition hcp(north) >= 15\n", bytes, 1, 40, 1000000, "oneline",
-  false, false, [], null, null))
+const result = JSON.parse(w.run_json(
+  JSON.stringify({ v: 1, script: "condition hcp(north) >= 15\n",
+    settings: { seed: 1, produce: 40, maxGenerate: 1000000, format: "oneline",
+                autoLevel: false, roundRobin: false } }),
+  bytes))
 console.log(result.input)
 // { format: "zrd", read: 10, solved: 10, unsolved: 0,
 //   separators: 0, skipped: [], skipped_count: 0, notes: [] }
@@ -204,7 +244,7 @@ Pavlicek's, solved over almost two years of computer time — but the file is
 So only the tables are published, as 640 KiB pieces, and the deals are not
 published at all: they are a pure function of their index, and `rpdd-reader`
 recreates them here at about 640ns each. `Library` joins the two and hands back
-`.zrd` bytes for `generate_from_deals` — the same bytes, the same reader and the
+`.zrd` bytes for `run_json` — the same bytes, the same reader and the
 same run as `--input-deals` at a terminal. There is deliberately no second run
 path.
 
@@ -219,9 +259,11 @@ while ((need = lib.needs(index, count)).length)
   for (const url of need)
     lib.supply(url, new Uint8Array(await (await fetch(url)).arrayBuffer()))
 
-const result = JSON.parse(w.generate_from_deals(
-  script, lib.zrd(index, count), seed, 40, 1000000, "oneline",
-  false, false, [], null))
+const result = JSON.parse(w.run_json(
+  JSON.stringify({ v: 1, script, settings: {
+    seed, produce: 40, maxGenerate: 1000000, format: "oneline",
+    autoLevel: false, roundRobin: false } }),
+  lib.zrd(index, count)))
 ```
 
 The first round asks for the manifest and the second for the chunks it names;
@@ -232,7 +274,7 @@ like — a `Map`, the Cache API, IndexedDB — and hand the same bytes back.
 |---|---|---|
 | `needs(firstDeal, count)` | `string[]` | URLs still wanted. Empty means `zrd` will answer |
 | `supply(url, bytes)` | — | Bytes for a URL `needs` returned. Throws for one it did not |
-| `zrd(firstDeal, count)` | `Uint8Array` | The run, for `generate_from_deals`. Throws while anything is missing |
+| `zrd(firstDeal, count)` | `Uint8Array` | The run, to pass to `run_json`. Throws while anything is missing |
 | `manifest_url` | string | What it was pointed at |
 | `total_deals` | number \| undefined | Known once the manifest has been supplied |
 | `forget_chunks()` | — | Release held pieces, keeping the manifest |
@@ -502,7 +544,7 @@ cd wasm && ./build.sh nodejs && node library-check.mjs
 `cargo test` inside `wasm/` already checks the arithmetic, in Rust, on the host.
 What it cannot check is that `needs()` arrives as an array, that a `Uint8Array`
 handed to `supply()` reaches Rust as `&[u8]`, and that `zrd()` comes back as
-bytes `generate_from_deals` accepts. Those are `wasm-bindgen`'s, and they are
+bytes `run_json` accepts. Those are `wasm-bindgen`'s, and they are
 where the wiring bugs happen. It serves the ten-record fixture as two `.zdd`
 chunks and checks the run byte for byte, across the join and around the wrap.
 
@@ -513,7 +555,7 @@ the only thing that stood in the way was the clock, and `now_ms` reads
 `SystemTime` off wasm rather than `Date.now()`. What it reads has no effect on
 which deals come out.
 
-That is what covers `generate_from_deals` — it runs over
+That is what covers a supplied-deals run — it runs over
 `dealer-run/tests/fixtures/rpdd_10First.zrd` and asserts the deals are the
 file's ten, that the filter still applies to them, and what `input` says about
 each format. It is not a browser, so it does not cover the JS boundary itself:

--- a/wasm/library-check.mjs
+++ b/wasm/library-check.mjs
@@ -16,6 +16,7 @@
 // join between the two chunks, and that is checked byte for byte.
 
 import { createRequire } from 'module'
+import { runEnvelope } from '../web/src/lib/envelope.js'
 import { readFileSync } from 'fs'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
@@ -80,10 +81,11 @@ check('a run across the chunk boundary is the library\'s own records, byte for b
   same(zrd, fixture.subarray(3 * RECORD, 8 * RECORD)))
 
 // And the point of emitting .zrd: the existing run reads it unchanged.
-const out = JSON.parse(w.generate_from_deals(
-  'condition 1\naction printoneline, average "N HCP" hcp(north)\n',
-  zrd, 1, 40, 1000000, 'oneline', false, false, [], undefined))
-check('the bytes feed generate_from_deals unchanged',
+const out = JSON.parse(w.run_json(
+  runEnvelope('condition 1\naction printoneline, average "N HCP" hcp(north)\n',
+    { seed: 1, produce: 40, maxGenerate: 1000000, format: 'oneline' }),
+  zrd, undefined))
+check('the bytes feed run_json unchanged',
   out.input?.format === 'zrd' && out.input?.read === 5 && out.produced === 5,
   JSON.stringify(out.input))
 check('every deal arrived with its table, so tricks() is a lookup',

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -30,7 +30,7 @@ use dealer_parser::vocabulary;
 use dealer_parser::{Statement, VulnerabilityType};
 use dealer_pbn::{format_oneline, format_printall, format_printpbn, PbnBoard, Vulnerability};
 use dealer_run::{Deals, LevelingOptions, Phase, Produced, RunHost, RunOptions};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 /// Upper bound on deals returned to the caller. A script may ask for tens of
@@ -616,138 +616,169 @@ impl RunHost for Page<'_> {
     }
 }
 
-/// Generate deals from a script, as JSON.
+/// The envelope version this build understands.
+///
+/// Bumped when a change would make an older caller wrong rather than merely
+/// out of date. A mismatch is refused by name rather than half-read.
+const ENVELOPE_VERSION: u32 = 1;
+
+/// A run, described in one shape.
+///
+/// This replaced ten positional arguments, and the comment that used to sit
+/// here defended them: wasm-bindgen exports positionally, so the arguments are
+/// "in the type system" while a settings object is a hand-written cast on both
+/// sides. That was half right, and the wrong half mattered.
+///
+/// JavaScript has no types to check. `produce` and `max_generate` are both
+/// numbers, `auto_level` and `round_robin` are both booleans, so transposing
+/// either pair type-checked perfectly and ran — and a `dealer-run` signature
+/// change once travelled through two merged pull requests before anyone
+/// noticed, which is why there is a WebAssembly job in CI at all. What the
+/// positional list actually offered was arity, and even that was thin:
+/// `verify.mjs` passed nine arguments to an eleven-argument function and was
+/// correct, but nothing about reading it said so.
+///
+/// Parsing gives back more than it takes. `deny_unknown_fields` means a
+/// misspelled setting is refused **by name** instead of silently taking its
+/// default, and the version says outright when a caller and this build
+/// disagree. Those are the two failures that actually happen here, and neither
+/// was catchable before.
+///
+/// The same shape is the share link's payload, the export file and a demo's
+/// manifest entry, so a setting is added once rather than in four places kept
+/// in step by hand.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct RunEnvelope {
+    v: u32,
+    script: String,
+    settings: RunSettings,
+}
+
+/// Everything about a run that is not the script and not the deals.
+///
+/// camelCase on the wire because every consumer is JavaScript — the page, the
+/// share link, the export file — and `session.js` already stores these names
+/// that way.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct RunSettings {
+    seed: u32,
+    produce: usize,
+    max_generate: usize,
+    format: String,
+    auto_level: bool,
+    round_robin: bool,
+    /// Absent means none, which is what nearly every script wants.
+    #[serde(default)]
+    params: Vec<String>,
+    /// Absent means [`MEASURE_BUDGET_MS`], as it did when this was an argument.
+    #[serde(default)]
+    measure_seconds: Option<f64>,
+}
+
+/// Run a script, described by an envelope, and return the report as JSON.
+///
+/// The one entry point. `deals` decides where the deals come from and is the
+/// only thing that does: bytes mean run over those — a Pavlicek `.zrd`, PBN, or
+/// the one-line and printall layouts, read by the same reader `--input-deals`
+/// uses — and nothing means shuffle from `seed`.
+///
+/// Deals and `on_progress` stay real arguments because they are not settings:
+/// one is a `Uint8Array` that has no business in JSON, the other is a callback.
 ///
 /// With `auto_level`, the engine characterizes the scenario first — how often
 /// each `HandType_*` comes up — works out a keep rate for each and deals the
-/// levelled copy. Both passes are the engine's business; what comes back is
-/// the deals and the numbers behind them.
+/// levelled copy. With `round_robin`, it divides `produce` among those
+/// variables instead of taking deals as they come; the two are refused
+/// together, since they ask for the same thing in different ways.
 ///
-/// With `round_robin`, it divides `produce` among the `HandType_*` variables —
-/// one of each per round, any remainder going to whichever types turn up next,
-/// one apiece — instead of taking deals as they come. Nothing is measured, so
-/// nothing can be measured wrong: a levelled set of twenty is four of each on
-/// average and 6/1/5/4/4 without anything having gone wrong, where a round is
-/// four. Refused alongside `auto_level`, which asks for the same thing the
-/// other way.
-/// `measure_seconds` is how long characterizing may take, and it is the only
-/// thing that stops it: `max_generate` bounds the run that was asked for, not
-/// the measuring that pays for it. Left out — `undefined` or `null` — it takes
-/// [`MEASURE_BUDGET_MS`]. The command line spells the same thing
-/// `--level-timeout`.
-// The argument list is the JS calling convention: wasm_bindgen exports these
-// positionally, and folding them into a settings object would move the naming
-// out of the type system and into a hand-written cast on both sides.
-#[allow(clippy::too_many_arguments)]
+/// `measure_seconds` bounds characterizing and is the only thing that does:
+/// `max_generate` bounds the run that was asked for, not the measuring that
+/// pays for it. Over supplied deals the pile bounds it too, and whichever
+/// limit arrives first stops the pass.
+///
+/// **Over supplied deals, look at `input` in what comes back.** `read` against
+/// the number of deals the caller believes it sent is what tells a run over a
+/// truncated download from a run over all of it; neither `produced` nor
+/// `hit_limit` can, because a run that exhausts its deals has not hit its
+/// budget — it stops short and looks like success.
+///
+/// `predeal` is refused over supplied deals rather than ignored: it arranges
+/// cards into deals this program shuffles, and there is nothing for it to do to
+/// deals that arrived already dealt. `seed` is still asked for, because it is
+/// what `rnd()` draws from and what orders an interleaved set.
+///
+/// **The browser is the HTTP client**: nothing here fetches, opens or names a
+/// file, which is why one entry point serves a download, a drag-and-drop, a
+/// file input and the solved-deal library alike.
 #[wasm_bindgen]
-pub fn generate(
-    script: &str,
-    seed: u32,
-    produce: usize,
-    max_generate: usize,
-    format: &str,
-    auto_level: bool,
-    round_robin: bool,
-    params: Vec<String>,
-    measure_seconds: Option<f64>,
+pub fn run_json(
+    envelope: &str,
+    deals: Option<Vec<u8>>,
     on_progress: Option<js_sys::Function>,
 ) -> Result<String, JsError> {
-    run_script(
-        script,
-        seed,
-        produce,
-        max_generate,
-        format,
-        auto_level,
-        round_robin,
-        &params,
-        measure_seconds,
-        on_progress,
-        DealSource::Shuffled,
-    )
-    .map_err(|e| JsError::new(&e))
+    run_envelope(envelope, deals.as_deref(), on_progress).map_err(|e| JsError::new(&e))
 }
 
-/// Run `script` over deals the caller supplies, rather than dealing any.
+/// [`run_json`]'s body.
 ///
-/// Everything else — `auto_level`, `round_robin`, `params`, `format` and the
-/// JSON that comes back — is [`generate`]'s and behaves as it does there. Where
-/// the deals come from is the only difference between the two.
-///
-/// `deals` is the file's bytes — a `Uint8Array`, which is what a `fetch()`
-/// gives after `arrayBuffer()`. **The browser is the HTTP client**: nothing
-/// here fetches, opens or names a file, which is why one entry point serves a
-/// download, a drag-and-drop and a file input alike.
-///
-/// The format is decided by what the bytes are, not what they were called — a
-/// Pavlicek `.zrd` library, PBN, or the one-line and printall layouts — through
-/// the same reader `--input-deals` uses at the terminal. A library's records
-/// and PBN's `[DoubleDummyTricks]` bring their double-dummy tables with them, so
-/// a script calling `tricks()` over a solved file solves nothing.
-///
-/// What came back is in `input`, and **a caller should look at it**: `read`
-/// against the number of deals it believes it sent is what tells a run over a
-/// truncated download from a run over all of it. Neither `produced` nor
-/// `hit_limit` can say that — a run that exhausts the deals it was given has
-/// not hit its budget, so it stops short and looks like success.
-///
-/// `seed` no longer decides which deals appear, since they are given, but it is
-/// still what `rnd()` draws from and what orders an interleaved set — so it is
-/// asked for, exactly as `generate` asks for it.
-///
-/// `predeal` is refused rather than ignored: it arranges cards into deals this
-/// program shuffles, and there is nothing for it to do to deals that arrived
-/// already dealt. The command line refuses the same combination.
-///
-/// `measure_seconds` bounds characterizing as it does in [`generate`], but here
-/// the deals bound it too: a supplied pile is finite, so both passes share it
-/// and whichever limit arrives first stops the pass.
-#[allow(clippy::too_many_arguments)]
-#[wasm_bindgen]
-pub fn generate_from_deals(
-    script: &str,
-    deals: &[u8],
-    seed: u32,
-    produce: usize,
-    max_generate: usize,
-    format: &str,
-    auto_level: bool,
-    round_robin: bool,
-    params: Vec<String>,
-    measure_seconds: Option<f64>,
+/// Speaks `String` rather than `JsError` for the reason [`run_script`] does:
+/// `JsError::new` reaches for JavaScript's `Error`, which does not exist off
+/// wasm, so a failure raised here would abort a test process instead of being
+/// something a test can assert on — and the failures are precisely what wants
+/// asserting.
+fn run_envelope(
+    envelope: &str,
+    deals: Option<&[u8]>,
     on_progress: Option<js_sys::Function>,
-) -> Result<String, JsError> {
+) -> Result<String, String> {
+    let envelope: RunEnvelope = serde_json::from_str(envelope)
+        .map_err(|e| format!("The run envelope could not be read: {}", e))?;
+    if envelope.v != ENVELOPE_VERSION {
+        return Err(format!(
+            "This build reads run envelope version {}, and was given version {}. \
+             A newer envelope needs a newer build; an older one needs its version raised.",
+            ENVELOPE_VERSION, envelope.v
+        ));
+    }
+    let s = envelope.settings;
+
     // One decoder, two front ends. Anything read here that the command line
     // would not read the same way is a bug in one of them, not a difference
     // between a page and a terminal.
-    // The whole file, in order. A page that wants to start somewhere else —
-    // the seed picking a position in a large library, which is what #68 asks
-    // for — will pass a window of its own; that is a decision about what the
-    // page offers, not one to make while wiring two branches together.
-    let (supplied, report) =
-        dealer_run::deals_from_bytes(deals, dealer_run::deal_input::Window::all())
-            .map_err(|e| JsError::new(&e))?;
+    let source = match deals {
+        Some(bytes) => {
+            // The whole of what was handed over, in order. A caller wanting to
+            // start elsewhere in a large library passes a window of its own;
+            // that is a decision about what the page offers, not one to make
+            // while wiring branches together.
+            let (supplied, report) =
+                dealer_run::deals_from_bytes(bytes, dealer_run::deal_input::Window::all())?;
+            DealSource::Supplied {
+                deals: supplied,
+                report,
+            }
+        }
+        None => DealSource::Shuffled,
+    };
+
     run_script(
-        script,
-        seed,
-        produce,
-        max_generate,
-        format,
-        auto_level,
-        round_robin,
-        &params,
-        measure_seconds,
+        &envelope.script,
+        s.seed,
+        s.produce,
+        s.max_generate,
+        &s.format,
+        s.auto_level,
+        s.round_robin,
+        &s.params,
+        s.measure_seconds,
         on_progress,
-        DealSource::Supplied {
-            deals: supplied,
-            report,
-        },
+        source,
     )
-    .map_err(|e| JsError::new(&e))
 }
 
-/// The body both entry points share: everything except where the deals came
-/// from.
+/// The run itself: everything except where the deals came from.
 ///
 /// Speaks `String` rather than `JsError` so that it can be called from an
 /// ordinary test. `JsError::new` reaches for JavaScript's `Error`, which does
@@ -1716,6 +1747,69 @@ pub fn version() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A well-formed envelope, which each test below then breaks in one way.
+    fn envelope(extra: &str) -> String {
+        format!(
+            r#"{{"v":1,"script":"condition 1\naction average \"h\" hcp(north)\n",
+                "settings":{{"seed":1,"produce":3,"maxGenerate":1000,
+                "format":"oneline","autoLevel":false,"roundRobin":false{}}}}}"#,
+            extra
+        )
+    }
+
+    #[test]
+    fn a_well_formed_envelope_runs() {
+        let json = run_envelope(&envelope(""), None, None).expect("should run");
+        assert!(json.contains("\"produced\":3"), "{}", json);
+    }
+
+    /// The reason the version is in the envelope at all: a caller from a later
+    /// build must be told, not half-read. Every field here is one this build
+    /// understands, so nothing but `v` says the two disagree.
+    #[test]
+    fn a_version_this_build_does_not_know_is_refused_by_number() {
+        let future = envelope("").replacen("\"v\":1", "\"v\":2", 1);
+        let err = run_envelope(&future, None, None).expect_err("should refuse");
+        assert!(err.contains('1') && err.contains('2'), "{}", err);
+    }
+
+    /// A misspelled setting used to be the dangerous case: with ten positional
+    /// arguments there was no name to misspell, and with a permissive parse
+    /// there would be no complaint — the run would take the default and return
+    /// numbers for a run nobody asked for. `deny_unknown_fields` makes it say
+    /// which word it did not know.
+    #[test]
+    fn a_misspelled_setting_is_refused_by_name() {
+        let typo = envelope(r#","autolevel":true"#);
+        let err = run_envelope(&typo, None, None).expect_err("should refuse");
+        assert!(err.contains("autolevel"), "{}", err);
+    }
+
+    /// `seed` has no sensible default — a run without one is not a run with
+    /// seed zero, it is a caller that forgot — so it is required and named.
+    #[test]
+    fn a_missing_required_setting_is_refused_by_name() {
+        let without = envelope("").replacen("\"seed\":1,", "", 1);
+        let err = run_envelope(&without, None, None).expect_err("should refuse");
+        assert!(err.contains("seed"), "{}", err);
+    }
+
+    /// The two genuinely optional ones, left out together.
+    #[test]
+    fn params_and_the_measure_budget_may_be_left_out() {
+        let json = run_envelope(&envelope(""), None, None).expect("should run");
+        assert!(json.contains("\"produced\":3"), "{}", json);
+    }
+
+    /// Bytes mean "run over these", and nothing means "shuffle". That is the
+    /// whole of what used to be two entry points.
+    #[test]
+    fn supplying_deals_reads_them_instead_of_shuffling() {
+        let json = run_envelope(&envelope(""), Some(LIBRARY), None).expect("should run");
+        assert!(json.contains("\"read\":10"), "{}", json);
+        assert!(json.contains("\"format\":\"zrd\""), "{}", json);
+    }
 
     /// Ten records of Pavlicek's library, every one of them solved. The same
     /// fixture `dealer-run` reads, so a front end that read it differently

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -644,9 +644,17 @@ const ENVELOPE_VERSION: u32 = 1;
 /// disagree. Those are the two failures that actually happen here, and neither
 /// was catchable before.
 ///
-/// The same shape is the share link's payload, the export file and a demo's
-/// manifest entry, so a setting is added once rather than in four places kept
-/// in step by hand.
+/// This is the **engine's** half of a run. A share link, an export file and a
+/// demo's manifest entry describe more than the engine does — which deal source
+/// to draw from, whether to roll a fresh seed each time — and those are the
+/// caller's business, not this one's. A document carrying them projects down to
+/// this by dropping them, so the two cannot drift: the engine's part of a saved
+/// run is literally this struct.
+///
+/// In particular the engine takes a **definite** seed. A run whose seed the
+/// engine invented would not be reproducible and the report does not say which
+/// one it used, so "roll a new one each time" is resolved by whoever is
+/// driving, before the call.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct RunEnvelope {

--- a/wasm/src/library.rs
+++ b/wasm/src/library.rs
@@ -23,7 +23,7 @@
 //! let need
 //! while ((need = lib.needs(index, count)).length)
 //!     for (const url of need) lib.supply(url, new Uint8Array(await (await fetch(url)).arrayBuffer()))
-//! const out = generate_from_deals(script, lib.zrd(index, count), seed, ...)
+//! const out = run_json(envelope, lib.zrd(index, count))
 //! ```
 //!
 //! The first round asks for the manifest and the second for the chunks it
@@ -31,7 +31,7 @@
 //!
 //! # Why it hands back `.zrd` bytes
 //!
-//! Because [`crate::generate_from_deals`] already reads them, unchanged. The
+//! Because [`crate::run_json`] already reads them, unchanged. The
 //! same bytes, the same reader and the same run as `--input-deals` at a
 //! terminal — so a library run in a tab and a library run in a shell cannot
 //! come to different conclusions about what they read.
@@ -146,7 +146,7 @@ impl Library {
     }
 
     /// `count` deals from `first_deal`, each with its double-dummy table, as
-    /// `.zrd` bytes for [`crate::generate_from_deals`].
+    /// `.zrd` bytes to hand to [`crate::run_json`].
     ///
     /// Fails while anything is still missing; ask [`needs`](Self::needs) first.
     pub fn zrd(&self, first_deal: u32, count: u32) -> Result<Vec<u8>, JsError> {

--- a/wasm/verify.mjs
+++ b/wasm/verify.mjs
@@ -9,6 +9,7 @@
 // Requires a release build of the CLI: ./dev-build.sh build --release
 
 import { createRequire } from 'module'
+import { runEnvelope } from '../web/src/lib/envelope.js'
 import { execFileSync, spawnSync } from 'child_process'
 import { writeFileSync, mkdtempSync, readFileSync } from 'fs'
 import { tmpdir } from 'os'
@@ -74,6 +75,17 @@ function parseCli(out) {
 let failures = 0
 const fail = (c, msg) => { failures++; console.log(`  ✗ ${c}: ${msg}`) }
 
+// The envelope for a shuffled run of one case, built the same way the page
+// builds it — importing the page's own builder rather than writing the shape
+// out again, so this cannot verify a shape the app does not send.
+const shuffled = (c) =>
+  runEnvelope(c.script, {
+    seed: c.seed,
+    produce: c.produce,
+    maxGenerate: 500000,
+    format: 'oneline',
+  })
+
 for (const c of CASES) {
   const path = join(tmp, `${c.name.replace(/\W+/g, '_')}.dlr`)
   writeFileSync(path, c.script)
@@ -84,7 +96,7 @@ for (const c of CASES) {
     const printed = execFileSync(CLI,
       [path, '-s', String(c.seed), '-p', String(c.produce), '-q'],
       { encoding: 'utf8' })
-    const fromWasm = JSON.parse(w.generate(c.script, c.seed, c.produce, 500000, 'oneline', false, false, [], undefined)).printes
+    const fromWasm = JSON.parse(w.run_json(shuffled(c), undefined, undefined)).printes
     if (printed !== fromWasm) {
       fail(c.name, `printes differs\n      cli:  ${JSON.stringify(printed)}\n      wasm: ${JSON.stringify(fromWasm)}`)
     } else {
@@ -96,7 +108,7 @@ for (const c of CASES) {
   const cli = parseCli(execFileSync(CLI,
     [path, '-s', String(c.seed), '-p', String(c.produce), '-f', 'oneline', '-X'],
     { encoding: 'utf8' }))
-  const wasm = JSON.parse(w.generate(c.script, c.seed, c.produce, 500000, 'oneline', false, false, [], undefined))
+  const wasm = JSON.parse(w.run_json(shuffled(c), undefined, undefined))
 
   if (JSON.stringify(cli.deals) !== JSON.stringify(wasm.deals)) {
     fail(c.name, `deals differ (cli ${cli.deals.length}, wasm ${wasm.deals.length})`)
@@ -158,8 +170,9 @@ for (const c of SUPPLIED) {
      '-p', '100', '-s', '1', '-f', 'oneline', '-X'],
     { encoding: 'utf8' }))
   const bytes = new Uint8Array(readFileSync(LIBRARY))
-  const wasm = JSON.parse(
-    w.generate_from_deals(c.script, bytes, 1, 100, 500000, 'oneline', false, false, []))
+  const wasm = JSON.parse(w.run_json(
+    runEnvelope(c.script, { seed: 1, produce: 100, maxGenerate: 500000, format: 'oneline' }),
+    bytes, undefined))
 
   if (JSON.stringify(cli.deals) !== JSON.stringify(wasm.deals)) {
     fail(c.name, `deals differ (cli ${cli.deals.length}, wasm ${wasm.deals.length})`)

--- a/web/src/lib/engine.worker.js
+++ b/web/src/lib/engine.worker.js
@@ -17,6 +17,7 @@
 // worth an await, so they stay on the main thread's own instance.
 
 import init, * as engine from '@/wasm/dealer3_wasm.js'
+import { runEnvelope } from './envelope.js'
 import {
   createLibraryFetcher,
   dealsToRequest,
@@ -177,9 +178,10 @@ self.onmessage = async (event) => {
       self.postMessage({ id, type: 'progress', message })
     }
 
-    // Two deal sources, one run. `generate_from_deals` is the same engine over
-    // deals it was handed instead of deals it shuffled — the filter, the
-    // statistics, the levelling and the output are all the ones above.
+    // Two deal sources, one run, one call. The engine takes an envelope
+    // describing the run and, separately, the deals to run it over: bytes mean
+    // use these, nothing means shuffle. The filter, the statistics, the
+    // levelling and the output are the same either way.
     let raw
     let libraryInfo = null
     // Getting the deals is part of the run, so it is part of the time. The
@@ -195,32 +197,9 @@ self.onmessage = async (event) => {
       )
       librarySeconds = (performance.now() - startedLibrary) / 1000
       libraryInfo = info
-      raw = engine.generate_from_deals(
-        script,
-        zrd,
-        options.seed,
-        options.produce,
-        options.maxGenerate,
-        options.format,
-        options.autoLevel,
-        options.roundRobin,
-        options.params || [],
-        options.measureSeconds,
-        onProgress,
-      )
+      raw = engine.run_json(runEnvelope(script, options), zrd, onProgress)
     } else {
-      raw = engine.generate(
-        script,
-        options.seed,
-        options.produce,
-        options.maxGenerate,
-        options.format,
-        options.autoLevel,
-        options.roundRobin,
-        options.params || [],
-        options.measureSeconds,
-        onProgress,
-      )
+      raw = engine.run_json(runEnvelope(script, options), undefined, onProgress)
     }
     self.postMessage({
       id,

--- a/web/src/lib/envelope.js
+++ b/web/src/lib/envelope.js
@@ -1,0 +1,54 @@
+// The one shape a run is described in.
+//
+// The engine takes this (`run_json`), and the same shape is meant to carry a
+// share link's payload, an export file and a demo's manifest entry. One
+// definition, so adding a setting is one edit and a version bump rather than
+// four edits kept in step by hand.
+//
+// It replaced ten positional arguments across the wasm boundary. JavaScript had
+// no types to check there: `produce` and `maxGenerate` are both numbers,
+// `autoLevel` and `roundRobin` are both booleans, so transposing either pair
+// ran perfectly. The engine now refuses an unknown field by name and refuses a
+// version it does not know, which are the two mistakes that actually happen.
+
+/// Bumped when a change would make an older reader wrong rather than merely
+/// out of date. The engine refuses a version it does not recognise.
+export const ENVELOPE_VERSION = 1
+
+/**
+ * Describe a run as the JSON string `run_json` takes.
+ *
+ * Booleans and `params` are coerced, because a checkbox nobody touched means
+ * off and no parameters means none — both are ordinary absences with an
+ * obvious answer.
+ *
+ * `seed`, `produce`, `maxGenerate` and `format` are passed through as they
+ * arrive, deliberately. A run missing one of those is broken, and the engine
+ * refuses it **by name** — "missing field `seed`" — which is a better outcome
+ * than quietly substituting a default and returning numbers for a run nobody
+ * asked for.
+ *
+ * `measureSeconds` is genuinely optional: left out, the engine uses its own
+ * characterizing budget.
+ *
+ * @param {string} script the script text
+ * @param {object} options the run's settings, in the page's own names
+ * @returns {string} JSON, ready for `run_json`
+ */
+export function runEnvelope(script, options = {}) {
+  const settings = {
+    seed: options.seed,
+    produce: options.produce,
+    maxGenerate: options.maxGenerate,
+    format: options.format,
+    autoLevel: !!options.autoLevel,
+    roundRobin: !!options.roundRobin,
+    params: options.params || [],
+  }
+  // Omitted rather than sent as null: the engine reads an absent field as
+  // "use the default budget", and `null` would have to mean the same thing in
+  // one more place.
+  if (options.measureSeconds != null) settings.measureSeconds = options.measureSeconds
+
+  return JSON.stringify({ v: ENVELOPE_VERSION, script, settings })
+}

--- a/web/src/lib/envelope.js
+++ b/web/src/lib/envelope.js
@@ -1,9 +1,14 @@
 // The one shape a run is described in.
 //
-// The engine takes this (`run_json`), and the same shape is meant to carry a
-// share link's payload, an export file and a demo's manifest entry. One
-// definition, so adding a setting is one edit and a version bump rather than
-// four edits kept in step by hand.
+// The engine takes this (`run_json`). A share link, an export file and a demo's
+// manifest entry describe more than the engine does — which deal source to draw
+// from, whether to roll a fresh seed each run — so a saved document is this
+// plus those, and projects back down to this by dropping them. The engine
+// refuses fields it does not know, deliberately, so a document must be narrowed
+// before it is run rather than passed through whole.
+//
+// Defining both here is what keeps them from drifting: a document's engine half
+// is not a copy of this shape, it is this shape.
 //
 // It replaced ten positional arguments across the wasm boundary. JavaScript had
 // no types to check there: `produce` and `maxGenerate` are both numbers,

--- a/web/src/lib/envelope.test.js
+++ b/web/src/lib/envelope.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { runEnvelope, ENVELOPE_VERSION } from './envelope.js'
+
+const settings = {
+  seed: 7,
+  produce: 5,
+  maxGenerate: 100000,
+  format: 'oneline',
+  autoLevel: false,
+  roundRobin: false,
+}
+
+const parsed = (script, options) => JSON.parse(runEnvelope(script, options))
+
+describe('runEnvelope', () => {
+  it('carries the version, so an older engine can refuse rather than half-read it', () => {
+    expect(parsed('condition 1\n', settings).v).toBe(ENVELOPE_VERSION)
+  })
+
+  it('sends the settings under the names the engine reads', () => {
+    // Not a restatement of the implementation: these exact spellings are what
+    // `deny_unknown_fields` checks on the other side, so a rename here that
+    // was not made there fails the run rather than being ignored.
+    expect(Object.keys(parsed('condition 1\n', settings).settings).sort()).toEqual([
+      'autoLevel',
+      'format',
+      'maxGenerate',
+      'params',
+      'produce',
+      'roundRobin',
+      'seed',
+    ])
+  })
+
+  it('treats an untouched checkbox as off rather than as missing', () => {
+    // The page can hand over settings with these absent. The engine requires
+    // them, so coercing here is what keeps an ordinary absence from being an
+    // error the user cannot act on.
+    const s = parsed('condition 1\n', { ...settings, autoLevel: undefined, roundRobin: undefined })
+      .settings
+    expect(s.autoLevel).toBe(false)
+    expect(s.roundRobin).toBe(false)
+  })
+
+  it('omits the measure budget rather than sending null, so the engine uses its own', () => {
+    expect('measureSeconds' in parsed('condition 1\n', settings).settings).toBe(false)
+    expect('measureSeconds' in parsed('condition 1\n', { ...settings, measureSeconds: null }).settings).toBe(false)
+    expect(parsed('condition 1\n', { ...settings, measureSeconds: 2.5 }).settings.measureSeconds).toBe(2.5)
+  })
+
+  it('passes a missing required setting through, so the engine names it', () => {
+    // Deliberately not defaulted. A run without a seed is not a run with seed
+    // zero, it is a caller that forgot, and "missing field `seed`" is a better
+    // outcome than numbers for a run nobody asked for.
+    const s = parsed('condition 1\n', { ...settings, seed: undefined }).settings
+    expect('seed' in s).toBe(false)
+  })
+
+  it('keeps the script exactly, newlines and all', () => {
+    const script = 'condition hcp(north) >= 15\naction average "h" hcp(north)\n'
+    expect(parsed(script, settings).script).toBe(script)
+  })
+})


### PR DESCRIPTION
Closes #106.

`generate` and `generate_from_deals` differed only in where the deals came from, and between them carried twenty-one positional arguments across a boundary JavaScript cannot type-check. They are now one export:

```js
run_json(envelope, deals, on_progress)
```

`deals` decides the source and is the only thing that does — bytes mean run over those, nothing means shuffle. It and `on_progress` stay real arguments because neither is a setting: one is a `Uint8Array` with no business in JSON, the other is a callback.

## The comment this replaces argued the other way

> The argument list is the JS calling convention: wasm_bindgen exports these positionally, and folding them into a settings object would move the naming out of the type system and into a hand-written cast on both sides.

Half right, and the wrong half mattered. **JavaScript has no types to check.** `produce` and `maxGenerate` are both numbers; `autoLevel` and `roundRobin` are both booleans. Transposing either pair type-checked perfectly and ran.

What the list actually offered was arity, and even that was thin. From `verify.mjs` before this change:

```js
w.generate_from_deals(c.script, bytes, 1, 100, 500000, 'oneline', false, false, [])
```

Nine arguments to an eleven-argument function. That was correct — the last two are optional — but nothing about reading it said so.

## What parsing buys

| | |
|---|---|
| `deny_unknown_fields` | `"autolevel"` is refused **by name**, instead of silently taking the default and returning numbers for a run nobody asked for |
| `v` | a caller from a different build is told, rather than half-read |
| required fields | `"missing field \`seed\`"` beats a plausible-looking run seeded from zero |

Those are the two mistakes that actually happen here. A `dealer-run` signature change once travelled through **two merged pull requests** before anyone noticed, which is why there is a WebAssembly job in CI at all.

## One definition

The envelope lives in `web/src/lib/envelope.js` and is imported by the worker and by both node verification scripts, rather than written out three times. It is the shape intended for share links (#98), export files (#100) and bundled demos (#104), so a new setting is one edit and a version bump instead of four edits kept in step by hand.

Required and uncoerced: `seed`, `produce`, `maxGenerate`, `format`. Coerced: `autoLevel`, `roundRobin`, `params` — an untouched checkbox is an ordinary absence with an obvious answer. Optional: `measureSeconds`, omitted rather than sent as `null` so "use the engine's own budget" has one spelling.

## Verification

The parse failures are new behaviour and are tested directly (version mismatch, misspelled field, missing required field, each asserting the message names the thing). But the load-bearing check is that the run itself did not change:

- **`verify.mjs`: all 17 cases still match the native CLI** through the new entry point — deals, produced counts, averages, frequencies and `printes` output.
- **`library-check.mjs`**: the library's bytes still feed a run unchanged, byte for byte across a chunk boundary.

Also run: `cargo clippy --all-targets --all-features -D warnings` (wasm and workspace), `cargo test` in both, `npm test` (216), `npm run build:all`, `./dev-build.sh test`.

`docs/WASM.md` updated throughout, including a new **The run envelope** section documenting the format and why unknown fields are refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)