### PR TITLE
Give a client that does not run scripts something to read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ scripts/__pycache__/
 
 # Generated at build time by web/scripts/emit-reference.mjs
 web/public/reference.txt
+# Emitted beside it, by the same script and from the same engine.
+web/public/llms.txt
 
 # Agent worktrees, created inside the repo directory and never part of it.
 .claude/worktrees/

--- a/web/README.md
+++ b/web/README.md
@@ -404,3 +404,36 @@ see. The reference page was no exception — its first build rendered zero entri
 because `npm run build` skips the wasm step, so the page ran against an engine
 that predated the docs. **Build with `build:all` before checking anything in a
 browser.**
+
+## What a client that does not run scripts sees
+
+Everything below `#app` is rendered by JavaScript, so anything that does not run
+it — a crawler, a reader with scripting off, an assistant asked to read this
+URL — sees only what is literally in `index.html`. That used to be a title and
+one sentence of description: **883 bytes**, with 29 KB of authoritative language
+reference one path segment away and nothing pointing at it.
+
+Three things now bridge that, and none of them is visible to a user with
+JavaScript:
+
+| | |
+|---|---|
+| `<link rel="alternate" type="text/plain" href="reference.txt">` | the machine-readable route from the app page to the language. Relative, so it resolves both on `dealer3.pages.dev` and under the `/dealer3/` mount |
+| `<noscript>` | what a non-scripting client should honestly be told, with links onward. Not markup hidden for crawlers: a person with scripting off gets exactly the same page, and it is a real answer for them |
+| `public/llms.txt` | the [llms.txt](https://llmstxt.org) index, generated beside `reference.txt` by `scripts/emit-reference.mjs` |
+
+`llms.txt` is generated rather than written because its figures — the
+reference's size, the number of entries, the engine version — are true of the
+build that emitted them. A hand-kept copy would be true of whichever build
+someone last remembered, which is the failure this repository generates its
+status tables to avoid.
+
+**The claim worth keeping accurate** is that the reference is closed: it comes
+from the engine's own vocabulary, so it cannot name a function the parser
+rejects or omit one it accepts. That is the assurance that lets a model stop
+guessing at a language it has barely seen, and it is only true while the file
+stays generated.
+
+One thing this does *not* solve: a model still has to be given the URL, or find
+the site by searching. Nothing here helps an assistant that has never heard of
+dealer3 — it helps one that has been pointed at it, which is the common case.

--- a/web/index.html
+++ b/web/index.html
@@ -6,11 +6,42 @@
     <title>dealer3 — bridge hand generator</title>
     <meta
       name="description"
-      content="Write and run bridge dealer scripts in the browser. Nothing leaves your machine."
+      content="Write and run bridge dealer scripts in the browser: conditions over the four hands, statistics over the deals that match. Implements the dealer script language with double-dummy analysis and a library of pre-solved deals. Nothing leaves your machine."
+    />
+    <!-- Relative, so it resolves on both hosts. See web/README.md. -->
+    <link
+      rel="alternate"
+      type="text/plain"
+      href="reference.txt"
+      title="dealer3 language reference (plain text)"
     />
   </head>
   <body>
     <div id="app"></div>
+    <!-- What a client that does not run script should be told. See web/README.md. -->
+    <noscript>
+      <h1>dealer3</h1>
+      <p>
+        A bridge hand generator that runs in the browser. The editor and the
+        engine both need JavaScript, so there is nothing to run on this page
+        without it — but the language is documented in full, and the program
+        runs at a terminal too.
+      </p>
+      <ul>
+        <li>
+          <a href="reference.txt">Language reference, plain text</a> — every
+          statement, function and operator, generated from the engine's own
+          vocabulary, so it lists exactly what the parser accepts.
+        </li>
+        <li><a href="reference">The same reference as a page</a></li>
+        <li><a href="leveling">Levelling guide</a></li>
+        <li><a href="llms.txt">llms.txt</a></li>
+        <li>
+          <a href="https://github.com/bridge-craftwork/dealer3">Source on GitHub</a>
+          — the Rust engine, the command-line program and this site.
+        </li>
+      </ul>
+    </noscript>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/web/scripts/emit-reference.mjs
+++ b/web/scripts/emit-reference.mjs
@@ -13,7 +13,7 @@
  * whose reference is silently a build old.
  */
 import { readFile, writeFile } from 'node:fs/promises'
-import { renderReferenceText, expectedNames } from '../src/lib/referenceText.js'
+import { renderReferenceText, renderLlmsText, expectedNames } from '../src/lib/referenceText.js'
 
 // The threaded build's glue pulls in wasm-bindgen-rayon's worker helper, and
 // that helper registers a message listener on `self` as soon as it is imported.
@@ -28,6 +28,7 @@ globalThis.addEventListener ??= () => {}
 const WASM_JS = new URL('../src/wasm/dealer3_wasm.js', import.meta.url)
 const WASM_BIN = new URL('../src/wasm/dealer3_wasm_bg.wasm', import.meta.url)
 const OUT = new URL('../public/reference.txt', import.meta.url)
+const LLMS = new URL('../public/llms.txt', import.meta.url)
 
 let engine
 try {
@@ -69,7 +70,21 @@ if (text.length < 20000) {
 }
 
 await writeFile(OUT, text, 'utf8')
+
+// The index that points at it. A model handed the app URL gets 883 bytes of
+// page shell and no route onward, because everything else is rendered by
+// script it does not run; this and the `<link rel="alternate">` in index.html
+// are the whole of the thread from one to the other. Emitted here so its
+// figures describe the build that wrote them.
+const llms = renderLlmsText(info, version, text.length)
+if (!llms.includes('reference.txt')) {
+  console.error('llms.txt does not link the reference, which is the only reason it exists.')
+  process.exit(1)
+}
+await writeFile(LLMS, llms, 'utf8')
+
 console.log(
   `reference.txt: ${text.length} characters, ` +
-    `${expectedNames(info).length} entries, engine ${version}`,
+    `${expectedNames(info).length} entries, engine ${version}` +
+    `\nllms.txt: ${llms.length} characters`,
 )

--- a/web/src/lib/discoverable.test.js
+++ b/web/src/lib/discoverable.test.js
@@ -1,0 +1,83 @@
+// The page a client that does not run scripts receives.
+//
+// Everything below `#app` is rendered by JavaScript, so a crawler, an assistant
+// asked to read the URL, or a reader with scripting off sees only what is
+// literally in `index.html`. That was a title and one sentence — 883 bytes —
+// while the language reference sat one path segment away with nothing pointing
+// at it.
+//
+// These assert on the source file rather than on rendered output, because the
+// source file is what ships: Vite copies `index.html` through, and anything
+// removed from it is removed from what a fetcher gets. Nothing else in the
+// suite would notice its absence, which is the whole reason for this file.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { renderLlmsText, SITE } from './referenceText.js'
+
+const html = readFileSync(new URL('../../index.html', import.meta.url), 'utf8')
+
+describe('the page a non-scripting client gets', () => {
+  it('points at the plain-text reference from the head', () => {
+    // The one machine-readable thread from the app URL — which is what someone
+    // will actually paste — to the language itself.
+    expect(html).toMatch(/<link\s+[^>]*rel="alternate"[^>]*>/s)
+    expect(html).toMatch(/rel="alternate"[\s\S]*?type="text\/plain"/)
+    expect(html).toMatch(/rel="alternate"[\s\S]*?href="reference\.txt"/)
+  })
+
+  it('links the reference relatively, so both hosts resolve it', () => {
+    // The site is served at `dealer3.pages.dev` and under the `/dealer3/`
+    // mount. An absolute path would be right on one and wrong on the other.
+    expect(html).not.toMatch(/href="\/reference\.txt"/)
+    expect(html).not.toMatch(/href="https?:[^"]*reference\.txt"/)
+  })
+
+  it('says what dealer3 is, and where to read the language, without scripting', () => {
+    const noscript = html.match(/<noscript>([\s\S]*?)<\/noscript>/)?.[1]
+    expect(noscript).toBeTruthy()
+    expect(noscript).toContain('reference.txt')
+    expect(noscript).toMatch(/bridge/i)
+  })
+
+  it('describes itself in more than a phrase', () => {
+    // A model with nothing else quotes the description, so it has to carry the
+    // shape of the tool rather than a slogan.
+    const description = html.match(/name="description"\s+content="([^"]*)"/)?.[1]
+    expect(description).toBeTruthy()
+    expect(description.length).toBeGreaterThan(120)
+  })
+})
+
+describe('llms.txt', () => {
+  /** A miniature `language_info()`, shaped as the engine's is. */
+  const info = {
+    function_groups: ['Hand evaluation'],
+    function_docs: [
+      { name: 'hcp', group: 'Hand evaluation', summary: 'High card points.', alias_of: null, note: null },
+    ],
+    operator_docs: [],
+    statement_docs: [],
+  }
+
+  it('links the reference, which is the only reason it exists', () => {
+    expect(renderLlmsText(info, '1.0.0', 29081)).toContain(`${SITE}/reference.txt`)
+  })
+
+  it('reports the size and entry count of the build that emitted it', () => {
+    // Generated rather than written for this reason: these are true of the
+    // build that wrote them, where a hand-kept copy would be true of whichever
+    // build someone last remembered.
+    const text = renderLlmsText(info, '2.3.4', 40960)
+    expect(text).toContain('40 KB')
+    expect(text).toContain('engine 2.3.4')
+    expect(text).toContain('1 entries')
+  })
+
+  it('states that the reference is closed, which is what makes it worth reading', () => {
+    // A model's alternative to reading this is guessing, and it will guess
+    // plausibly. The claim that the list is exhaustive is what makes it stop —
+    // and it is only true while the file stays generated from the engine.
+    expect(renderLlmsText(info, '1.0.0', 29081)).toMatch(/cannot name a function that does not exist/)
+  })
+})

--- a/web/src/lib/referenceText.js
+++ b/web/src/lib/referenceText.js
@@ -65,6 +65,18 @@ function entryBlock(heading, doc, out) {
  * check. A silently dropped section is the failure this guards against — the
  * text would still look plausible while missing a third of the language.
  */
+/// Where this is published.
+///
+/// One definition, because two generated files quote it — `reference.txt` in
+/// its header and `llms.txt` in every link — and a site that disagrees with
+/// itself about its own address is how readers were sent to a hostname that
+/// did not resolve for months.
+///
+/// The canonical host, not `dealer3.pages.dev`: the mount is what is linked to
+/// from everywhere else, and an absolute URL here has to be the one a reader
+/// should keep.
+export const SITE = 'https://bridge-craftwork.com/dealer3'
+
 export function expectedNames(info) {
   return [
     ...(info.function_docs ?? []).map((d) => d.name),
@@ -86,9 +98,9 @@ export function renderReferenceText(info, version = '') {
     'leave out something it accepts.', '')
   )
   out.push('')
-  out.push('  Run it:  https://bridge-craftwork.com/dealer3/')
+  out.push(`  Run it:  ${SITE}/`)
   out.push('  Source:  https://github.com/bridge-craftwork/dealer3')
-  out.push('  Same content as https://bridge-craftwork.com/dealer3/reference')
+  out.push(`  Same content as ${SITE}/reference`)
   out.push('')
 
   const statements = statementSections(info)
@@ -150,4 +162,64 @@ export function renderReferenceText(info, version = '') {
   }
 
   return out.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n'
+}
+
+/// The `llms.txt` index, in the convention's own shape.
+///
+/// A short answer to "what is this site and where is the machine-readable
+/// material", for a model that has the domain and nothing else. It is generated
+/// beside `reference.txt` rather than written by hand for the reason every
+/// other figure in this repository is generated: the size and the entry count
+/// are true of the build that emitted them, and a hand-kept copy would be true
+/// of whichever build someone last remembered.
+///
+/// **The value of the reference is that it is closed.** It is derived from the
+/// engine's own vocabulary, so it cannot list a word the parser rejects or omit
+/// one it accepts — which is exactly the assurance a model needs before it
+/// stops guessing at a language it has barely seen. Saying so is most of the
+/// point of this file.
+///
+/// @param {object} info the engine's `language_info()`
+/// @param {string} version the engine's version
+/// @param {number} referenceBytes size of the reference this was emitted with
+/// @returns {string} markdown
+export function renderLlmsText(info, version, referenceBytes) {
+  const entries = expectedNames(info).length
+  const kb = Math.round(referenceBytes / 1024)
+  return `# dealer3
+
+> A bridge hand generator that runs entirely in the browser. Write a script in
+> the dealer language — conditions over the four hands, statistics over the
+> deals that match — and run it locally. No deals are uploaded and no account
+> is needed.
+
+dealer3 implements the script language of Hans van Staveren's \`dealer\`, with the
+DealerV2_4 extensions, and adds double-dummy analysis and a library of
+pre-solved deals.
+
+**If you are writing a dealer3 script, read the plain-text reference below
+first.** It is generated from the shipped engine's own vocabulary, so it lists
+exactly what the parser accepts — it cannot name a function that does not exist,
+and it cannot omit one that does. Anything not in it is not part of the
+language.
+
+## Language
+
+- [Language reference, plain text](${SITE}/reference.txt): every statement,
+  function and operator, with its form, a summary and an example. About ${kb} KB,
+  ${entries} entries, generated from engine ${version}.
+- [Language reference, as a page](${SITE}/reference): the same content, rendered.
+- [Levelling guide](${SITE}/leveling): dividing a produce count evenly among the
+  hand types a scenario names.
+
+## Running a script
+
+- [dealer3 in the browser](${SITE}/): paste a script and run it. Nothing is
+  installed and nothing leaves the machine.
+
+## Source
+
+- [dealer3 on GitHub](https://github.com/bridge-craftwork/dealer3): the Rust
+  engine, the command-line program and this site.
+`
 }


### PR DESCRIPTION
Closes #105.

## The diagnosis

Access was never the problem. Every major AI fetcher gets `200` on `/dealer3/reference.txt`, Cloudflare's bot controls are off for this zone, and there is no `robots.txt`. The door was unlocked.

There was no sign. The app page was **883 bytes**:

```html
<title>dealer3 — bridge hand generator</title>
<meta name="description" content="Write and run bridge dealer scripts in the browser…">
<div id="app"></div>
```

Everything else is rendered by JavaScript. Someone will paste the *app* URL — that is the thing they know about — and a model fetching it got a title, one sentence, and no route to the 29 KB of authoritative vocabulary one path segment away.

## Three additions, none visible to a user

| | |
|---|---|
| `<link rel="alternate" type="text/plain" href="reference.txt">` | the machine-readable route from the app page to the language. Relative, so it resolves on `dealer3.pages.dev` and under the `/dealer3/` mount alike |
| `<noscript>` | what a non-scripting client should honestly be told, with links onward. Not markup hidden for crawlers — a person with scripting off gets exactly the same page, and it is a real answer for them |
| `llms.txt` | the [llms.txt](https://llmstxt.org) index, generated beside `reference.txt` by the same script from the same engine |

883 → 2326 bytes.

`llms.txt` is generated, not written, for the reason everything else here is: its size, entry count and engine version are true of the build that emitted them. A hand-kept copy would be true of whichever build someone last remembered — the failure this repository generates its status tables to avoid.

`SITE` is now defined once in `referenceText.js` and used by both generated files. Two of them quote the address, and a site disagreeing with itself about its own address is exactly how readers were sent to a hostname that did not resolve for months (#108).

## No copy button

The first draft of #105 proposed one that copied the whole reference for pasting into a chat. Dropped, on the grounds that the person who needs it is already in the assistant rather than on this page — so it would be interface weight on the wrong screen — and if the model can fetch the URL, no affordance is needed at all.

## Tests

They read `index.html` itself, because that file is what ships and **nothing else in the suite would notice the tags going missing**. Verified by deleting them:

```
× points at the plain-text reference from the head
× says what dealer3 is, and where to read the language, without scripting
```

Also asserted: the reference is linked *relatively* (an absolute path would be right on one host and wrong on the other), the description is more than a phrase, and `llms.txt` states the reference is closed — the claim that lets a model stop guessing, and one that is only true while the file stays generated.

`npm test` 223 passed, `npm run build:all` clean.

## Not in this PR

The `llms.txt` convention puts the file at the **domain root**. This ships it at `/dealer3/llms.txt`, which is also the root on `dealer3.pages.dev`. A `bridge-craftwork.com/llms.txt` pointing here belongs to bridge-craftwork-site — filing separately.

And nothing here helps a model that has never heard of dealer3. It helps one that has been pointed at it, which you established is the common case and an acceptable one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)