### PR TITLE
Give the settings button a box, and check that CSS tokens exist

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1067,20 +1067,33 @@ body {
 /* The gear sits with Run, not adrift at the far edge: `margin-left: auto` on
    Run pushes everything before it left, so placing this immediately before Run
    keeps the pair together however wide the row gets. */
+/* Sized and bordered like Cancel, because it is that kind of control: a
+   secondary button on the Run row. It first shipped with `var(--border)` and
+   `var(--bg-raised)`, neither of which this file defines — and an undefined
+   `var()` inside the `border` shorthand makes the whole declaration invalid,
+   which resolves to `border-style: none`. So it had no border, no background
+   and no box at all, and nothing anywhere reported a problem.
+
+   The row is `align-items: end`, so what makes this look level with its
+   neighbours is its box height matching theirs rather than any alignment
+   property. 4 + 4 padding, 16px glyph and 2px border is 26px, against Run's
+   ~26 and Cancel's ~28. */
 .settings-toggle {
-  font-size: 1rem; line-height: 1; padding: 5px 9px; cursor: pointer;
-  border: 1px solid var(--border); border-radius: 6px;
-  background: var(--bg-raised); color: var(--fg-muted);
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 32px;
+  padding: 4px 9px; font-size: 16px; line-height: 1; cursor: pointer;
+  border: 1px solid var(--line); border-radius: 4px;
+  background: #fff; color: var(--fg-muted);
 }
-.settings-toggle:hover { color: var(--fg); }
+.settings-toggle:hover { color: var(--fg); border-color: var(--fg-muted); }
 /* Open is a state, not a hover: with the panel below, the button has to say
    which of the two it is, or the only way to tell is to look away from it. */
-.settings-toggle.on { color: var(--fg); border-color: var(--accent); background: var(--bg); }
+.settings-toggle.on { color: var(--accent); border-color: var(--accent); }
 
 .settings-panel {
   display: flex; flex-wrap: wrap; align-items: center; gap: 6px 14px;
   padding: 8px 10px; margin: 0 0 6px;
-  border: 1px solid var(--border); border-radius: 6px; background: var(--bg-raised);
+  border: 1px solid var(--line); border-radius: 6px; background: var(--bg-subtle);
 }
 .settings-panel label { font-size: 0.82rem; white-space: nowrap; }
 /* Wraps onto its own line rather than sitting in the flow of controls: it is a

--- a/web/src/lib/cssTokens.test.js
+++ b/web/src/lib/cssTokens.test.js
@@ -1,0 +1,64 @@
+// Every `var(--token)` resolves to a token something defines.
+//
+// CSS fails silently and specifically: an undefined `var()` is not ignored,
+// it makes the whole declaration invalid at computed-value time, and the
+// property falls back to its initial value. `border: 1px solid var(--nope)`
+// does not draw a default border — it resolves to `border-style: none` and
+// draws nothing at all.
+//
+// So a typo in a token name deletes a rule, in a build that succeeds, with no
+// warning from Vite, no console error, and no failing test. The settings
+// button shipped with `var(--border)` and `var(--bg-raised)`, neither of which
+// exists, and had no border, no background and no box; it took someone looking
+// at it to notice.
+//
+// `var(--x, fallback)` is deliberately allowed. A fallback is the language's
+// own way of saying "this may not be defined", and `var(--muted, #777)` is
+// correct code.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = new URL('../', import.meta.url).pathname
+
+/** Every `.vue` under `web/src`, since that is where all the styling lives. */
+function vueFiles(dir = ROOT, found = []) {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name)
+    if (statSync(path).isDirectory()) vueFiles(path, found)
+    else if (name.endsWith('.vue')) found.push(path)
+  }
+  return found
+}
+
+/** Comments hold prose about tokens; only real declarations count. */
+const withoutComments = (s) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/<!--[\s\S]*?-->/g, '')
+
+const files = vueFiles()
+const sources = new Map(files.map((f) => [f, withoutComments(readFileSync(f, 'utf8'))]))
+
+/** Tokens defined anywhere: they are inherited, so `:root` in App.vue serves all. */
+const defined = new Set()
+for (const source of sources.values()) {
+  for (const [, name] of source.matchAll(/(--[a-z0-9-]+)\s*:/g)) defined.add(name)
+}
+
+describe('CSS custom properties', () => {
+  it('finds the app to check', () => {
+    // If the walk breaks, every assertion below passes vacuously.
+    expect(files.length).toBeGreaterThan(5)
+    expect(defined.size).toBeGreaterThan(15)
+  })
+
+  it.each([...sources.keys()].map((f) => [f.slice(ROOT.length), f]))(
+    '%s uses only tokens that exist',
+    (_label, file) => {
+      // Bare `var(--x)` only. `var(--x, fallback)` says out loud that the
+      // token may be missing, and is correct.
+      const used = [...sources.get(file).matchAll(/var\(\s*(--[a-z0-9-]+)\s*\)/g)].map((m) => m[1])
+      const missing = [...new Set(used)].filter((name) => !defined.has(name))
+      expect(missing).toEqual([])
+    },
+  )
+})


### PR DESCRIPTION
The gear from #112 was a bare glyph — small, no border, no background, sitting at a different height from its neighbours.

## Cause: two tokens I invented

`.settings-toggle` and `.settings-panel` used `var(--border)` and `var(--bg-raised)`. This app defines neither; it has `--line` and `--bg-subtle`.

**An undefined `var()` does not fall back to a sensible default.** It makes the whole declaration invalid at computed-value time, so the property takes its *initial* value:

```css
border: 1px solid var(--border);   /* → border-style: none. No border at all. */
background: var(--bg-raised);      /* → transparent */
```

So the button had no box, and the panel had quietly lost its border and background too.

## Size and alignment

The row is `align-items: end`, so what makes a control look level is its **box height matching its neighbours'**, not any alignment property. Now sized like Cancel — 4px padding, a 16px glyph, a 1px border — giving 26px against Run's ~26 and Cancel's ~28.

`min-width: 32px` and an inner flex centre so the glyph sits in the middle of a square-ish button, and open state now shows in the accent colour rather than a background swap.

## The part worth keeping

**The build succeeded. 224 tests passed. It deployed.** Nothing in the toolchain reports an undefined custom property — not Vite, not the console, not a test.

So now something does. `cssTokens.test.js` walks every `.vue` under `web/src` and asserts each bare `var(--x)` names a token something defines. Tokens inherit, so `:root` in App.vue counts for all of them.

`var(--x, fallback)` is deliberately allowed: a fallback is the language's own way of saying the token may be missing, and `var(--muted, #777)` in ResultsPanel is correct code. The check strips comments first, or prose about tokens would trip it.

Verified by introducing a typo:

```
× CSS custom properties > App.vue uses only tokens that exist
  → expected [ '--borderr' ] to deeply equal []
```

4ms, and it names the token.

237 tests pass; `npm run build:all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)