### PR TITLE
Stop iOS inflating the text, which was pushing the page off the screen

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -122,7 +122,13 @@
             :aria-expanded="settingsOpen ? 'true' : 'false'"
             @click="settingsOpen = !settingsOpen"
           >
-            <span aria-hidden="true">⚙</span>
+            <!-- U+FE0E, the text variation selector. U+2699 has no default
+                 presentation, so a platform chooses: macOS draws the glyph,
+                 iOS draws a colour emoji, and the button showed a shaded 3D
+                 cog on a phone and a flat one on a desktop. This asks for the
+                 text form, which also keeps it in `currentColor` with the
+                 rest of the button. -->
+            <span aria-hidden="true">⚙︎</span>
           </button>
 
           <button
@@ -1037,7 +1043,13 @@ body {
 .settings-panel input, .settings-panel select, .run-row input {
   font: inherit; font-size: 12px; padding: 3px 5px;
   border: 1px solid var(--line); border-radius: 3px; background: var(--bg); color: var(--fg);
+  /* The widths below are in `ch` and `em`, so they follow the font. If anything
+     ever inflates it again — a platform, a user's setting — a field grows and
+     its row does not. These two stop it from taking the page with it: a label
+     that may shrink, and a field that may not exceed what holds it. */
+  max-width: 100%; min-width: 0;
 }
+.settings-panel label, .run-row label { min-width: 0; }
 /* Numeric fields sized for the values they actually hold.
    A number input draws its spinner INSIDE its own box, and the box also carries
    the field's padding and border, so the digits are clipped well before the

--- a/web/src/base.css
+++ b/web/src/base.css
@@ -1,0 +1,27 @@
+/* Rules that have to reach `html`, which a scoped component stylesheet cannot.
+ *
+ * ## Text that inflates itself
+ *
+ * iOS Safari's default is `-webkit-text-size-adjust: auto`, which inflates text
+ * in blocks it judges too small for the viewport **while leaving layout widths
+ * alone**. Everything measured in `ch` or `em` — every number field on this
+ * page, and CodeMirror's own content width, which it computes from the font's
+ * metrics — grows with the font, and the containers holding them do not.
+ *
+ * The result on an iPhone 16 Pro Max: the editor's 13px script rendered at
+ * about 18px, a 1.4x boost, and the editor box and the Run button hung off the
+ * right of a page that fit perfectly in every desktop measurement, including
+ * one taken at 300px with the same script.
+ *
+ * `100%` turns the boost off; it does not stop pinch-zoom, and it does not
+ * disable Dynamic Type for text set in a system font. normalize.css and
+ * Tailwind's preflight both set it, for this reason.
+ *
+ * The wider lesson is worth keeping: a layout verified only in a desktop
+ * browser at a phone's *width* has not been verified on a phone. The width was
+ * never what differed.
+ */
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import './base.css'
 import './print.css'
 
 createApp(App).mount('#app')


### PR DESCRIPTION
The layout still clipped on an iPhone after #116. **The reason was not width** — every desktop measurement in that PR was correct, and none of them modelled the phone.

## What is actually happening

iOS Safari defaults to `-webkit-text-size-adjust: auto`, which inflates text in blocks it judges too small for the viewport **while leaving layout widths alone**.

Everything sized in `ch` or `em` grows with the font — every number field on this page, and CodeMirror's content width, which it computes from the font's own metrics — while the containers holding them do not.

Measured off the screenshot rather than guessed. The device is an iPhone 16 Pro Max (1320×2868 = 440 CSS px at 3×), and the editor's monospace line `# alias: Jacoby2NLeveled` — 24 characters — spans ~257 CSS px:

| | |
|---|---|
| editor font-size in CSS | **13px** |
| implied by the screenshot | **~18px** (10.7px per character ÷ 0.6) |
| `-webkit-text-size-adjust` | **`auto`** |

A 1.4× boost. That is why the editor box and Run hung off the right of a page that fits at 440px, at 300px, and at 300px with the same long-line script.

## Why I could not reproduce it at first

I tried narrowing the viewport, and I tried inflating the text — but only within `.run-row`, where flex wrapping absorbed it. iOS inflates the editor too, and CodeMirror's measured width is what carried the row off the page.

## The fix

`html { -webkit-text-size-adjust: 100% }`, in a new `base.css` because App.vue's stylesheet is scoped and cannot reach `html`. It does not stop pinch-zoom and does not disable Dynamic Type for system-font text. normalize.css and Tailwind's preflight both set it, for this reason.

Verified: `getComputedStyle(document.documentElement).webkitTextSizeAdjust === '100%'`, the rule reaches `dist/assets/main-*.css`, and at 440×956 — your device's exact viewport — `scrollWidth === clientWidth` with Run on screen at 432.

## Two smaller things

**Fields cannot widen their row.** `max-width: 100%` on the inputs and `min-width: 0` on their labels. Under a simulated 1.8× boost the page still does not overflow. A safety net for the next inflation rather than a fix for this one.

**The gear asks for text presentation** — U+2699 followed by U+FE0E. U+2699 has no default presentation, so the platform chooses: macOS drew the glyph, iOS drew a shaded colour emoji.

## Worth keeping

A layout verified in a desktop browser at a phone's *width* has not been verified on a phone. Width was never what differed. The `scrollWidth === clientWidth` Playwright guard I proposed on #116 would **not** have caught this either — it would need a WebKit runtime with autosizing on.

249 tests pass; `npm run build:all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)