### PR TITLE
Share a script by link, and open one without running it (#98, #99)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -28,6 +28,9 @@ src/
 │   ├── guide.js          rendering a docs/ markdown file as a page
 │   ├── engine.worker.js  generation, off the main thread
 │   ├── library.js        the solved-deal library: fetching, caching, wording
+│   ├── envelope.js       the run the engine takes, and the document a link carries
+│   ├── share.js          a document to a URL fragment and back
+│   ├── clipboard.js      copying text, with the fallback the platforms need
 │   └── download.js       saving results as PBN or text
 ├── Reference.vue         the language reference page
 ├── Leveling.vue          the levelling guide, rendered from docs/
@@ -132,7 +135,100 @@ is no caret to select from either.
 `CopyButton.vue` reads the document from the editor at click time rather than
 holding its own copy, and falls back to a hidden `<textarea>` when
 `navigator.clipboard` is missing or refused, which it is on an insecure origin.
-A failure says so rather than flashing "Copied".
+A failure says so rather than flashing "Copied". The clipboard itself lives in
+`clipboard.js`, shared with the Share button below.
+
+## Sharing a script by link
+
+**Share**, beside the settings gear, copies a link that opens the script *and*
+its settings on somebody else's machine. The alternative was sending a PDF,
+which the recipient cannot run: they have to copy the text back out, and none of
+the settings travel with it.
+
+The payload is in the **URL fragment**, and never in the query string. Nothing
+after the `#` is sent with the request, so a link reaches no server log, no cache
+key and no edge rule — which is what makes this shippable with no back end, and
+why it costs nothing to keep working. It is also the form that survives the trip:
+a real BBO capture sent as a query string came back **403 at the edge** on
+2026-08-28 while the identical payload in the fragment loaded. bridge-solver
+already hands hands over this way; the cross-tool contract
+(`bridge-craftwork-site#3`, item 4) settles it for every tool here.
+
+Three forms, cheapest first, all of which open the same way:
+
+| Fragment | Means |
+|---|---|
+| `#s=<scenario>` | a scenario from the list, unmodified, plus what was changed |
+| `#d=<base64url>` | the document itself, deflated — no network at all |
+| `#k=<key>` | the short-link service (#103), which is not built |
+
+Sharing an untouched scenario needs no encoding at all: the recipient's page
+fetches the same script from the same list, so the link is
+`#s=Sup_X_By_Advancer&seed=8391` and stays readable in an email. Change one
+character of it and the whole script travels instead — otherwise the recipient
+would open a *different* script under the right name, which is worse than a long
+link. That form is `JSON.stringify` → `CompressionStream('deflate-raw')` →
+base64url, native in Safari 16.4, Chrome and Firefox, so no library: 600–900
+bytes of script comes out around 350–550 characters.
+
+`#k=` is recognised and refused with a sentence, rather than opening a page that
+looks as though there was no link. Nothing produces one yet.
+
+### What a link carries, and what it does not
+
+The engine's envelope (`run_json`) is one half of a run: script, seed, produce,
+max generate, format, auto-level, round robin, params, measure budget. It
+refuses fields it does not know, deliberately. A **document** is that plus the
+two settings the caller acts on and the engine never sees:
+
+- **`dealSource`** — random or the pre-solved library. The engine infers the
+  source from whether deals were handed to it, so being *told* "library" would
+  be a field it could not act on. The recipient's page needs it to know to fetch
+  before calling.
+- **`newSeedEachRun`** — the engine takes a *definite* seed, so "roll a new one"
+  is resolved before the call. A demo link probably wants it on; a link showing a
+  particular hand definitely wants it off.
+
+`scenario` travels with them, so the list opens pointing at the right entry.
+What must **not** travel is UI state — whether the picker or the settings panel
+was open is about the sender's window.
+
+Both shapes live in `envelope.js`, and narrowing is not a function: `runEnvelope`
+names the engine's fields, so passing it a document's settings drops the caller's
+by not asking for them. There is deliberately no second list to keep in step. A
+document cannot be handed to `run_json` whole — that is refused, by design.
+
+One conversion is easy to lose: the page keeps `paramValues` by parameter number,
+the envelope takes `params` as `N=TEXT`, and a link carries the engine's
+spelling. `paramValuesFrom` projects it back. Miss it and a shared parameterised
+scenario arrives with blank fields, running on the script's declared defaults —
+looking exactly as though it had worked.
+
+### Opening one
+
+A link **loads and stops**. Nothing runs: an unknown script can be expensive (a
+double-dummy condition on shuffled deals takes minutes), the recipient should see
+what they are about to run, and a page that starts work on open makes the back
+button surprising.
+
+The fragment is untrusted input, so it parses or it is refused with a sentence
+worth reading — a truncated link says it was truncated, an unknown version says
+so by number rather than half-loading, and a setting that means nothing falls
+back to its default rather than throwing the script away with it. Inflation is
+bounded: a few hundred characters of deflate can become hundreds of megabytes,
+and a tab that hangs before anything is on screen is the one failure with no way
+back.
+
+A shared script never silently replaces what was in the editor. The session from
+before the link is held in memory — the autosave overwrites the stored copy
+within half a second — and the notice above the editor offers it back. That is
+the only way back: the page never navigated, so the back button would leave the
+site.
+
+The fragment is left in the address bar, so the link can be re-opened from
+history and the autosave takes over from the first edit. Declining it with
+**Bring back what I had** removes it, since it must not open again on the next
+reload.
 
 ## Deploying
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -73,6 +73,23 @@
       </aside>
 
       <section class="col col-editor">
+        <!-- What a link did, said where the script it replaced is. A link that
+             quietly swapped somebody's work for a stranger's would be the one
+             unforgivable thing this feature could do, so the way back is
+             offered here rather than left to the back button — which would not
+             help, the page having never navigated. -->
+        <p v-if="shareError" class="shared-notice bad">{{ shareError }}</p>
+        <p v-else-if="sharedNotice" class="shared-notice">
+          <span>{{ sharedNotice }}</span>
+          <button
+            v-if="canRestore"
+            class="shared-restore"
+            title="Put back the script and settings that were here before this link was opened"
+            @click="restorePrevious"
+          >Bring back what I had</button>
+          <button class="shared-dismiss" title="Hide this" @click="sharedNotice = ''">Dismiss</button>
+        </p>
+
         <!-- Said where it is chosen rather than in the results, because it is
              a reason to choose differently before pressing Run: a script with
              no double-dummy question in it downloads 640 KiB and reads none of
@@ -113,6 +130,18 @@
                place beside Run. -->
           <label>Produce <input v-model.number="produce" class="num-produce" type="number" min="1" /></label>
 
+          <!-- Beside the gear rather than in it: sharing is something you go
+               looking for, and a control behind a disclosure is one nobody
+               finds. It shares what is in the editor and the settings around
+               it — on the Leveled tab that is still the script that produced
+               the levelling, which is the thing worth sending. -->
+          <button
+            class="share"
+            :disabled="!script.trim()"
+            title="Copy a link to this script and its settings. The link holds them itself — nothing is uploaded."
+            @click="onShare"
+          >Share</button>
+
           <button
             class="settings-toggle"
             :class="{ on: settingsOpen }"
@@ -143,6 +172,24 @@
                a sub-second run would otherwise flash a button nobody could
                have used. -->
           <button v-if="showProgress" class="cancel" @click="cancel">Cancel</button>
+        </div>
+
+        <!-- The link itself, and not only the clipboard: a copy can be refused
+             outright by the browser, and a link nobody can see would then be a
+             button that appeared to work. Selectable, so it can be taken by
+             hand. -->
+        <div v-if="shareLink" class="share-panel">
+          <input
+            ref="shareField"
+            class="share-input"
+            type="text"
+            readonly
+            aria-label="Link to this script"
+            :value="shareLink"
+            @focus="$event.target.select()"
+          />
+          <button class="shared-dismiss" @click="shareLink = ''">Done</button>
+          <p class="share-note settings-note">{{ shareNote }}</p>
         </div>
 
         <!-- Everything that is set once and then left alone. It used to be a
@@ -361,10 +408,13 @@ import {
   poolInfo,
 } from '@/lib/engine.js'
 import { libraryStatusText, pointlessLibraryWarning, slowRandomWarning } from '@/lib/library.js'
-import { fetchScenarioScript } from '@/lib/pbsScenarios.js'
+import { fetchScenarioScript, prettifyLabel } from '@/lib/pbsScenarios.js'
 import { downloadText, resultFilename, statisticsText } from '@/lib/download.js'
 import { loadSession, saveSession } from '@/lib/session.js'
 import { randomSeed } from '@/lib/format.js'
+import { makeDocument, paramValuesFrom } from '@/lib/envelope.js'
+import { parseFragment, resolveFragment, shareFragment, shareUrl } from '@/lib/share.js'
+import { copyText } from '@/lib/clipboard.js'
 
 const STARTER = `# Write a dealer script, or pick a scenario on the left.
 condition hcp(north) >= 15 && shape(north, any 4333 + any 4432 + any 5332)
@@ -723,6 +773,13 @@ watch(leveledScript, (text) => {
 })
 
 onMounted(async () => {
+  // First, and not awaited with the rest: a shared script should be on screen
+  // while the engine is still loading, exactly as a restored one is.
+  openSharedLink()
+  // A link pasted into the address bar of a tab that is already here changes
+  // the fragment without reloading anything, and without this the page would
+  // sit there having visibly done nothing.
+  window.addEventListener('hashchange', openSharedLink)
   await ready()
   engineReady.value = true
   engineVersion.value = version()
@@ -798,7 +855,13 @@ async function pickScenario(item) {
   loadingFile.value = item.file
   error.value = ''
   try {
-    script.value = await fetchScenarioScript(item.file)
+    const text = await fetchScenarioScript(item.file)
+    script.value = text
+    // What the list served, kept so Share can tell an untouched scenario from
+    // an edited one. An untouched one travels as its name; one changed by a
+    // character cannot, or the recipient would open a different script under
+    // the right name.
+    pristine.value = { file: item.file, text }
     selectedFile.value = item.file
     result.value = null
     // Let the editor take the new buffer and re-validate before running.
@@ -873,6 +936,201 @@ async function onDownload(kind) {
 // nothing to the bundle.
 function onPrint() {
   window.print()
+}
+
+// --- Sharing, and opening what somebody shared ---------------------------
+//
+// A link carries the script and the settings in its fragment, so it reaches no
+// server: there is nothing to store, nothing to expire, and nothing logged.
+// `share.js` holds the encoding and the three forms; here is only what the page
+// does with them.
+
+/// The script as the scenario list served it. Share compares against this to
+/// decide whether the script itself has to travel.
+const pristine = ref({ file: '', text: '' })
+
+/// The link most recently made, shown until it is dismissed.
+const shareLink = ref('')
+const shareNote = ref('')
+const shareField = ref(null)
+
+/// What opening a link did, and what went wrong if it did not open.
+const sharedNotice = ref('')
+const shareError = ref('')
+
+/// What the editor held before a link replaced it.
+///
+/// Kept here rather than read back from the session: the autosave overwrites
+/// the stored copy within half a second of the shared script arriving, and this
+/// also covers work done since the page was opened, which the stored copy would
+/// not have.
+const displaced = ref(null)
+const canRestore = computed(() => !!displaced.value)
+
+/// Everything a link can change, as it stands.
+function currentState() {
+  return {
+    script: script.value,
+    seed: seed.value,
+    produce: produce.value,
+    maxGenerate: maxGenerate.value,
+    format: format.value,
+    roundRobin: roundRobin.value,
+    dealSource: dealSource.value,
+    scenario: selectedFile.value,
+    paramValues: paramValues.value,
+    newSeedEachRun: newSeedEachRun.value,
+    measureSeconds: measureSeconds.value,
+    autoLevel: autoLevel.value,
+    autoLevelTouched: autoLevelTouched.value,
+    pristine: pristine.value,
+  }
+}
+
+function sharedMeasureSeconds() {
+  if (!autoLevel.value || !hasHandTypes.value || measureSeconds.value == null) return undefined
+  const engineDefault = engineReady.value ? defaultMeasureSeconds() : null
+  return measureSeconds.value === engineDefault ? undefined : measureSeconds.value
+}
+
+async function onShare() {
+  shareError.value = ''
+  const doc = makeDocument(script.value, {
+    seed: seed.value,
+    produce: produce.value,
+    maxGenerate: maxGenerate.value,
+    format: format.value,
+    autoLevel: autoLevel.value && hasHandTypes.value,
+    roundRobin: roundRobinAsked.value,
+    // What the run would send, rather than what has been typed: a value for a
+    // parameter the script does not use would not change the run, and should
+    // not change the link either.
+    params: paramSpecs.value,
+    // Only when the run would use it, and only when it is not the engine's own
+    // number. A link saying twenty seconds when twenty is the default says
+    // nothing — and would go on saying it after the default had changed.
+    measureSeconds: sharedMeasureSeconds(),
+    dealSource: dealSource.value,
+    newSeedEachRun: newSeedEachRun.value,
+    scenario: selectedFile.value,
+  })
+  let fragment
+  try {
+    fragment = await shareFragment(doc, {
+      pristineScript: pristine.value.file === selectedFile.value ? pristine.value.text : null,
+    })
+  } catch (e) {
+    shareLink.value = ''
+    shareError.value = e?.message || String(e)
+    return
+  }
+  shareLink.value = shareUrl(window.location, fragment)
+  const copied = await copyText(shareLink.value)
+  // Short, because the panel it sits in is squeezed on a phone \u2014 which is
+  // where a link is most likely to be read.
+  shareNote.value =
+    (copied ? 'Copied. ' : 'The browser refused to copy \u2014 take it from here. ') +
+    (fragment.startsWith('#s=')
+      ? 'It names the scenario and your settings; the script comes from the same list.'
+      : `The whole script is in the link \u2014 ${shareLink.value.length} characters, and ` +
+        'nothing is uploaded.')
+  // Selected, so it can be taken by hand on the platforms where a copy is
+  // refused, which are the platforms this matters on.
+  await nextTick()
+  shareField.value?.select?.()
+}
+
+/// Open whatever the fragment names, and stop. Nothing runs: an unknown script
+/// can be expensive, the reader should see what they are about to run, and a
+/// page that starts work on open makes the back button surprising.
+async function openSharedLink() {
+  if (!parseFragment(window.location.hash)) return
+  // A second link, pasted after a first one failed, must not open underneath
+  // the first one's complaint.
+  shareError.value = ''
+  try {
+    const opened = await resolveFragment(window.location.hash, {
+      fetchScenario: fetchScenarioScript,
+    })
+    if (opened) applySharedDocument(opened)
+  } catch (e) {
+    shareError.value = e?.message || String(e)
+  }
+}
+
+function applySharedDocument({ source, doc }) {
+  const s = doc.settings
+  // Only worth keeping when there is something to lose. This is the only way
+  // back to it: the page has not navigated, so the back button would leave the
+  // site rather than undo this.
+  const before = currentState()
+  displaced.value = before.script.trim() && before.script !== doc.script ? before : null
+
+  script.value = doc.script
+  // A link that names no seed is about a script rather than about particular
+  // hands, so every visitor gets their own sample.
+  seed.value = s.seed ?? randomSeed()
+  produce.value = s.produce
+  maxGenerate.value = s.maxGenerate
+  format.value = s.format
+  roundRobin.value = s.roundRobin
+  dealSource.value = s.dealSource
+  newSeedEachRun.value = s.newSeedEachRun
+  selectedFile.value = s.scenario || ''
+  // The conversion this is easiest to miss: the link carries the engine's
+  // `N=TEXT`, the fields hold values by number. Without it a shared
+  // parameterised scenario arrives blank and runs on its declared defaults.
+  paramValues.value = paramValuesFrom(s.params)
+  if (s.measureSeconds != null) measureSeconds.value = s.measureSeconds
+  autoLevel.value = s.autoLevel
+  // The link had an opinion, so the box must not be re-ticked underneath it by
+  // the watcher that ticks it for a script naming hand types.
+  autoLevelTouched.value = true
+  // A shared scenario's script is the list's own, so Share can send it back the
+  // short way.
+  pristine.value = source === 'scenario' ? { file: s.scenario, text: doc.script } : { file: '', text: '' }
+
+  result.value = null
+  leveling.value = null
+  error.value = ''
+  editorTab.value = 'script'
+
+  const named = source === 'scenario' && s.scenario ? ` \u201c${prettifyLabel(s.scenario)}\u201d` : ''
+  // That nothing has run is the part worth saying: it is the difference between
+  // this and every other link, and the reason the page looks idle.
+  sharedNotice.value = `Opened a shared script${named}. Nothing has run yet.`
+}
+
+/// Put back what the link replaced.
+function restorePrevious() {
+  const was = displaced.value
+  sharedNotice.value = ''
+  displaced.value = null
+  // The link has been declined, so it must not open again on the next reload.
+  // The fragment goes; the page does not navigate.
+  try {
+    window.history.replaceState(null, '', window.location.pathname + window.location.search)
+  } catch {
+    // Some embeddings refuse it. Losing the fragment is not worth an error.
+  }
+  if (!was) return
+  script.value = was.script
+  seed.value = was.seed
+  produce.value = was.produce
+  maxGenerate.value = was.maxGenerate
+  format.value = was.format
+  roundRobin.value = was.roundRobin
+  dealSource.value = was.dealSource
+  selectedFile.value = was.scenario || ''
+  paramValues.value = was.paramValues || {}
+  newSeedEachRun.value = was.newSeedEachRun ?? false
+  if (was.measureSeconds != null) measureSeconds.value = was.measureSeconds
+  // `scenario` is the picker's highlight, and it came back with the script.
+  autoLevel.value = was.autoLevel ?? false
+  autoLevelTouched.value = was.autoLevelTouched
+  pristine.value = was.pristine
+  result.value = null
+  leveling.value = null
 }
 
 async function run() {
@@ -1168,6 +1426,63 @@ input.num-seed { --num-digits: 10; }
   background: #fff; color: var(--fg-muted); cursor: pointer;
 }
 .cancel:hover { color: #b23b3b; border-color: #d8a9a9; }
+
+/* Quieter than Run, like Cancel, and the same height as both: the row is
+   `align-items: end`, so what makes these look level is their boxes matching
+   rather than any alignment property. */
+.share {
+  padding: 5px 12px; font: inherit; font-size: 13px;
+  border: 1px solid var(--line); border-radius: 4px;
+  background: #fff; color: var(--fg-muted); cursor: pointer;
+}
+.share:hover:not(:disabled) { color: var(--accent); border-color: var(--accent); }
+.share:disabled { color: var(--line); cursor: default; }
+
+/* Opens under the row that made it, like the settings panel and for the same
+   reason: a disclosure belongs below the control that owns it. */
+.share-panel {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 6px 10px;
+  padding: 8px 10px; margin: 0 0 6px;
+  border: 1px solid var(--line); border-radius: 6px; background: var(--bg-subtle);
+}
+/* Takes the row: a link that is cut off is one that gets pasted cut off.
+   `min-width: 0` because a flex item will otherwise refuse to shrink below the
+   width of its content, and this content is several hundred characters. */
+.share-input {
+  flex: 1; min-width: 0;
+  font: 12px/1.5 var(--mono);
+  padding: 4px 6px;
+  border: 1px solid var(--line); border-radius: 3px;
+  background: var(--bg); color: var(--fg);
+}
+/* The same size as the notes under the run controls, and for the same reason:
+   this is a line about a control, not body text. At 14px it was three lines on
+   a phone, and the panel is squeezed there already. */
+.share-note { color: var(--fg-muted); font-size: 11.5px; line-height: 1.45; }
+
+/* What a link did to the page, above the script it did it to. Not styled as a
+   warning: opening a shared script is the feature working. */
+.shared-notice {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 6px 10px;
+  margin: 0 0 6px; padding: 6px 9px;
+  font-size: 11.5px; line-height: 1.45;
+  border-left: 3px solid var(--accent);
+  background: var(--accent-subtle); color: var(--fg);
+}
+/* A link that could not be opened at all. */
+.shared-notice.bad {
+  border-left-color: var(--warn);
+  background: var(--warn-subtle);
+  color: var(--warn-fg);
+}
+.shared-restore, .shared-dismiss {
+  font: inherit; font-size: 11px;
+  padding: 2px 8px;
+  border: 1px solid var(--line); border-radius: 3px;
+  background: var(--bg); color: var(--fg-muted); cursor: pointer;
+}
+.shared-restore { color: var(--accent); border-color: var(--accent); }
+.shared-restore:hover, .shared-dismiss:hover { background: var(--bg-subtle); }
 
 /* The deal source, set apart from the numeric fields beside it: it is the one
    control on the row that changes what a run reads rather than how much of it.

--- a/web/src/components/CopyButton.vue
+++ b/web/src/components/CopyButton.vue
@@ -19,6 +19,7 @@
 // worth copying out — it is what you paste into BBO — and it is read-only, so
 // there is no caret to select from either.
 import { ref } from 'vue'
+import { copyText } from '@/lib/clipboard.js'
 
 const props = defineProps({
   /// Called for the text, rather than passing it: the editor holds the current
@@ -42,29 +43,8 @@ function flash(next, text) {
 }
 
 async function copy() {
-  const value = props.text() ?? ''
-  try {
-    // `navigator.clipboard` is absent on an insecure origin and can be refused
-    // outright, so the older path is a real fallback rather than politeness.
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(value)
-    } else {
-      const area = document.createElement('textarea')
-      area.value = value
-      area.setAttribute('readonly', '')
-      area.style.position = 'fixed'
-      area.style.opacity = '0'
-      document.body.appendChild(area)
-      area.select()
-      const ok = document.execCommand('copy')
-      document.body.removeChild(area)
-      if (!ok) throw new Error('execCommand refused')
-    }
-    flash('done', 'Copied')
-  } catch {
-    // Saying so beats a button that looks as though it worked.
-    flash('failed', 'Press ⌘C')
-  }
+  if (await copyText(props.text() ?? '')) flash('done', 'Copied')
+  else flash('failed', 'Press \u2318C')
 }
 </script>
 

--- a/web/src/lib/clipboard.js
+++ b/web/src/lib/clipboard.js
@@ -1,0 +1,34 @@
+// Copying text, from the two places that offer it.
+//
+// `navigator.clipboard` is absent on an insecure origin and can be refused
+// outright, so the older path is a real fallback rather than politeness.
+
+/**
+ * Put text on the clipboard.
+ *
+ * @param {string} text
+ * @returns {Promise<boolean>} whether it worked, so the caller can say so
+ */
+export async function copyText(text) {
+  const value = text ?? ''
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value)
+      return true
+    }
+    const area = document.createElement('textarea')
+    area.value = value
+    area.setAttribute('readonly', '')
+    area.style.position = 'fixed'
+    area.style.opacity = '0'
+    document.body.appendChild(area)
+    area.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(area)
+    return ok
+  } catch {
+    // Refused, or no clipboard at all. Saying so beats a control that looks as
+    // though it worked.
+    return false
+  }
+}

--- a/web/src/lib/envelope.js
+++ b/web/src/lib/envelope.js
@@ -57,3 +57,218 @@ export function runEnvelope(script, options = {}) {
 
   return JSON.stringify({ v: ENVELOPE_VERSION, script, settings })
 }
+
+// --- A document: a run somebody else can open -----------------------------
+//
+// The envelope above is the engine's half. A shared link, an export file and a
+// demo's manifest entry all describe more than the engine does, and a document
+// is that: the engine's settings plus the caller's own.
+//
+// The caller's two are `dealSource` and `newSeedEachRun`, and neither is a
+// field the engine could act on. It infers the source from whether deals were
+// handed to it, so being *told* "library" would say nothing; and it takes a
+// definite seed, because a run whose seed it invented would not be
+// reproducible and the report does not echo it back. Both are resolved before
+// the call, by whoever is driving.
+//
+// `scenario` travels with them: which entry in the scenario list this came
+// from, so a link opens with the list pointing at it.
+//
+// Narrowing is not a function here, it is `runEnvelope` itself: it names the
+// engine's fields, so handing it a document's settings drops the caller's by
+// not asking for them. There is deliberately no second place that lists them.
+//
+// What must NOT travel is UI state — `pickerOpen`, `settingsOpen`. Whether a
+// panel was open is about the sender's window, not about the run.
+
+/// Bumped when a change would make an older reader wrong rather than merely out
+/// of date. A reader refuses a version it does not know rather than half-
+/// reading it.
+export const DOCUMENT_VERSION = 1
+
+/// What the page's Format menu offers. A document naming something else is
+/// read back as the default: the value has to reach a `<select>`, and one that
+/// holds a value with no option shows blank.
+export const DOCUMENT_FORMATS = ['oneline', 'printall', 'pbn', 'none']
+
+/// What a setting means when a link does not mention it.
+///
+/// This is what lets a link for an unmodified scenario be `#s=Some_Scenario`
+/// plus the two or three things that were actually changed, rather than ten
+/// fields most of which say what the page would have done anyway.
+///
+/// `seed` is deliberately absent, and so is `measureSeconds`. A link that names
+/// no seed is a link about a script rather than about particular hands, and the
+/// reader rolls one; an absent characterizing budget means the engine's own,
+/// which is a number this file would otherwise have to keep a copy of.
+export const DOCUMENT_DEFAULTS = Object.freeze({
+  produce: 20,
+  maxGenerate: 1000000,
+  format: 'oneline',
+  autoLevel: false,
+  roundRobin: false,
+  params: [],
+  dealSource: 'random',
+  newSeedEachRun: false,
+  scenario: '',
+})
+
+/// Well beyond any real script — the largest of the ~350 PBS scripts is ~20 kB
+/// — and the same bound `session.js` uses for the same reason.
+const MAX_SCRIPT_CHARS = 256 * 1024
+
+/// A u32, as the engine and the seed field both take.
+const MAX_SEED = 4294967295
+
+/**
+ * Describe a run as a document: the engine's settings plus the caller's.
+ *
+ * Takes the same options object `runEnvelope` does, so a caller builds one
+ * from the page's state without a second projection in between.
+ *
+ * @param {string} script the script text
+ * @param {object} options the run's settings, in the page's own names
+ * @returns {{v: number, script: string, settings: object}}
+ */
+export function makeDocument(script, options = {}) {
+  const settings = {
+    seed: options.seed,
+    produce: options.produce,
+    maxGenerate: options.maxGenerate,
+    format: options.format,
+    autoLevel: !!options.autoLevel,
+    roundRobin: !!options.roundRobin,
+    params: options.params || [],
+    dealSource: options.dealSource === 'library' ? 'library' : 'random',
+    newSeedEachRun: !!options.newSeedEachRun,
+  }
+  if (options.measureSeconds != null) settings.measureSeconds = options.measureSeconds
+  if (options.scenario) settings.scenario = options.scenario
+  return { v: DOCUMENT_VERSION, script, settings }
+}
+
+/**
+ * Read a document that arrived from outside — a link, a file, a manifest.
+ *
+ * Untrusted input: it parses or it is refused with a sentence the recipient
+ * can act on. An unknown version says so rather than half-loading, which is
+ * the failure worth spending a version field on — a link that opened with two
+ * of its five settings applied would look like it had worked.
+ *
+ * Settings are read field by field and anything unrecognised falls back to
+ * `DOCUMENT_DEFAULTS`, so a truncated or hand-edited fragment opens the script
+ * rather than failing over a stray `format=xml`. Fields this version does not
+ * know are dropped: they cannot reach the engine, which refuses what it does
+ * not recognise.
+ *
+ * @param {unknown} value the parsed JSON
+ * @returns {{v: number, script: string, settings: object}}
+ * @throws {Error} with a message meant to be shown
+ */
+export function readDocument(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('This link does not hold a dealer3 script.')
+  }
+  if (value.v !== DOCUMENT_VERSION) {
+    throw new Error(
+      Number.isFinite(value.v) && value.v > DOCUMENT_VERSION
+        ? `This link was made by a newer dealer3 — it is version ${value.v}, and this page ` +
+          `reads version ${DOCUMENT_VERSION}. Reload the page and try it again.`
+        : 'This link is not in a form this page recognises.',
+    )
+  }
+  if (typeof value.script !== 'string' || !value.script.trim()) {
+    throw new Error('This link carries no script.')
+  }
+  if (value.script.length > MAX_SCRIPT_CHARS) {
+    throw new Error('The script in this link is far larger than any real one.')
+  }
+
+  const from =
+    value.settings && typeof value.settings === 'object' && !Array.isArray(value.settings)
+      ? value.settings
+      : {}
+
+  const settings = {
+    ...DOCUMENT_DEFAULTS,
+    produce: whole(from.produce, DOCUMENT_DEFAULTS.produce),
+    maxGenerate: whole(from.maxGenerate, DOCUMENT_DEFAULTS.maxGenerate),
+    format: DOCUMENT_FORMATS.includes(from.format) ? from.format : DOCUMENT_DEFAULTS.format,
+    autoLevel: from.autoLevel === true,
+    roundRobin: from.roundRobin === true,
+    dealSource: from.dealSource === 'library' ? 'library' : 'random',
+    newSeedEachRun: from.newSeedEachRun === true,
+    scenario: typeof from.scenario === 'string' ? from.scenario : '',
+    params: readParams(from.params),
+  }
+  // Left out rather than defaulted, both of them. An absent seed means the
+  // reader rolls one; an absent budget means the engine's own.
+  if (Number.isFinite(from.seed) && from.seed >= 0 && from.seed <= MAX_SEED) {
+    settings.seed = Math.floor(from.seed)
+  }
+  if (Number.isFinite(from.measureSeconds) && from.measureSeconds >= 1) {
+    settings.measureSeconds = Math.min(300, from.measureSeconds)
+  }
+
+  return { v: DOCUMENT_VERSION, script: value.script, settings }
+}
+
+/** A whole number of at least one, or the default. */
+function whole(value, fallback) {
+  return Number.isFinite(value) && value >= 1 ? Math.floor(value) : fallback
+}
+
+/// `--param`'s own spelling, `N=TEXT`, with `N` a single digit — which is all
+/// the language has. Anything else is dropped rather than passed to the engine
+/// to be refused there, where the message would be about a script the reader
+/// did not write.
+function readParams(value) {
+  if (!Array.isArray(value)) return []
+  return value.filter((spec) => typeof spec === 'string' && /^[0-9]=/.test(spec)).slice(0, 10)
+}
+
+/**
+ * `['0=west', '1=15']` back to `{ 0: 'west', 1: '15' }`.
+ *
+ * The one conversion a document needs and the engine does not. The page keeps
+ * what was typed into the parameter fields by parameter number, and projects
+ * that to `--param`'s positional spelling before a run; a document carries the
+ * engine's side of it, so opening one has to project back the other way. Miss
+ * this and a parameterised scenario arrives with its fields blank — running,
+ * on its declared defaults, and not the run that was shared.
+ *
+ * @param {string[]} params specs as the engine takes them
+ * @returns {object} values by parameter number
+ */
+export function paramValuesFrom(params) {
+  const values = {}
+  for (const spec of readParams(params)) {
+    values[Number(spec[0])] = spec.slice(2)
+  }
+  return values
+}
+
+/**
+ * The settings a link has to state, being those that differ from the defaults.
+ *
+ * `seed` is always among them when the document has one: it is what makes the
+ * link show the same hands, and there is no default it could be compared to.
+ *
+ * @param {object} settings a document's settings
+ * @returns {object} the subset worth writing down
+ */
+export function settingsDelta(settings = {}) {
+  const delta = {}
+  for (const [key, value] of Object.entries(settings)) {
+    if (value == null) continue
+    const fallback = DOCUMENT_DEFAULTS[key]
+    if (fallback === undefined) {
+      delta[key] = value // seed, measureSeconds: nothing to compare against
+    } else if (Array.isArray(value)) {
+      if (value.length) delta[key] = value
+    } else if (value !== fallback) {
+      delta[key] = value
+    }
+  }
+  return delta
+}

--- a/web/src/lib/envelope.test.js
+++ b/web/src/lib/envelope.test.js
@@ -1,5 +1,17 @@
-import { describe, it, expect } from 'vitest'
-import { runEnvelope, ENVELOPE_VERSION } from './envelope.js'
+import { describe, it, expect, vi } from 'vitest'
+import {
+  runEnvelope,
+  ENVELOPE_VERSION,
+  DOCUMENT_VERSION,
+  DOCUMENT_DEFAULTS,
+  DOCUMENT_FORMATS,
+  makeDocument,
+  readDocument,
+  paramValuesFrom,
+  settingsDelta,
+} from './envelope.js'
+import { loadSession } from './session.js'
+import { readFileSync } from 'node:fs'
 
 const settings = {
   seed: 7,
@@ -59,5 +71,160 @@ describe('runEnvelope', () => {
   it('keeps the script exactly, newlines and all', () => {
     const script = 'condition hcp(north) >= 15\naction average "h" hcp(north)\n'
     expect(parsed(script, settings).script).toBe(script)
+  })
+})
+
+describe('a document', () => {
+  const page = {
+    seed: 8391,
+    produce: 20,
+    maxGenerate: 1000000,
+    format: 'oneline',
+    autoLevel: false,
+    roundRobin: false,
+    params: [],
+    dealSource: 'library',
+    newSeedEachRun: true,
+    scenario: 'Sup_X_By_Advancer',
+  }
+
+  it('carries the caller settings the engine never sees', () => {
+    const doc = makeDocument('condition 1\n', page)
+    expect(doc.settings.dealSource).toBe('library')
+    expect(doc.settings.newSeedEachRun).toBe(true)
+    expect(doc.settings.scenario).toBe('Sup_X_By_Advancer')
+  })
+
+  it('narrows to the engine envelope by being read through it', () => {
+    // The point of the two living in one file: there is no second list of the
+    // engine's fields to keep in step. `runEnvelope` names them, so handing it
+    // a document's settings drops the caller's by not asking for them — and
+    // the engine refuses what it does not know, so a leak here fails a run.
+    const doc = makeDocument('condition 1\n', page)
+    const envelope = JSON.parse(runEnvelope(doc.script, doc.settings))
+    expect(Object.keys(envelope.settings).sort()).toEqual([
+      'autoLevel',
+      'format',
+      'maxGenerate',
+      'params',
+      'produce',
+      'roundRobin',
+      'seed',
+    ])
+    expect(envelope.settings.seed).toBe(8391)
+  })
+
+  it('round-trips through a reader', () => {
+    const doc = makeDocument('condition hcp(north) >= 15\n', { ...page, measureSeconds: 12 })
+    expect(readDocument(JSON.parse(JSON.stringify(doc)))).toEqual({
+      v: DOCUMENT_VERSION,
+      script: 'condition hcp(north) >= 15\n',
+      settings: { ...page, measureSeconds: 12 },
+    })
+  })
+
+  it('refuses a version it does not know, by name, rather than half-loading', () => {
+    expect(() => readDocument({ v: 2, script: 'condition 1\n' })).toThrow(/version 2/)
+    expect(() => readDocument({ v: 2, script: 'condition 1\n' })).toThrow(/newer/)
+  })
+
+  it('refuses what is not a document at all', () => {
+    expect(() => readDocument(null)).toThrow(/does not hold/)
+    expect(() => readDocument([1, 2])).toThrow(/does not hold/)
+    expect(() => readDocument({ v: 1 })).toThrow(/no script/)
+    expect(() => readDocument({ v: 1, script: '   ' })).toThrow(/no script/)
+    expect(() => readDocument({ v: 1, script: 'x'.repeat(300 * 1024) })).toThrow(/larger/)
+  })
+
+  it('opens the script rather than failing over a setting it cannot use', () => {
+    // A hand-edited or truncated fragment. The script is the thing that was
+    // shared; refusing the whole link over `format=xml` would throw it away to
+    // no purpose, and the engine would refuse the value anyway.
+    const s = readDocument({
+      v: 1,
+      script: 'condition 1\n',
+      settings: { format: 'xml', produce: -3, dealSource: 'wat', params: 'nope', nonsense: 1 },
+    }).settings
+    expect(s.format).toBe('oneline')
+    expect(s.produce).toBe(20)
+    expect(s.dealSource).toBe('random')
+    expect(s.params).toEqual([])
+    expect('nonsense' in s).toBe(false)
+  })
+
+  it('leaves out a seed it was not given, so the reader rolls one', () => {
+    // Not defaulted to a number. A link that names no seed is about a script
+    // rather than about particular hands, and every visitor should see a
+    // different sample rather than all of them seeing seed 1.
+    expect('seed' in readDocument({ v: 1, script: 'condition 1\n' }).settings).toBe(false)
+    expect('seed' in readDocument({ v: 1, script: 'c\n', settings: { seed: -1 } }).settings).toBe(false)
+    expect(readDocument({ v: 1, script: 'c\n', settings: { seed: 7 } }).settings.seed).toBe(7)
+  })
+
+  it('agrees with the session about what a setting means when nobody said', () => {
+    // Two readers of the same fields — one from localStorage, one from a link.
+    // They are separate on purpose (a session holds UI state a link must not
+    // carry), which is exactly the shape that drifts, so this pins the overlap.
+    vi.stubGlobal('localStorage', {
+      getItem: () => '{}',
+      setItem: () => {},
+      removeItem: () => {},
+    })
+    const stored = loadSession()
+    vi.unstubAllGlobals()
+    for (const key of ['produce', 'maxGenerate', 'format', 'roundRobin', 'dealSource']) {
+      expect([key, stored[key]]).toEqual([key, DOCUMENT_DEFAULTS[key]])
+    }
+  })
+})
+
+describe('paramValuesFrom', () => {
+  it('projects the engine spelling back to the fields it was typed into', () => {
+    // Miss this and a shared parameterised scenario opens with its fields
+    // blank — running on the script's declared defaults, which is not the run
+    // that was shared.
+    expect(paramValuesFrom(['0=west', '1=15'])).toEqual({ 0: 'west', 1: '15' })
+  })
+
+  it('keeps a value containing an equals sign whole', () => {
+    expect(paramValuesFrom(['2=hcp(north) >= 15'])).toEqual({ 2: 'hcp(north) >= 15' })
+  })
+
+  it('ignores anything that is not a parameter', () => {
+    expect(paramValuesFrom(['west', '=x', 'x=1', undefined, 12])).toEqual({})
+    expect(paramValuesFrom(undefined)).toEqual({})
+  })
+})
+
+describe('settingsDelta', () => {
+  it('keeps only what a link has to say', () => {
+    expect(settingsDelta({ ...DOCUMENT_DEFAULTS, seed: 5, produce: 20, format: 'pbn' })).toEqual({
+      seed: 5,
+      format: 'pbn',
+    })
+  })
+
+  it('always keeps the seed, which has no default to be equal to', () => {
+    expect(settingsDelta({ seed: 0 }).seed).toBe(0)
+  })
+
+  it('drops an empty parameter list and keeps a full one', () => {
+    expect('params' in settingsDelta({ params: [] })).toBe(false)
+    expect(settingsDelta({ params: ['0=west'] }).params).toEqual(['0=west'])
+  })
+})
+
+describe('the formats a document may name', () => {
+  it('are the ones the page offers', () => {
+    // A document is read back into a `<select>`, and a select holding a value
+    // no option carries shows blank — so a format the menu dropped would open
+    // a link with the field empty and run something else. Two lists, one of
+    // them in a template, is exactly the pair that drifts.
+    const app = readFileSync(new URL('../App.vue', import.meta.url), 'utf8')
+    const menu = app.slice(app.indexOf('<select v-model="format">'))
+    const offered = [...menu.slice(0, menu.indexOf('</select>')).matchAll(/value="([^"]+)"/g)].map(
+      (m) => m[1],
+    )
+    expect(offered).toEqual(DOCUMENT_FORMATS)
   })
 })

--- a/web/src/lib/share.js
+++ b/web/src/lib/share.js
@@ -1,0 +1,285 @@
+// Putting a run in a link, and taking one back out.
+//
+// ## Why the fragment, and never the query string
+//
+// Everything after `#` stays in the browser. It is not sent with the request,
+// so it reaches no server log, no cache key and no edge rule — which is what
+// makes this shippable with no back end at all, and the reason a link works
+// for ever and costs nothing to keep working.
+//
+// It is also the form that survives the trip. A real BBO capture sent as a
+// query string came back **403 at the edge** on 2026-08-28, while the identical
+// payload in the fragment loaded; bridge-solver already hands hands over this
+// way for that reason, and the cross-tool contract (bridge-craftwork-site#3,
+// item 4) settles it for every tool here. Do not redesign it.
+//
+// ## Three forms, one load path
+//
+//   #s=<scenario>   a scenario from the list, unmodified, plus what was changed
+//   #d=<base64url>  the document itself, deflated — no network at all
+//   #k=<key>        fetched from the short-link service (#103, not built)
+//
+// All three resolve to the same document, so opening one is one path with
+// three sources rather than three features.
+//
+// ## The cheap case is the common one
+//
+// Someone sharing a scenario they picked from the list has not changed a
+// character of it, and there is nothing to encode: the recipient can fetch the
+// same script from the same place. `#s=Sup_X_By_Advancer&seed=8391` against
+// some five hundred characters of base64 is the difference between a link
+// somebody will read and one they will only paste.
+//
+// A modified script takes the second form. 600-900 bytes of dealer script
+// deflates to roughly 250-400, which is 350-550 base64 characters — ugly in an
+// email and still strictly better than sending a PDF nobody can run.
+
+import { DOCUMENT_VERSION, readDocument, settingsDelta } from './envelope.js'
+
+/// Longer than this and it is not a link anyone made from this page: the whole
+/// point of the `#s=` form is that the big ones are rare. Refusing early keeps
+/// a hostile fragment from being decompressed at all.
+const MAX_FRAGMENT_CHARS = 64 * 1024
+
+/// What a fragment is allowed to inflate to. Deflate is happy to turn a few
+/// hundred bytes into a few hundred megabytes, and a link that hangs the tab
+/// before anything is on screen is the one failure with no way back.
+const MAX_DOCUMENT_BYTES = 512 * 1024
+
+/// Booleans in the readable form. `1` rather than `true` because these are read
+/// by people as often as by the page.
+const TRUE = ['1', 'true', 'yes', 'on']
+
+/**
+ * Which of the three forms a fragment is, if it is one at all.
+ *
+ * Anything else — no fragment, someone else's fragment, an in-page anchor —
+ * returns null, and the page carries on as if it had been opened plainly.
+ *
+ * @param {string} hash `location.hash`, with or without its `#`
+ * @returns {{kind: string}|null}
+ */
+export function parseFragment(hash) {
+  const text = String(hash || '').replace(/^#/, '')
+  if (!text || text.length > MAX_FRAGMENT_CHARS) return null
+  const query = new URLSearchParams(text)
+  // In order of cheapness, which is also the order they should be preferred in
+  // if a hand-edited fragment somehow carries two.
+  const slug = query.get('s')
+  if (slug) return { kind: 'scenario', slug, query }
+  const data = query.get('d')
+  if (data) return { kind: 'document', data }
+  const key = query.get('k')
+  if (key) return { kind: 'key', key }
+  return null
+}
+
+/**
+ * Open a fragment: the document it names, and which form it came in.
+ *
+ * `fetchScenario` is passed in rather than imported so this stays testable
+ * without a network, and so the one caller that needs a scenario is the one
+ * that supplies the way to get it.
+ *
+ * @param {string} hash `location.hash`
+ * @param {{fetchScenario: (slug: string) => Promise<string>}} sources
+ * @returns {Promise<{source: string, doc: object}|null>}
+ * @throws {Error} with a message meant to be shown
+ */
+export async function resolveFragment(hash, { fetchScenario } = {}) {
+  const found = parseFragment(hash)
+  if (!found) return null
+
+  if (found.kind === 'key') {
+    // Recognised rather than ignored. Nothing produces these yet — the service
+    // behind them is #103 — but a link that arrives from one deserves better
+    // than a page that opens as though there had been no link.
+    throw new Error(
+      'This is a short link, and short links are not available yet. Ask whoever sent it ' +
+        'for the long form — it opens the same script.',
+    )
+  }
+
+  if (found.kind === 'document') {
+    return { source: 'document', doc: readDocument(await decodeDocument(found.data)) }
+  }
+
+  if (typeof fetchScenario !== 'function') {
+    throw new Error('This link names a scenario, and there is no way to fetch one here.')
+  }
+  const script = await fetchScenario(found.slug)
+  return {
+    source: 'scenario',
+    doc: readDocument({
+      v: DOCUMENT_VERSION,
+      script,
+      settings: { ...settingsFromQuery(found.query), scenario: found.slug },
+    }),
+  }
+}
+
+/**
+ * The fragment for a document, in the shortest form that can carry it.
+ *
+ * `pristineScript` is the scenario's text as it was fetched. Equal to the
+ * document's script, the script itself need not travel; changed by so much as
+ * a comment, it must, or the recipient would open a different script under the
+ * right name — which is worse than a long link.
+ *
+ * @param {object} doc a document, from `makeDocument`
+ * @param {{pristineScript?: string|null}} options
+ * @returns {Promise<string>} the fragment, `#` and all
+ */
+export async function shareFragment(doc, { pristineScript = null } = {}) {
+  if (doc?.settings?.scenario && pristineScript != null && pristineScript === doc.script) {
+    return scenarioFragment(doc)
+  }
+  return `#d=${await encodeDocument(doc)}`
+}
+
+/** `#s=<scenario>` plus whatever was changed from the defaults. */
+export function scenarioFragment(doc) {
+  const query = new URLSearchParams()
+  query.set('s', doc.settings.scenario)
+  for (const [key, value] of Object.entries(settingsDelta(doc.settings))) {
+    // Already said, as the `s` this whole form is built around.
+    if (key === 'scenario') continue
+    if (Array.isArray(value)) {
+      for (const item of value) query.append(key, item)
+    } else if (typeof value === 'boolean') {
+      query.set(key, value ? '1' : '0')
+    } else {
+      query.set(key, String(value))
+    }
+  }
+  return `#${query.toString()}`
+}
+
+/** The whole link: this page, wherever it is being served from, plus the fragment. */
+export function shareUrl(location, fragment) {
+  return `${location.origin}${location.pathname}${location.search}${fragment}`
+}
+
+/// The `#s=` form's settings, read back from ordinary `name=value` pairs.
+///
+/// Spelled out in full rather than abbreviated. This form exists to be short
+/// enough to read, and a link saying `p=20&f=pbn` is shorter still and says
+/// nothing to the person holding it — while a second vocabulary is one more
+/// thing to keep in step with the document.
+function settingsFromQuery(query) {
+  const settings = {}
+  for (const key of ['seed', 'produce', 'maxGenerate', 'measureSeconds']) {
+    const value = query.get(key)
+    if (value != null && value !== '' && Number.isFinite(Number(value))) {
+      settings[key] = Number(value)
+    }
+  }
+  for (const key of ['autoLevel', 'roundRobin', 'newSeedEachRun']) {
+    const value = query.get(key)
+    if (value != null) settings[key] = TRUE.includes(value.toLowerCase())
+  }
+  for (const key of ['format', 'dealSource']) {
+    const value = query.get(key)
+    if (value) settings[key] = value
+  }
+  const params = query.getAll('params')
+  if (params.length) settings.params = params
+  return settings
+}
+
+// --- The wire: deflate, then base64url ------------------------------------
+//
+// `CompressionStream` is native in Safari 16.4, Chrome and Firefox, so this
+// needs no library. `deflate-raw` rather than `deflate` or `gzip`: the wrapper
+// bytes are pure cost in a link, and both ends are this file.
+
+/** Whether this browser can make a `#d=` link at all. */
+export function canCompress() {
+  return typeof CompressionStream === 'function' && typeof DecompressionStream === 'function'
+}
+
+/** A document as the base64url of its deflated JSON. */
+export async function encodeDocument(doc) {
+  if (!canCompress()) {
+    throw new Error(
+      'This browser cannot compress, so it cannot make a link. Safari 16.4, Chrome and ' +
+        'Firefox all can.',
+    )
+  }
+  const json = JSON.stringify(doc)
+  const stream = new Blob([json]).stream().pipeThrough(new CompressionStream('deflate-raw'))
+  return toBase64Url(new Uint8Array(await new Response(stream).arrayBuffer()))
+}
+
+/** And back: base64url, inflate, parse. Throws a showable message on any of it. */
+export async function decodeDocument(text) {
+  if (!canCompress()) {
+    throw new Error(
+      'This browser cannot decompress, so it cannot open this link. Safari 16.4, Chrome ' +
+        'and Firefox all can.',
+    )
+  }
+  let json
+  try {
+    json = await inflate(fromBase64Url(text))
+  } catch (e) {
+    // A truncated link is the common cause by a distance: mail clients wrap
+    // long URLs, and the fragment is the end of one.
+    throw new Error(
+      `This link is damaged and cannot be read (${e?.message || e}). It may have been cut ` +
+        'short — check that the whole of it was copied.',
+    )
+  }
+  try {
+    return JSON.parse(json)
+  } catch {
+    throw new Error('This link is damaged: what it holds is not a dealer3 script.')
+  }
+}
+
+function toBase64Url(bytes) {
+  let binary = ''
+  // `String.fromCharCode(...bytes)` overflows the argument list on a large
+  // enough script, and does it only for the large ones.
+  const CHUNK = 0x8000
+  for (let at = 0; at < bytes.length; at += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(at, at + CHUNK))
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function fromBase64Url(text) {
+  if (!/^[A-Za-z0-9_-]+$/.test(text)) throw new Error('it is not base64url')
+  const padded = text.replace(/-/g, '+').replace(/_/g, '/')
+  const binary = atob(padded.padEnd(Math.ceil(padded.length / 4) * 4, '='))
+  const bytes = new Uint8Array(binary.length)
+  for (let at = 0; at < binary.length; at++) bytes[at] = binary.charCodeAt(at)
+  return bytes
+}
+
+/// Inflate with a budget, reading the stream rather than awaiting all of it:
+/// `Response.text()` would have the whole bomb in memory before anything could
+/// object to its size.
+async function inflate(bytes) {
+  const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('deflate-raw'))
+  const reader = stream.getReader()
+  const chunks = []
+  let total = 0
+  for (;;) {
+    const { value, done } = await reader.read()
+    if (done) break
+    total += value.length
+    if (total > MAX_DOCUMENT_BYTES) {
+      await reader.cancel()
+      throw new Error('it holds far more than any script')
+    }
+    chunks.push(value)
+  }
+  const all = new Uint8Array(total)
+  let at = 0
+  for (const chunk of chunks) {
+    all.set(chunk, at)
+    at += chunk.length
+  }
+  return new TextDecoder().decode(all)
+}

--- a/web/src/lib/share.test.js
+++ b/web/src/lib/share.test.js
@@ -1,0 +1,238 @@
+// The link, both ways round.
+//
+// A producer with no consumer cannot be tested, which is why the two halves
+// (#98, #99) shipped together: every case here makes a link and then opens it.
+
+import { describe, it, expect } from 'vitest'
+import {
+  parseFragment,
+  resolveFragment,
+  shareFragment,
+  scenarioFragment,
+  shareUrl,
+  encodeDocument,
+  decodeDocument,
+} from './share.js'
+import { makeDocument, DOCUMENT_VERSION } from './envelope.js'
+
+const SCRIPT = `# A scenario worth sending someone
+condition hcp(north) >= 15 && shape(north, any 4333 + any 4432)
+
+action printoneline,
+  average "N HCP" hcp(north)
+`
+
+const page = {
+  seed: 8391,
+  produce: 20,
+  maxGenerate: 1000000,
+  format: 'oneline',
+  autoLevel: false,
+  roundRobin: false,
+  params: [],
+  dealSource: 'random',
+  newSeedEachRun: false,
+}
+
+const open = (fragment, fetchScenario) => resolveFragment(fragment, { fetchScenario })
+
+describe('parseFragment', () => {
+  it('tells the three forms apart', () => {
+    expect(parseFragment('#s=Weak_2_Bids').kind).toBe('scenario')
+    expect(parseFragment('#d=abc123').kind).toBe('document')
+    expect(parseFragment('#k=Ab3x9').kind).toBe('key')
+  })
+
+  it('says nothing about a fragment that is not ours', () => {
+    // The page has to open normally on an in-page anchor, an empty hash, or
+    // whatever somebody else appended.
+    expect(parseFragment('')).toBe(null)
+    expect(parseFragment('#')).toBe(null)
+    expect(parseFragment('#top')).toBe(null)
+    expect(parseFragment(undefined)).toBe(null)
+    expect(parseFragment('#utm_source=mail')).toBe(null)
+  })
+
+  it('refuses a fragment far longer than any link this makes', () => {
+    expect(parseFragment('#d=' + 'a'.repeat(100 * 1024))).toBe(null)
+  })
+})
+
+describe('a script somebody wrote', () => {
+  it('travels whole, through deflate and back', async () => {
+    const doc = makeDocument(SCRIPT, page)
+    const fragment = await shareFragment(doc)
+    expect(fragment.startsWith('#d=')).toBe(true)
+    const { source, doc: back } = await open(fragment)
+    expect(source).toBe('document')
+    expect(back.script).toBe(SCRIPT)
+    expect(back.settings.seed).toBe(8391)
+  })
+
+  it('is shorter for having been compressed, which is the whole reason for it', async () => {
+    // Against the same document base64'd on its own, which is the alternative:
+    // base64 pays four characters for every three bytes whatever it holds, so
+    // the deflate step is what keeps a real script inside a few hundred
+    // characters instead of a couple of thousand.
+    const doc = makeDocument(SCRIPT, page)
+    const plain = Math.ceil((JSON.stringify(doc).length * 4) / 3)
+    const encoded = await encodeDocument(doc)
+    expect(encoded.length).toBeLessThan(plain)
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/) // base64url: nothing a URL escapes
+  })
+
+  it('carries the parameters that were typed in, not just the script', async () => {
+    // The conversion this is most likely to lose. The page keeps values by
+    // parameter number and the engine takes `N=TEXT`; a link that dropped them
+    // would open a parameterised scenario running on its declared defaults,
+    // and look as though it had worked.
+    const doc = makeDocument(SCRIPT, { ...page, params: ['0=west', '1=15'] })
+    const { doc: back } = await open(await shareFragment(doc))
+    expect(back.settings.params).toEqual(['0=west', '1=15'])
+  })
+
+  it('carries the settings the engine never sees', async () => {
+    const doc = makeDocument(SCRIPT, { ...page, dealSource: 'library', newSeedEachRun: true })
+    const { doc: back } = await open(await shareFragment(doc))
+    expect(back.settings.dealSource).toBe('library')
+    expect(back.settings.newSeedEachRun).toBe(true)
+  })
+})
+
+describe('a scenario nobody changed', () => {
+  const doc = makeDocument(SCRIPT, { ...page, scenario: 'Sup_X_By_Advancer' })
+
+  it('travels as its name, and reads as a link rather than as base64', async () => {
+    const fragment = await shareFragment(doc, { pristineScript: SCRIPT })
+    expect(fragment).toBe('#s=Sup_X_By_Advancer&seed=8391')
+  })
+
+  it('is fetched from the list when it is opened', async () => {
+    const asked = []
+    const { source, doc: back } = await open(
+      await shareFragment(doc, { pristineScript: SCRIPT }),
+      (slug) => {
+        asked.push(slug)
+        return Promise.resolve(SCRIPT)
+      },
+    )
+    expect(asked).toEqual(['Sup_X_By_Advancer'])
+    expect(source).toBe('scenario')
+    expect(back.script).toBe(SCRIPT)
+    expect(back.settings.seed).toBe(8391)
+    expect(back.settings.scenario).toBe('Sup_X_By_Advancer')
+  })
+
+  it('sends the whole script the moment a character of it changes', async () => {
+    // Otherwise the recipient opens a different script under the right name,
+    // which is worse than a long link.
+    const edited = makeDocument(SCRIPT + '# and one more line\n', {
+      ...page,
+      scenario: 'Sup_X_By_Advancer',
+    })
+    expect((await shareFragment(edited, { pristineScript: SCRIPT })).startsWith('#d=')).toBe(true)
+  })
+
+  it('states what was changed and stays quiet about what was not', async () => {
+    const fragment = scenarioFragment(
+      makeDocument(SCRIPT, {
+        ...page,
+        scenario: 'Weak_2_Bids',
+        produce: 60,
+        format: 'pbn',
+        roundRobin: true,
+        dealSource: 'library',
+        params: ['0=west'],
+      }),
+    )
+    const query = new URLSearchParams(fragment.slice(1))
+    expect(query.get('produce')).toBe('60')
+    expect(query.get('format')).toBe('pbn')
+    expect(query.get('roundRobin')).toBe('1')
+    expect(query.get('dealSource')).toBe('library')
+    expect(query.getAll('params')).toEqual(['0=west'])
+    // Untouched, so unsaid: this is what keeps the form short enough to read.
+    expect(query.has('maxGenerate')).toBe(false)
+    expect(query.has('autoLevel')).toBe(false)
+  })
+
+  it('opens with everything the fragment stated', async () => {
+    const { doc: back } = await open(
+      '#s=Weak_2_Bids&seed=5&produce=60&format=pbn&roundRobin=1&dealSource=library&params=0%3Dwest',
+      () => Promise.resolve(SCRIPT),
+    )
+    expect(back.settings).toMatchObject({
+      seed: 5,
+      produce: 60,
+      format: 'pbn',
+      roundRobin: true,
+      dealSource: 'library',
+      params: ['0=west'],
+      scenario: 'Weak_2_Bids',
+    })
+  })
+
+  it('opens on the defaults for everything it did not', async () => {
+    const { doc: back } = await open('#s=Weak_2_Bids', () => Promise.resolve(SCRIPT))
+    expect(back.settings.produce).toBe(20)
+    expect(back.settings.format).toBe('oneline')
+    expect(back.settings.dealSource).toBe('random')
+    // No seed named, so the reader rolls one rather than everyone seeing the
+    // same hands from a link that never said which.
+    expect('seed' in back.settings).toBe(false)
+  })
+
+  it('says so when the scenario cannot be fetched', async () => {
+    await expect(
+      open('#s=No_Such_Thing', () => Promise.reject(new Error('No dealer script for No_Such_Thing (HTTP 404)'))),
+    ).rejects.toThrow(/No dealer script/)
+  })
+})
+
+describe('a link that is not what it claims', () => {
+  it('says a short link cannot be opened yet, rather than opening nothing', async () => {
+    await expect(open('#k=Ab3x9')).rejects.toThrow(/short link/i)
+  })
+
+  it('says a truncated link was truncated', async () => {
+    // The common failure by a distance: mail clients wrap long URLs, and the
+    // fragment is the end of one.
+    const whole = await encodeDocument(makeDocument(SCRIPT, page))
+    await expect(open(`#d=${whole.slice(0, whole.length - 12)}`)).rejects.toThrow(/damaged/)
+  })
+
+  it('refuses base64 that is not base64', async () => {
+    await expect(decodeDocument('not base64 !!')).rejects.toThrow(/damaged/)
+  })
+
+  it('refuses a version it does not know rather than half-loading it', async () => {
+    const future = await encodeDocument({ v: DOCUMENT_VERSION + 1, script: SCRIPT, settings: {} })
+    await expect(open(`#d=${future}`)).rejects.toThrow(/newer dealer3/)
+  })
+
+  it('will not be talked into inflating a bomb', async () => {
+    // A fragment of a few hundred characters can inflate to hundreds of
+    // megabytes, and a tab that hangs before anything is on screen is the one
+    // failure with no way back.
+    const zeros = new Uint8Array(4 * 1024 * 1024)
+    const stream = new Blob([zeros]).stream().pipeThrough(new CompressionStream('deflate-raw'))
+    const packed = new Uint8Array(await new Response(stream).arrayBuffer())
+    let binary = ''
+    for (const byte of packed) binary += String.fromCharCode(byte)
+    const base64url = btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+    await expect(decodeDocument(base64url)).rejects.toThrow(/more than any script/)
+  })
+})
+
+describe('shareUrl', () => {
+  it('keeps the page it was made on, wherever that is served from', () => {
+    // Relative everywhere else in this app for the same reason: the site is
+    // both `dealer3.pages.dev` and `/dealer3/` under the apex.
+    expect(
+      shareUrl(
+        { origin: 'https://bridge-craftwork.com', pathname: '/dealer3/', search: '' },
+        '#s=Weak_2_Bids',
+      ),
+    ).toBe('https://bridge-craftwork.com/dealer3/#s=Weak_2_Bids')
+  })
+})


### PR DESCRIPTION
Closes #98. Closes #99.

Both halves at once: #98 produces a link and #99 consumes one, and a producer with no consumer cannot be tested.

## What it does

**Share**, beside the settings gear, copies a link that carries the script *and* its settings. Opening one loads the script, restores the settings, and **stops** — an unknown script can be expensive, the recipient should see what they are about to run, and a page that starts work on open makes the back button surprising.

Two forms are produced, cheapest first:

| Fragment | When |
|---|---|
| `#s=Basic_Major&seed=42&produce=8` | a scenario from the list, unmodified — the recipient fetches the same script from the same list |
| `#d=<base64url>` | anything edited: the whole document, deflated, ~300–450 characters for a real scenario |

`#k=` (the short link, #103, out of scope) is recognised and refused with a sentence, rather than opening a page that looks as though there had been no link.

Fragment, never query string: nothing after the `#` is sent with the request, so a link reaches no server log, no cache key and no edge rule. A real BBO capture came back 403 at the edge as a query string on 2026-08-28 while the identical payload in the fragment loaded — bridge-craftwork-site#3, item 4.

## The document, and how it relates to the envelope

A document is **not** `run_json`'s envelope. It carries `dealSource` and `newSeedEachRun` too — the engine infers the source from whether deals were handed to it, and takes a *definite* seed — plus `scenario`, so the list opens pointing at the right entry. UI state (`pickerOpen`, `settingsOpen`) does not travel.

Narrowing is not a function: `runEnvelope` names the engine's fields, so passing it a document's settings drops the caller's by not asking for them. Both shapes live in `envelope.js` for that reason — there is no second list to keep in step, and a test asserts the narrowing rather than restating it.

`session.js`'s shape is promoted rather than a third one defined beside it, `paramValues` included: the link carries the engine's `N=TEXT`, and `paramValuesFrom` projects it back into the fields. Without that a shared parameterised scenario arrives blank and runs on the script's declared defaults, looking exactly as though it had worked.

## Untrusted input

The fragment parses or is refused with a sentence worth reading. A truncated link says it was truncated (mail clients wrap long URLs, and the fragment is the end of one); an unknown version says so by number rather than half-loading; a setting that means nothing falls back to its default rather than throwing the script away with it; and inflation is bounded, because a few hundred characters of deflate can become hundreds of megabytes and a tab that hangs before anything is on screen is the one failure with no way back.

## Not overwriting somebody's work

What the link displaced is held in memory — the autosave overwrites the stored copy within half a second — and the notice above the editor offers it back. That is the only way back: the page never navigated, so the back button would leave the site. Declining drops the fragment so the link cannot re-open on the next reload; accepting leaves it alone and the autosave takes over from the first edit.

A link pasted into a tab that is already open changes the fragment without reloading anything, so `hashchange` opens it too — otherwise the page would sit there having visibly done nothing.

## Verification

`./dev-build.sh test`, `npm test` (284, up from 264) and `npm run build:all` all pass. No prettier was run.

In a real browser (Chromium at 1440×900 and 390×844), against the built `dist/`:

- both link forms round-trip: Share → open → same script, same settings
- a shared run produces what it should (`#s=Basic_Major&seed=42&produce=8&format=printall` → 8 produced from 283 generated)
- a shared parameter arrives in its field as `south`, not the script's declared `north`
- restore brings back the displaced script and drops the fragment
- the three failure messages read as sentences (truncated / short link / not base64)
- at 390 CSS px `documentElement.scrollWidth` stays 390, with an inflated root font as well

One thing found and left alone: on a phone, opening **any** panel in the editor column squeezes the editor pane to nothing. That is pre-existing — the settings panel does it on `main` — and the fix I tried (`overflow-y: auto` on the column) collapses the editor outright, so it wants its own issue rather than a change smuggled in here. The share panel was made compact (a smaller, shorter note) so it costs as little of that column as it can, and with only the notice up the column fits exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)