### PR TITLE
Write double-dummy tables back on export (#64), and stop claiming a -Z that never existed

### DIFF
--- a/dealer-pbn/Cargo.toml
+++ b/dealer-pbn/Cargo.toml
@@ -6,6 +6,8 @@ license = "Unlicense"
 
 [dependencies]
 dealer-core = { path = "../dealer-core" }
+bridge-encodings = { git = "https://github.com/bridge-craftwork/bridge-encodings" }
+bridge-types = { git = "https://github.com/bridge-craftwork/bridge-types" }
 chrono = "0.4"
 
 [dev-dependencies]

--- a/dealer-pbn/src/formatters.rs
+++ b/dealer-pbn/src/formatters.rs
@@ -207,6 +207,30 @@ pub enum DdTags {
     Both,
 }
 
+impl std::str::FromStr for DdTags {
+    type Err = String;
+
+    /// The spellings both front ends accept.
+    ///
+    /// Here rather than in either caller: the command line and the page read
+    /// the same word out of the same envelope, and two lists would be two
+    /// chances to disagree about what `tricks` means. The tag names are
+    /// accepted as well as the short words, because someone reaching for this
+    /// is looking at a PBN file and those are what it says.
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_lowercase().as_str() {
+            "none" | "no" | "off" => Ok(DdTags::None),
+            "optimum" | "optimumresulttable" | "table" => Ok(DdTags::Optimum),
+            "tricks" | "doubledummytricks" | "tag" => Ok(DdTags::Tricks),
+            "both" | "all" => Ok(DdTags::Both),
+            _ => Err(format!(
+                "Invalid dd-tags value '{}'. Valid options: none, optimum, tricks, both",
+                value
+            )),
+        }
+    }
+}
+
 /// Format a deal in PBN (Portable Bridge Notation) format.
 ///
 /// Writes the standard tags — Event, Site, Date, Board, the four player

--- a/dealer-pbn/src/formatters.rs
+++ b/dealer-pbn/src/formatters.rs
@@ -1,3 +1,4 @@
+use bridge_types::DdTable;
 use chrono::{Datelike, Local};
 use dealer_core::{Deal, Position, Rank, Suit};
 
@@ -165,6 +166,45 @@ pub struct PbnBoard<'a> {
     /// variables. Written as `[HandType "..."]`, which is not a standard tag —
     /// readers ignore what they do not know, so the file stays a PBN file.
     pub hand_type: Option<&'a str>,
+    /// This deal's double-dummy table, when all twenty cells are known.
+    ///
+    /// Never solved for: a table is here because the deal arrived with one or
+    /// because the script asked for every cell of it. Writing PBN must not
+    /// start a search — that would make the output format decide how long a
+    /// run takes.
+    pub dd_table: Option<&'a DdTable>,
+    /// Which of the two redundant encodings to write it in.
+    pub dd_tags: DdTags,
+}
+
+/// Which double-dummy encoding a PBN export writes.
+///
+/// The two say the same thing, so this is the consumer's choice rather than
+/// ours. `[OptimumResultTable]` is the one with a specification — PBN 2.1 §5.7
+/// — while `[DoubleDummyTricks]` is a Bridge Composer extension that appears
+/// nowhere in the standard, which is why the standard form is the default.
+///
+/// Writing only the standard form is safe for Bridge Composer users: its own
+/// help says its Double Dummy commands "make sure that both the
+/// DoubleDummyTricks tag and the OptimumResultTable tag are set properly", so
+/// it fills in its own tag when it analyses a board. That cannot be assumed of
+/// every tool, which is why `Tricks` and `Both` exist rather than the
+/// extension being dropped outright.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DdTags {
+    /// No analysis tags, even for a deal that knows its table.
+    ///
+    /// Not free to carry: the section is twenty-two lines a board against one
+    /// for the tag, where a whole board is a few hundred bytes. An export
+    /// nobody will read the analysis in should be able to say so.
+    None,
+    /// `[OptimumResultTable]` alone.
+    #[default]
+    Optimum,
+    /// `[DoubleDummyTricks]` alone.
+    Tricks,
+    /// Both, as `bridge-solver`'s CLI writes.
+    Both,
 }
 
 /// Format a deal in PBN (Portable Bridge Notation) format.
@@ -181,6 +221,8 @@ pub fn format_printpbn(deal: &Deal, board: &PbnBoard) -> String {
         seed,
         input_file,
         hand_type,
+        dd_table,
+        dd_tags,
     } = *board;
     let mut result = String::new();
 
@@ -281,10 +323,40 @@ pub fn format_printpbn(deal: &Deal, board: &PbnBoard) -> String {
     }
     result.push_str("\"]\n");
 
+    // What is known of this deal's double-dummy results, in whichever encoding
+    // was asked for. The tag goes with the tags; the section has to come after
+    // all of them, since its rows run until a blank line and a tag after them
+    // would read as part of the table.
+    let writes_tricks = matches!(dd_tags, DdTags::Tricks | DdTags::Both);
+    if let (Some(table), true) = (dd_table, writes_tricks) {
+        result.push_str(&format!(
+            "[DoubleDummyTricks \"{}\"]\n",
+            bridge_encodings::pbn::dd_table_to_pbn(table)
+        ));
+    }
+
     // Placeholder tags for game info
     result.push_str("[Declarer \"?\"]\n");
     result.push_str("[Contract \"?\"]\n");
     result.push_str("[Result \"?\"]\n");
+
+    let writes_optimum = matches!(dd_tags, DdTags::Optimum | DdTags::Both);
+    if let (Some(table), true) = (dd_table, writes_optimum) {
+        // The `Result` column is one character wide when no declarer takes ten
+        // tricks and two when one does. Header and rows come from the same
+        // place for that reason: a header declaring one width over rows padded
+        // to another is what had Bridge Composer rewriting every single-digit
+        // table on open and save.
+        result.push_str(&format!(
+            "[OptimumResultTable \"{}\"]\n",
+            bridge_encodings::pbn::optimum_result_table_header(table)
+        ));
+        for row in bridge_encodings::pbn::optimum_result_table_rows(table) {
+            result.push_str(&row);
+            result.push('\n');
+        }
+    }
+
     result.push('\n');
 
     result

--- a/dealer-pbn/src/lib.rs
+++ b/dealer-pbn/src/lib.rs
@@ -5,6 +5,6 @@ mod oneline;
 pub use deal::{format_deal_tag, parse_deal_tag, ParseError, PbnDeal};
 pub use formatters::{
     format_hand_pbn, format_printall, format_printcompact, format_printew, format_printns,
-    format_printpbn, PbnBoard, PrintFormat, Vulnerability,
+    format_printpbn, DdTags, PbnBoard, PrintFormat, Vulnerability,
 };
 pub use oneline::{format_oneline, parse_oneline};

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -618,6 +618,17 @@ pub struct Rows {
 }
 
 impl<'a> Produced<'a> {
+    /// This deal's complete double-dummy table, if it has one.
+    ///
+    /// What it arrived with, plus whatever the run worked out — the same
+    /// `DealTricks` the script's own `tricks()` reads. `None` unless all
+    /// twenty cells are known, and **nothing is solved to answer this**: an
+    /// exporter asks "do we know already?", and a deal nobody asked about is
+    /// not worth twenty searches to annotate.
+    pub fn dd_table(&self) -> Option<dealer_dds::bridge_solver::DdTable> {
+        self.dd_tricks.table()
+    }
+
     /// A fresh context over this deal, for a caller's own per-deal work.
     ///
     /// Fresh rather than shared for the reason contexts are built where they

--- a/dealer/Cargo.toml
+++ b/dealer/Cargo.toml
@@ -14,6 +14,7 @@ dealer-run = { path = "../dealer-run", features = ["parallel"] }
 dealer-eval = { path = "../dealer-eval" }
 dealer-pbn = { path = "../dealer-pbn" }
 bridge-encodings = { git = "https://github.com/bridge-craftwork/bridge-encodings" }
+bridge-types = { git = "https://github.com/bridge-craftwork/bridge-types" }
 clap = { version = "4.5", features = ["derive"] }
 
 [dev-dependencies]

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -66,7 +66,7 @@ struct Args {
     /// takes would be a trap, and `-f pbn` on a script that never mentions
     /// double-dummy would suddenly cost minutes a deal.
     #[arg(long = "dd-tags", value_name = "WHICH", default_value = "optimum")]
-    dd_tags: DdTagsArg,
+    dd_tags: DdTags,
 
     /// Dealer position (N/E/S/W) - used with PBN format (defaults to rotating, or value from input file if not specified)
     #[arg(short = 'd', long = "dealer")]
@@ -360,49 +360,6 @@ enum OutputFormat {
     /// dealer.exe script or command line means changes. The browser offers the
     /// same choice in its format list, where there is no `-q` to reach for.
     None,
-}
-
-/// `--dd-tags`, as the command line spells it.
-///
-/// A separate type from [`dealer_pbn::DdTags`] so that the formatter crate
-/// needs no argument parser, and so the spellings this accepts are decided
-/// here, where every other switch's are.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DdTagsArg {
-    None,
-    Optimum,
-    Tricks,
-    Both,
-}
-
-impl From<DdTagsArg> for DdTags {
-    fn from(value: DdTagsArg) -> Self {
-        match value {
-            DdTagsArg::None => DdTags::None,
-            DdTagsArg::Optimum => DdTags::Optimum,
-            DdTagsArg::Tricks => DdTags::Tricks,
-            DdTagsArg::Both => DdTags::Both,
-        }
-    }
-}
-
-impl std::str::FromStr for DdTagsArg {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // The tag names as well as the short words, because someone writing
-        // this switch is looking at a PBN file and those are what it says.
-        match s.to_lowercase().as_str() {
-            "none" | "no" | "off" => Ok(DdTagsArg::None),
-            "optimum" | "optimumresulttable" | "table" => Ok(DdTagsArg::Optimum),
-            "tricks" | "doubledummytricks" | "tag" => Ok(DdTagsArg::Tricks),
-            "both" | "all" => Ok(DdTagsArg::Both),
-            _ => Err(format!(
-                "Invalid --dd-tags value '{}'. Valid options: none, optimum, tricks, both",
-                s
-            )),
-        }
-    }
 }
 
 impl std::str::FromStr for OutputFormat {
@@ -1964,7 +1921,7 @@ fn main() {
                                 self.seed,
                                 self.args.input_file.as_deref(),
                                 table.as_ref(),
-                                self.args.dd_tags.into(),
+                                self.args.dd_tags,
                             )
                         );
                     }
@@ -2198,7 +2155,7 @@ fn main() {
                         seed,
                         args.input_file.as_deref(),
                         table.as_ref(),
-                        args.dd_tags.into(),
+                        args.dd_tags,
                     )
                 );
             }

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -18,7 +18,7 @@ use dealer_level::{
 use dealer_parser::{ActionType, CsvTerm, Statement, VulnerabilityType};
 use dealer_pbn::{
     format_oneline, format_printall, format_printcompact, format_printew, format_printns,
-    format_printpbn, PbnBoard, Vulnerability,
+    format_printpbn, DdTags, PbnBoard, Vulnerability,
 };
 use dealer_run::{Phase, Produced, RunHost, RunOptions};
 use std::fs::OpenOptions;
@@ -56,6 +56,17 @@ struct Args {
     /// script's own `printes`, `printrpt` and `print(...)` output is unaffected.
     #[arg(short = 'f', long = "format")]
     format: Option<OutputFormat>,
+
+    /// Which double-dummy tags a PBN export writes: none, optimum, tricks or
+    /// both (defaults to optimum).
+    ///
+    /// Only for deals that already know all twenty cells — one read from a
+    /// solved library, or one whose script asked for every cell. **Nothing is
+    /// solved to satisfy this**: an output format that decided how long a run
+    /// takes would be a trap, and `-f pbn` on a script that never mentions
+    /// double-dummy would suddenly cost minutes a deal.
+    #[arg(long = "dd-tags", value_name = "WHICH", default_value = "optimum")]
+    dd_tags: DdTagsArg,
 
     /// Dealer position (N/E/S/W) - used with PBN format (defaults to rotating, or value from input file if not specified)
     #[arg(short = 'd', long = "dealer")]
@@ -349,6 +360,49 @@ enum OutputFormat {
     /// dealer.exe script or command line means changes. The browser offers the
     /// same choice in its format list, where there is no `-q` to reach for.
     None,
+}
+
+/// `--dd-tags`, as the command line spells it.
+///
+/// A separate type from [`dealer_pbn::DdTags`] so that the formatter crate
+/// needs no argument parser, and so the spellings this accepts are decided
+/// here, where every other switch's are.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DdTagsArg {
+    None,
+    Optimum,
+    Tricks,
+    Both,
+}
+
+impl From<DdTagsArg> for DdTags {
+    fn from(value: DdTagsArg) -> Self {
+        match value {
+            DdTagsArg::None => DdTags::None,
+            DdTagsArg::Optimum => DdTags::Optimum,
+            DdTagsArg::Tricks => DdTags::Tricks,
+            DdTagsArg::Both => DdTags::Both,
+        }
+    }
+}
+
+impl std::str::FromStr for DdTagsArg {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // The tag names as well as the short words, because someone writing
+        // this switch is looking at a PBN file and those are what it says.
+        match s.to_lowercase().as_str() {
+            "none" | "no" | "off" => Ok(DdTagsArg::None),
+            "optimum" | "optimumresulttable" | "table" => Ok(DdTagsArg::Optimum),
+            "tricks" | "doubledummytricks" | "tag" => Ok(DdTagsArg::Tricks),
+            "both" | "all" => Ok(DdTagsArg::Both),
+            _ => Err(format!(
+                "Invalid --dd-tags value '{}'. Valid options: none, optimum, tricks, both",
+                s
+            )),
+        }
+    }
 }
 
 impl std::str::FromStr for OutputFormat {
@@ -658,6 +712,8 @@ fn render_board(
     event_name: Option<&str>,
     seed: u32,
     input_file: Option<&str>,
+    dd_table: Option<&bridge_types::DdTable>,
+    dd_tags: DdTags,
 ) -> String {
     match format {
         OutputFormat::PrintAll => format_printall(deal, board_number),
@@ -673,6 +729,8 @@ fn render_board(
                 seed: Some(seed),
                 input_file,
                 hand_type,
+                dd_table,
+                dd_tags,
             },
         ),
         OutputFormat::PrintCompact => format_printcompact(deal),
@@ -1769,7 +1827,12 @@ fn main() {
             /// Held rather than printed when `--interleave` is on: the order is
             /// not known until every deal is in, and a board's number belongs to
             /// where it lands.
-            held: Vec<(Option<String>, Deal)>,
+            ///
+            /// The double-dummy table is held with it. It is twenty bytes and
+            /// `Copy`, and the alternative is `--interleave` quietly writing
+            /// PBN without the analysis every other path writes — a difference
+            /// nobody would think to look for.
+            held: Vec<(Option<String>, Deal, Option<bridge_types::DdTable>)>,
             printed_deals: Vec<Deal>,
             produced: usize,
             /// The progress meter's last report, in deals.
@@ -1879,9 +1942,15 @@ fn main() {
 
                 if !self.args.quiet {
                     if self.args.interleave {
-                        self.held
-                            .push((hand_type.map(str::to_string), deal.deal.clone()));
+                        self.held.push((
+                            hand_type.map(str::to_string),
+                            deal.deal.clone(),
+                            deal.dd_table(),
+                        ));
                     } else if self.print_deals {
+                        // Bound rather than passed inline: the renderer borrows
+                        // it, and a temporary would not outlive the call.
+                        let table = deal.dd_table();
                         print!(
                             "{}",
                             render_board(
@@ -1894,6 +1963,8 @@ fn main() {
                                 self.title.as_deref(),
                                 self.seed,
                                 self.args.input_file.as_deref(),
+                                table.as_ref(),
+                                self.args.dd_tags.into(),
                             )
                         );
                     }
@@ -2082,7 +2153,7 @@ fn main() {
         // rather than meeting them as they happen to fall.
         if args.interleave && !held.is_empty() {
             let mut buckets: Vec<(Option<String>, Vec<usize>)> = Vec::new();
-            for (index, (hand_type, _)) in held.iter().enumerate() {
+            for (index, (hand_type, _, _)) in held.iter().enumerate() {
                 match buckets.iter_mut().find(|(name, _)| name == hand_type) {
                     Some((_, deals)) => deals.push(index),
                     None => buckets.push((hand_type.clone(), vec![index])),
@@ -2113,7 +2184,7 @@ fn main() {
                 if !print_deals {
                     continue;
                 }
-                let (hand_type, deal) = &held[index];
+                let (hand_type, deal, table) = &held[index];
                 print!(
                     "{}",
                     render_board(
@@ -2126,6 +2197,8 @@ fn main() {
                         title.as_deref(),
                         seed,
                         args.input_file.as_deref(),
+                        table.as_ref(),
+                        args.dd_tags.into(),
                     )
                 );
             }

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -34,7 +34,12 @@ pub enum DoneWhen {
 impl DoneWhen {
     fn is_done(self) -> bool {
         match self {
-            DoneWhen::Switch(flag) => support(flag, "") == Support::Yes,
+            // Passed as both, because `support` matches a short against
+            // `-c` and a long against `--word` and ignores the one that
+            // cannot match. Passing the flag only as `short` — which this
+            // did — meant a row waiting on a long switch could never be
+            // satisfied, and would have outlived the work it described.
+            DoneWhen::Switch(flag) => support(flag, flag) == Support::Yes,
             DoneWhen::Function(name) => vocabulary::FUNCTIONS.contains(&name),
             DoneWhen::Statement(name) => vocabulary::STATEMENT_KEYWORDS.contains(&name),
         }
@@ -195,24 +200,6 @@ pub const REMAINING: &[WorkItem] = &[
         effort: Effort::High,
         value: Value::Low,
         note: Some("`--input-deals` already covers the common case in dealer3's own way."),
-    },
-    WorkItem {
-        what: "Write RP ZRD, and write double-dummy tables back on export",
-        done_when: Some(DoneWhen::Switch("-Z")),
-        issue: Some(64),
-        effort: Effort::Medium,
-        value: Value::Medium,
-        note: Some(
-            "**Reading has shipped**, which was the valuable half: `--input-deals` takes a \
-             `.zrd`, and a deal read from any format arrives with the double-dummy table it \
-             carried — a ZRD record's twenty results, a PBN `[DoubleDummyTricks]` or an \
-             `[OptimumResultTable]` — so `tricks()`, `dds()` and `par()` are lookups rather \
-             than hundred-millisecond searches, which is what made them affordable in the \
-             browser. What is left is the other direction: writing a table back out, as a \
-             PBN tag and as ZRD records, so a run's deals can be saved solved — which is \
-             what this issue now covers, the encoding a PBN export writes included. The \
-             format work is bridge-encodings#20.",
-        ),
     },
     WorkItem {
         what: "Exhaust mode — which no build of the original ships",

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -199,7 +199,7 @@ pub const REMAINING: &[WorkItem] = &[
     WorkItem {
         what: "Write RP ZRD, and write double-dummy tables back on export",
         done_when: Some(DoneWhen::Switch("-Z")),
-        issue: Some(61),
+        issue: Some(64),
         effort: Effort::Medium,
         value: Value::Medium,
         note: Some(
@@ -209,8 +209,8 @@ pub const REMAINING: &[WorkItem] = &[
              `[OptimumResultTable]` — so `tricks()`, `dds()` and `par()` are lookups rather \
              than hundred-millisecond searches, which is what made them affordable in the \
              browser. What is left is the other direction: writing a table back out, as a \
-             PBN tag and as ZRD records, so a run's deals can be saved solved. \
-             bridge-craftwork/Dealer3#64 chooses which encoding a PBN export writes. The \
+             PBN tag and as ZRD records, so a run's deals can be saved solved — which is \
+             what this issue now covers, the encoding a PBN export writes included. The \
              format work is bridge-encodings#20.",
         ),
     },

--- a/dealer/src/roadmap.rs
+++ b/dealer/src/roadmap.rs
@@ -197,16 +197,21 @@ pub const REMAINING: &[WorkItem] = &[
         note: Some("`--input-deals` already covers the common case in dealer3's own way."),
     },
     WorkItem {
-        what: "Read and write RP ZRD, Pavlicek's solved-deal library",
+        what: "Write RP ZRD, and write double-dummy tables back on export",
         done_when: Some(DoneWhen::Switch("-Z")),
         issue: Some(61),
         effort: Effort::Medium,
         value: Value::Medium,
         note: Some(
-            "Reading is the valuable half: a ZRD record carries a deal *and* its twenty \
-             double-dummy results, so `tricks()`, `dds()` and `par()` become lookups rather \
-             than hundred-millisecond searches — which is also what would make them usable \
-             in the browser. The format work is bridge-encodings#20.",
+            "**Reading has shipped**, which was the valuable half: `--input-deals` takes a \
+             `.zrd`, and a deal read from any format arrives with the double-dummy table it \
+             carried — a ZRD record's twenty results, a PBN `[DoubleDummyTricks]` or an \
+             `[OptimumResultTable]` — so `tricks()`, `dds()` and `par()` are lookups rather \
+             than hundred-millisecond searches, which is what made them affordable in the \
+             browser. What is left is the other direction: writing a table back out, as a \
+             PBN tag and as ZRD records, so a run's deals can be saved solved. \
+             bridge-craftwork/Dealer3#64 chooses which encoding a PBN export writes. The \
+             format work is bridge-encodings#20.",
         ),
     },
     WorkItem {

--- a/dealer/src/switches.rs
+++ b/dealer/src/switches.rs
@@ -356,6 +356,21 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
         ),
     },
     SwitchRow {
+        short: "",
+        long: "--dd-tags",
+        group: "Output",
+        what: "Which double-dummy tags a PBN export writes",
+        dealer_exe: Origin::Absent,
+        dealer_v2: Origin::Absent,
+        note: Some(
+            "dealer3's own. `none`, `optimum` (the default), `tricks` or `both`: the two PBN \
+             encodings are redundant and which one a consumer wants depends on the consumer. \
+             Only for a deal that already knows all twenty cells — one read from a solved \
+             library, or one whose script asked for every cell. Nothing is solved to fill a \
+             tag, so choosing an output format never decides how long a run takes.",
+        ),
+    },
+    SwitchRow {
         short: "-d",
         long: "--dealer",
         group: "Output",
@@ -610,15 +625,6 @@ pub const SWITCH_ROWS: &[SwitchRow] = &[
         dealer_exe: Origin::Absent,
         dealer_v2: Origin::Same,
         note: Some("It prints nothing. DealerV2_4's own docs describe it as \"1 Single result mode; 2 all 20 strain-compass combinations\" (`docs/Handstat_layout.txt`), so it chooses how the DDS library is called, not what comes out — and DealerV2_4 switches to mode 2 by itself whenever `par` or `trix` needs it. dealer3 has no such choice to offer: results are kept per (deal, denomination, declarer) and travel with their deal, so asking once costs one search, asking twenty costs twenty, and asking again costs nothing."),
-    },
-    SwitchRow {
-        short: "-Z",
-        long: "",
-        group: "Not implemented",
-        what: "Export in RP zrd format",
-        dealer_exe: Origin::Absent,
-        dealer_v2: Origin::Same,
-        note: None,
     },
     SwitchRow {
         short: "-U",

--- a/dealer/tests/input_deals.rs
+++ b/dealer/tests/input_deals.rs
@@ -908,3 +908,228 @@ fn the_window_switches_need_input_deals() {
         );
     }
 }
+
+// --- Writing back what came in (#64) --------------------------------------
+//
+// A deal that arrived solved can leave solved. These drive the real binary
+// both ways round — read a library, write PBN, read that PBN back — because
+// the encodings are the point and a unit test over our own writer alone would
+// prove only that it agrees with itself.
+
+/// Run a script over the fixture library and return what it wrote.
+fn library_pbn(tag: &str, extra: &[&str]) -> Output {
+    let library = temp_binary(tag, "zrd", LIBRARY);
+    let script = temp_file(&format!("script-{}", tag), "condition 1\n");
+    let mut all = vec![
+        script.to_str().expect("utf-8 path").to_string(),
+        "--input-deals".to_string(),
+        library.to_str().expect("utf-8 path").to_string(),
+        "-f".to_string(),
+        "pbn".to_string(),
+        "-p".to_string(),
+        "3".to_string(),
+        "-s".to_string(),
+        "1".to_string(),
+    ];
+    all.extend(extra.iter().map(|arg| arg.to_string()));
+    let borrowed: Vec<&str> = all.iter().map(String::as_str).collect();
+    run(&borrowed, None)
+}
+
+#[test]
+fn a_pbn_export_carries_the_table_a_deal_arrived_with() {
+    // The standard encoding by default: `OptimumResultTable` is PBN 2.1 §5.7,
+    // where `DoubleDummyTricks` is a Bridge Composer extension.
+    let out = library_pbn("dd-default", &[]);
+    assert!(out.success, "{}", out.stderr);
+    assert!(
+        out.stdout.contains("[OptimumResultTable "),
+        "the default writes the standard section:\n{}",
+        out.stdout
+    );
+    assert!(
+        !out.stdout.contains("[DoubleDummyTricks "),
+        "and not the extension as well:\n{}",
+        out.stdout
+    );
+    // Twenty rows a board, three boards.
+    assert_eq!(
+        out.stdout
+            .lines()
+            .filter(|line| line.starts_with("N NT"))
+            .count(),
+        3,
+        "one table per board:\n{}",
+        out.stdout
+    );
+}
+
+#[test]
+fn the_result_column_is_as_wide_as_the_table_needs() {
+    // Header and rows come from one place for this reason: a header declaring
+    // one width over rows padded to another is what had Bridge Composer
+    // rewriting every single-digit table on open and save.
+    let out = library_pbn("dd-width", &[]);
+    let header = out
+        .stdout
+        .lines()
+        .find(|line| line.starts_with("[OptimumResultTable "))
+        .expect("a table header");
+    let width: usize = if header.contains("Result\\2R") { 2 } else { 1 };
+    let row = out
+        .stdout
+        .lines()
+        .find(|line| line.starts_with("N NT"))
+        .expect("a table row");
+    let tricks = row.split_whitespace().last().expect("a trick count");
+    assert_eq!(
+        row.len(),
+        "N NT ".len() + width,
+        "the rows are padded to the width the header declares ({}): {:?}",
+        header,
+        row
+    );
+    assert!(
+        tricks.parse::<u8>().is_ok(),
+        "and end in a number: {:?}",
+        row
+    );
+}
+
+#[test]
+fn dd_tags_chooses_the_encoding() {
+    for (value, wants, not) in [
+        ("tricks", "[DoubleDummyTricks ", "[OptimumResultTable "),
+        ("optimum", "[OptimumResultTable ", "[DoubleDummyTricks "),
+    ] {
+        let out = library_pbn(&format!("dd-{}", value), &["--dd-tags", value]);
+        assert!(out.success, "{}", out.stderr);
+        assert!(
+            out.stdout.contains(wants),
+            "--dd-tags {} writes {}",
+            value,
+            wants
+        );
+        assert!(
+            !out.stdout.contains(not),
+            "--dd-tags {} writes only that:\n{}",
+            value,
+            out.stdout
+        );
+    }
+
+    let both = library_pbn("dd-both", &["--dd-tags", "both"]);
+    assert!(both.stdout.contains("[DoubleDummyTricks "));
+    assert!(both.stdout.contains("[OptimumResultTable "));
+
+    // Not free to carry: the section is twenty-two lines a board, where a whole
+    // board is a few hundred bytes.
+    let none = library_pbn("dd-none", &["--dd-tags", "none"]);
+    assert!(
+        !none.stdout.contains("DoubleDummy") && !none.stdout.contains("Optimum"),
+        "--dd-tags none writes neither:\n{}",
+        none.stdout
+    );
+}
+
+#[test]
+fn what_is_written_reads_back_as_the_same_analysis() {
+    // The test that matters. Both encodings go out and come back through the
+    // reader, and the answers have to survive the trip — a transposed axis
+    // yields a plausible table, and for the seat axis it yields the
+    // *opponents'* plausible table, so "it parsed" proves nothing on its own.
+    let script = temp_file(
+        "dd-roundtrip-script",
+        "condition 1\naction average \"nt\" tricks(north, notrump), \
+         average \"eh\" tricks(east, hearts)\n",
+    );
+    let script = script.to_str().expect("utf-8 path");
+
+    let library = temp_binary("dd-roundtrip", "zrd", LIBRARY);
+    let direct = run(
+        &[
+            script,
+            "--input-deals",
+            library.to_str().expect("utf-8 path"),
+            "-f",
+            "none",
+            "-p",
+            "3",
+            "-s",
+            "1",
+        ],
+        None,
+    );
+    assert!(direct.success, "{}", direct.stderr);
+    let expected = statistics(&direct.stdout);
+    assert!(
+        !expected.is_empty(),
+        "the run reported nothing:\n{}",
+        direct.stdout
+    );
+
+    for value in ["optimum", "tricks", "both"] {
+        let written = library_pbn(&format!("dd-rt-{}", value), &["--dd-tags", value]);
+        let file = temp_file(&format!("dd-rt-file-{}", value), &written.stdout);
+        let back = run(
+            &[
+                script,
+                "--input-deals",
+                file.to_str().expect("utf-8 path"),
+                "-f",
+                "none",
+                "-p",
+                "3",
+            ],
+            None,
+        );
+        assert!(back.success, "{}", back.stderr);
+        assert!(
+            back.stderr.contains("arrived with double-dummy tables"),
+            "--dd-tags {} produced a file the reader sees as solved:\n{}",
+            value,
+            back.stderr
+        );
+        assert_eq!(
+            statistics(&back.stdout),
+            expected,
+            "--dd-tags {} carried the same answers out and back",
+            value
+        );
+    }
+}
+
+/// The `average` lines of a run, which is where the double-dummy answers show.
+fn statistics(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .filter(|line| line.contains(':'))
+        .map(|line| line.trim().to_string())
+        .collect()
+}
+
+#[test]
+fn a_generated_deal_nobody_asked_about_is_not_solved_to_fill_a_tag() {
+    // The trap this switch must not become: `-f pbn` on a script that never
+    // mentions double-dummy would otherwise cost twenty searches a deal, and
+    // the output format would be deciding how long the run takes.
+    let script = temp_file("dd-unsolved", "condition 1\n");
+    let out = run(
+        &[
+            script.to_str().expect("utf-8 path"),
+            "-f",
+            "pbn",
+            "-p",
+            "2",
+            "-s",
+            "7",
+        ],
+        None,
+    );
+    assert!(out.success, "{}", out.stderr);
+    assert!(
+        !out.stdout.contains("OptimumResultTable") && !out.stdout.contains("DoubleDummyTricks"),
+        "a deal with no table carries no tags:\n{}",
+        out.stdout
+    );
+}

--- a/docs/command_line_comparison.md
+++ b/docs/command_line_comparison.md
@@ -24,7 +24,7 @@ UPDATE_DOCS=1 cargo test -p dealer
 
 <!-- BEGIN GENERATED: switches -->
 
-dealer3 implements **41 of the 51 switches** listed here. The dealer3 column is read from the argument parser itself, so it cannot drift; the other two columns are reference data (see `dealer/src/switches.rs` for their provenance).
+dealer3 implements **42 of the 51 switches** listed here. The dealer3 column is read from the argument parser itself, so it cannot drift; the other two columns are reference data (see `dealer/src/switches.rs` for their provenance).
 
 In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed and then refused with an explanation, so a script using it gets told rather than ignored. In the other two columns ✅ means the same meaning, ⚠️ a different one, and — not present at all.
 
@@ -56,6 +56,7 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 | `-u` | Upper-case the honour cards in output | ✅ | ✅ | — | Accepted and ignored, because it does nothing in dealer.exe either: `-u` sets a flag read only by the `representation` macro in `dealer.c`, and that macro is never invoked — every output path uses `ucrep` directly. Verified; the reference binary's output is byte-identical with and without it. dealer3's honours are upper case too, so the switch is accepted rather than refused and a command line carrying it still runs. `-v` says so. |
 | `--interleave` | Order the output so each hand type appears before any repeats | ✅ | — | — | Needs `HandType_*` variables to classify against. Rare types are spread across the run rather than exhausted early. See `docs/leveling-guide.md`. |
 | `-f`, `--format` | Output format | ✅ | — | — | The original selects a format with an `action` statement instead. `-f none` writes no deals and keeps the statistics, for a run that only wants its `average` and `frequency` results. |
+| `--dd-tags` | Which double-dummy tags a PBN export writes | ✅ | — | — | dealer3's own. `none`, `optimum` (the default), `tricks` or `both`: the two PBN encodings are redundant and which one a consumer wants depends on the consumer. Only for a deal that already knows all twenty cells — one read from a solved library, or one whose script asked for every cell. Nothing is solved to fill a tag, so choosing an output format never decides how long a run takes. |
 | `-d`, `--dealer` | Dealer position | ✅ | — | — | The original uses the `dealer` statement, which dealer3 also accepts. |
 | `--vulnerable` | Vulnerability | ✅ | — | ⚠️ -P sets vulnerability for par | Long form only. `-v` is verbose, as in the original — this was the 0.2.0 breaking change. |
 | `-v`, `--verbose` | Toggle the closing statistics | ✅ | ✅ | ✅ |  |
@@ -113,7 +114,6 @@ In the dealer3 column ✅ is implemented and ⚠️ means the switch is parsed a
 | Switch | What it does | dealer3 | dealer.exe | DealerV2_4 | Notes |
 |---|---|---|---|---|---|
 | `-M` | Double-dummy solver mode — nothing to implement | ❌ | — | ✅ | It prints nothing. DealerV2_4's own docs describe it as "1 Single result mode; 2 all 20 strain-compass combinations" (`docs/Handstat_layout.txt`), so it chooses how the DDS library is called, not what comes out — and DealerV2_4 switches to mode 2 by itself whenever `par` or `trix` needs it. dealer3 has no such choice to offer: results are kept per (deal, denomination, declarer) and travel with their deal, so asking once costs one search, asking twenty costs twenty, and asking again costs nothing. |
-| `-Z` | Export in RP zrd format | ❌ | — | ✅ |  |
 | `-U` | DealerServer path | ❌ | — | ✅ |  |
 | `-O` | OPC evaluation for the opener | ❌ | — | ✅ |  |
 | `-D` | Debug verbosity 0-9 | ❌ | — | ✅ |  |

--- a/docs/command_line_switch_requirements.md
+++ b/docs/command_line_switch_requirements.md
@@ -252,7 +252,6 @@ dealer --vulnerable none  # Vulnerability (long form only)
 |--------|-------------|----------|--------|-------|
 | `-M MODE` | DDS mode | 🔵 Low | Very High | Requires DDS library |
 | `-R N` | Multi-threading | 🔵 Low | High | Performance feature |
-| `-Z FILE` | RP zrd export | 🔵 Low | Medium | Niche format |
 | `-L PATH` | Library source | 🔵 Low | High | Advanced feature |
 | `-O POS` | OPC evaluation | 🔵 Low | High | Advanced analysis |
 | `-P N` | Par vulnerability | 🔵 Low | High | Requires DDS |

--- a/docs/dealer_vs_dealer2_switches.md
+++ b/docs/dealer_vs_dealer2_switches.md
@@ -69,7 +69,6 @@ These switches are new features added in DealerV2_4:
 |--------|-------------|----------|
 | `-C FILE` | CSV Report filename | Export |
 | `-X FILE` | Export predeal holdings | Export |
-| `-Z FILE` | RP zrd format export | Export |
 
 ### Advanced Features
 
@@ -187,7 +186,12 @@ Based on this analysis, dealer3 should:
 ### Low Priority (Advanced Features)
 9. ~~Swapping modes~~ - done, using dealer.exe's `-0`/`-2`/`-3` rather than V2_4's `-x MODE`
 10. DDS integration (`-M`, `-R`) - High effort, requires external library
-11. Export formats (`-Z` RP ZRD) - niche, but reading ZRD is not: see #61
+11. ~~Export formats (`-Z` RP ZRD)~~ - **there is no such switch.** DealerV2_4's
+    option string carries no `Z`, its usage message does not list one, and neither
+    its user guide nor its README mentions a ZRD export; `.zrd` appears there only
+    as the library `-L` *reads*, built by Pavlicek's own `xxdd.exe`. Reading it is
+    the valuable half and is done — see the closed #61. Writing it is not wanted:
+    any-to-any conversion belongs in bridge-wrangler
 
 ### Avoid Conflicts
 - **DO NOT** implement dealer.exe's `-l` (library.dat reader) to avoid confusion with V2_4

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -158,8 +158,8 @@ shipped, it named `-l` twice for two different features, and it offered
 letters are dealer.exe's swapping switches and already taken.
 
 So what remains of it is in **What is left** below, which is generated from
-`dealer/src/roadmap.rs` and checked against the argument parser — `-M`, `-Z`,
-Library mode is a row in that table, with the switch collisions
+`dealer/src/roadmap.rs` and checked against the argument parser — `-M` and
+Library mode are rows in that table, with the switch collisions
 written down where they belong. Script parameters used to be a row there too,
 and are now finished: `--param` fills one, a `# param 0 = west` comment declares
 what it should be when nothing does, and `--params` lists what a script wants.
@@ -218,11 +218,18 @@ See `CHANGELOG.md` for the migration note.
       which is what made double-dummy affordable in the browser. The global
       memo it was prototyped through is retired; a table travels with its deal
       and goes with it when the filter throws it away (#61)
-- [ ] ZRD: **write** one — the half that is left. Export writing tables back,
-      as a PBN tag and as ZRD records, is `-Z`, and it lives in
-      [#64](https://github.com/bridge-craftwork/Dealer3/issues/64) along with
-      the choice of which encoding a PBN export writes. #61, which was the
-      reading half, is closed
+- [x] Write a known table back out on a **PBN** export - **COMPLETED**.
+      `--dd-tags none|optimum|tricks|both` chooses which of the two redundant
+      encodings is written, `optimum` by default because
+      `[OptimumResultTable]` is the one PBN 2.1 specifies and
+      `[DoubleDummyTricks]` is a Bridge Composer extension. Only for a deal
+      that already knows all twenty cells: nothing is solved to fill a tag, so
+      an output format never decides how long a run takes
+      ([#64](https://github.com/bridge-craftwork/Dealer3/issues/64))
+- **Writing ZRD is not planned**, and there is nothing to be compatible with:
+  DealerV2 reads that format and does not write it — no `Z` in its option
+  string, none in its usage, and `.zrd` appears in its guide only as the
+  library `-L` reads. Any-to-any conversion belongs in bridge-wrangler
 - [x] Script parameters (`$0`-`$9`) - **COMPLETED**. `--param 1=west` rather than
       DealerV2_4's `-1`, which is dealer.exe's swapping switch; a script declares
       its own defaults in a `# param 1 = 15` comment, which the original's lexer
@@ -278,7 +285,6 @@ Priority is derived from effort and value rather than written down beside them.
 
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
-| 🟢 Someday | Write RP ZRD, and write double-dummy tables back on export | Medium | Medium | [#64](https://github.com/bridge-craftwork/Dealer3/issues/64) | **Reading has shipped**, which was the valuable half: `--input-deals` takes a `.zrd`, and a deal read from any format arrives with the double-dummy table it carried — a ZRD record's twenty results, a PBN `[DoubleDummyTricks]` or an `[OptimumResultTable]` — so `tricks()`, `dds()` and `par()` are lookups rather than hundred-millisecond searches, which is what made them affordable in the browser. What is left is the other direction: writing a table back out, as a PBN tag and as ZRD records, so a run's deals can be saved solved — which is what this issue now covers, the encoding a PBN export writes included. The format work is bridge-encodings#20. |
 | 🔵 Unlikely | The length-bias form of `predeal`, `spades(north) == 5` — which the original ignores | Medium | Low |  | **The original accepts it and does nothing with it.** `predealarg : SUIT '(' COMPASS ')' CMPEQ NUMBER` in `defs.y` calls `bias_deal`, which writes `biasdeal[compass][suit]` — and nothing ever reads that array; `dealer.c` contains its declaration and no other mention. Measured rather than inferred: `predeal spades(north) == 5` over 200 deals gives North an average of 3.285 spades, the natural 3.25, on the macOS build and on the Windows one BBO's lineage comes from. So there is no behaviour to be compatible with. dealer3 rejects it loudly, which is the better of the two; implementing it would make dealer3 differ from the original rather than match it. |
 | 🔵 Unlikely | `--bbo-strict`: warn when a script will behave differently on BBO | Medium | Low | [#13](https://github.com/bridge-craftwork/Dealer3/issues/13) | Rick judged it unlikely to bite. |
 | 🔵 Unlikely | `bktfreq`: frequency in buckets, one and two dimensional | Medium | Low |  | Adjacent to the two-dimensional `frequency` below but not the same thing: that one is the original's, this one groups a range into buckets. |

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -219,9 +219,10 @@ See `CHANGELOG.md` for the migration note.
       memo it was prototyped through is retired; a table travels with its deal
       and goes with it when the filter throws it away (#61)
 - [ ] ZRD: **write** one — the half that is left. Export writing tables back,
-      as a PBN tag and as ZRD records, is `-Z`; [#64](https://github.com/bridge-craftwork/Dealer3/issues/64)
-      chooses which encoding a PBN export writes
-      ([#61](https://github.com/bridge-craftwork/Dealer3/issues/61))
+      as a PBN tag and as ZRD records, is `-Z`, and it lives in
+      [#64](https://github.com/bridge-craftwork/Dealer3/issues/64) along with
+      the choice of which encoding a PBN export writes. #61, which was the
+      reading half, is closed
 - [x] Script parameters (`$0`-`$9`) - **COMPLETED**. `--param 1=west` rather than
       DealerV2_4's `-1`, which is dealer.exe's swapping switch; a script declares
       its own defaults in a `# param 1 = 15` comment, which the original's lexer
@@ -277,7 +278,7 @@ Priority is derived from effort and value rather than written down beside them.
 
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
-| 🟢 Someday | Write RP ZRD, and write double-dummy tables back on export | Medium | Medium | [#61](https://github.com/bridge-craftwork/Dealer3/issues/61) | **Reading has shipped**, which was the valuable half: `--input-deals` takes a `.zrd`, and a deal read from any format arrives with the double-dummy table it carried — a ZRD record's twenty results, a PBN `[DoubleDummyTricks]` or an `[OptimumResultTable]` — so `tricks()`, `dds()` and `par()` are lookups rather than hundred-millisecond searches, which is what made them affordable in the browser. What is left is the other direction: writing a table back out, as a PBN tag and as ZRD records, so a run's deals can be saved solved. bridge-craftwork/Dealer3#64 chooses which encoding a PBN export writes. The format work is bridge-encodings#20. |
+| 🟢 Someday | Write RP ZRD, and write double-dummy tables back on export | Medium | Medium | [#64](https://github.com/bridge-craftwork/Dealer3/issues/64) | **Reading has shipped**, which was the valuable half: `--input-deals` takes a `.zrd`, and a deal read from any format arrives with the double-dummy table it carried — a ZRD record's twenty results, a PBN `[DoubleDummyTricks]` or an `[OptimumResultTable]` — so `tricks()`, `dds()` and `par()` are lookups rather than hundred-millisecond searches, which is what made them affordable in the browser. What is left is the other direction: writing a table back out, as a PBN tag and as ZRD records, so a run's deals can be saved solved — which is what this issue now covers, the encoding a PBN export writes included. The format work is bridge-encodings#20. |
 | 🔵 Unlikely | The length-bias form of `predeal`, `spades(north) == 5` — which the original ignores | Medium | Low |  | **The original accepts it and does nothing with it.** `predealarg : SUIT '(' COMPASS ')' CMPEQ NUMBER` in `defs.y` calls `bias_deal`, which writes `biasdeal[compass][suit]` — and nothing ever reads that array; `dealer.c` contains its declaration and no other mention. Measured rather than inferred: `predeal spades(north) == 5` over 200 deals gives North an average of 3.285 spades, the natural 3.25, on the macOS build and on the Windows one BBO's lineage comes from. So there is no behaviour to be compatible with. dealer3 rejects it loudly, which is the better of the two; implementing it would make dealer3 differ from the original rather than match it. |
 | 🔵 Unlikely | `--bbo-strict`: warn when a script will behave differently on BBO | Medium | Low | [#13](https://github.com/bridge-craftwork/Dealer3/issues/13) | Rick judged it unlikely to bite. |
 | 🔵 Unlikely | `bktfreq`: frequency in buckets, one and two dimensional | Medium | Low |  | Adjacent to the two-dimensional `frequency` below but not the same thing: that one is the original's, this one groups a range into buckets. |

--- a/docs/implementation_roadmap.md
+++ b/docs/implementation_roadmap.md
@@ -209,7 +209,19 @@ See `CHANGELOG.md` for the migration note.
 - [x] DDS integration - **COMPLETED** via `tricks()`, `score()`, `imps()`,
       solved by `bridge-solver` and remembered per deal (#14)
 - [ ] Library mode - `--input-deals` covers the common case; `-l` is rejected
-- [ ] ZRD: read a solved library, and write one ([#61](https://github.com/bridge-craftwork/Dealer3/issues/61))
+- [x] ZRD: **read** a solved library - **COMPLETED**. `--input-deals` takes a
+      Pavlicek `.zrd`, PBN or one-line, decided by the content, with
+      `--input-offset` to say where in a library to start. The tables come with
+      it: a deal read from a file carries its own `DdTable` — from a ZRD record,
+      a PBN `[DoubleDummyTricks]` or an `[OptimumResultTable]` — so `tricks()`,
+      `dds()` and `par()` are lookups rather than hundred-millisecond searches,
+      which is what made double-dummy affordable in the browser. The global
+      memo it was prototyped through is retired; a table travels with its deal
+      and goes with it when the filter throws it away (#61)
+- [ ] ZRD: **write** one — the half that is left. Export writing tables back,
+      as a PBN tag and as ZRD records, is `-Z`; [#64](https://github.com/bridge-craftwork/Dealer3/issues/64)
+      chooses which encoding a PBN export writes
+      ([#61](https://github.com/bridge-craftwork/Dealer3/issues/61))
 - [x] Script parameters (`$0`-`$9`) - **COMPLETED**. `--param 1=west` rather than
       DealerV2_4's `-1`, which is dealer.exe's swapping switch; a script declares
       its own defaults in a `# param 1 = 15` comment, which the original's lexer
@@ -265,7 +277,7 @@ Priority is derived from effort and value rather than written down beside them.
 
 | Priority | What | Effort | Value | Issue | Notes |
 |---|---|---|---|---|---|
-| 🟢 Someday | Read and write RP ZRD, Pavlicek's solved-deal library | Medium | Medium | [#61](https://github.com/bridge-craftwork/Dealer3/issues/61) | Reading is the valuable half: a ZRD record carries a deal *and* its twenty double-dummy results, so `tricks()`, `dds()` and `par()` become lookups rather than hundred-millisecond searches — which is also what would make them usable in the browser. The format work is bridge-encodings#20. |
+| 🟢 Someday | Write RP ZRD, and write double-dummy tables back on export | Medium | Medium | [#61](https://github.com/bridge-craftwork/Dealer3/issues/61) | **Reading has shipped**, which was the valuable half: `--input-deals` takes a `.zrd`, and a deal read from any format arrives with the double-dummy table it carried — a ZRD record's twenty results, a PBN `[DoubleDummyTricks]` or an `[OptimumResultTable]` — so `tricks()`, `dds()` and `par()` are lookups rather than hundred-millisecond searches, which is what made them affordable in the browser. What is left is the other direction: writing a table back out, as a PBN tag and as ZRD records, so a run's deals can be saved solved. bridge-craftwork/Dealer3#64 chooses which encoding a PBN export writes. The format work is bridge-encodings#20. |
 | 🔵 Unlikely | The length-bias form of `predeal`, `spades(north) == 5` — which the original ignores | Medium | Low |  | **The original accepts it and does nothing with it.** `predealarg : SUIT '(' COMPASS ')' CMPEQ NUMBER` in `defs.y` calls `bias_deal`, which writes `biasdeal[compass][suit]` — and nothing ever reads that array; `dealer.c` contains its declaration and no other mention. Measured rather than inferred: `predeal spades(north) == 5` over 200 deals gives North an average of 3.285 spades, the natural 3.25, on the macOS build and on the Windows one BBO's lineage comes from. So there is no behaviour to be compatible with. dealer3 rejects it loudly, which is the better of the two; implementing it would make dealer3 differ from the original rather than match it. |
 | 🔵 Unlikely | `--bbo-strict`: warn when a script will behave differently on BBO | Medium | Low | [#13](https://github.com/bridge-craftwork/Dealer3/issues/13) | Rick judged it unlikely to bite. |
 | 🔵 Unlikely | `bktfreq`: frequency in buckets, one and two dimensional | Medium | Low |  | Adjacent to the two-dimensional `frequency` below but not the same thing: that one is the original's, this one groups a range into buckets. |

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -23,6 +23,7 @@ dealer-core = { path = "../dealer-core" }
 dealer-parser = { path = "../dealer-parser" }
 dealer-eval = { path = "../dealer-eval" }
 dealer-pbn = { path = "../dealer-pbn" }
+bridge-types = { git = "https://github.com/bridge-craftwork/bridge-types" }
 dealer-level = { path = "../dealer-level" }
 dealer-run = { path = "../dealer-run" }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -28,7 +28,9 @@ mod library;
 use dealer_core::{Deal, FastDealConfig, Position};
 use dealer_parser::vocabulary;
 use dealer_parser::{Statement, VulnerabilityType};
-use dealer_pbn::{format_oneline, format_printall, format_printpbn, DdTags, PbnBoard, Vulnerability};
+use dealer_pbn::{
+    format_oneline, format_printall, format_printpbn, DdTags, PbnBoard, Vulnerability,
+};
 use dealer_run::{Deals, LevelingOptions, Phase, Produced, RunHost, RunOptions};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -28,7 +28,7 @@ mod library;
 use dealer_core::{Deal, FastDealConfig, Position};
 use dealer_parser::vocabulary;
 use dealer_parser::{Statement, VulnerabilityType};
-use dealer_pbn::{format_oneline, format_printall, format_printpbn, PbnBoard, Vulnerability};
+use dealer_pbn::{format_oneline, format_printall, format_printpbn, DdTags, PbnBoard, Vulnerability};
 use dealer_run::{Deals, LevelingOptions, Phase, Produced, RunHost, RunOptions};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -96,6 +96,7 @@ impl Format {
         index: usize,
         ctx: &OutputContext,
         hand_type: Option<&str>,
+        table: Option<&bridge_types::DdTable>,
     ) -> String {
         match self {
             Format::OneLine => format_oneline(deal).trim_end().to_string(),
@@ -112,6 +113,11 @@ impl Format {
                     vulnerability: ctx.vulnerability,
                     seed: Some(ctx.seed),
                     hand_type,
+                    // A deal from the pre-solved library arrives with all
+                    // twenty cells, so a set saved from the page carries its
+                    // analysis the way one saved from the command line does.
+                    dd_table: table,
+                    dd_tags: ctx.dd_tags,
                     ..Default::default()
                 },
             ),
@@ -379,6 +385,8 @@ struct OutputContext {
     dealer: Option<Position>,
     vulnerability: Option<Vulnerability>,
     seed: u32,
+    /// Which double-dummy tags a PBN board carries, when it has a table at all.
+    dd_tags: DdTags,
 }
 
 /// Wall-clock milliseconds. `std::time::SystemTime::now()` panics on
@@ -482,7 +490,12 @@ struct Page<'a> {
     /// Deals to hand back, capped: a large `produce` used to gather statistics
     /// does not have to ship every deal to JS. Left empty altogether under
     /// `Format::None`, which is the whole point of that format.
-    held: Vec<(Option<usize>, Deal)>,
+    ///
+    /// The double-dummy table travels with each one. It is twenty bytes and
+    /// `Copy`, and a deal from the pre-solved library always has one — so a
+    /// PBN saved from the page can carry the analysis it was dealt with
+    /// instead of quietly dropping it.
+    held: Vec<(Option<usize>, Deal, Option<bridge_types::DdTable>)>,
     /// Whether the chosen format has any use for a deal. False only under
     /// `Format::None`, and then nothing is cloned, rendered or shipped.
     collects_deals: bool,
@@ -610,7 +623,8 @@ impl RunHost for Page<'_> {
         // The deal itself, which `Format::None` has no use for: no clone here,
         // no render after the run, and nothing to serialise across to the page.
         if self.collects_deals {
-            self.held.push((deal.hand_type, deal.deal.clone()));
+            self.held
+                .push((deal.hand_type, deal.deal.clone(), deal.dd_table()));
         }
         Ok(())
     }
@@ -683,6 +697,14 @@ struct RunSettings {
     /// Absent means [`MEASURE_BUDGET_MS`], as it did when this was an argument.
     #[serde(default)]
     measure_seconds: Option<f64>,
+    /// Which double-dummy tags a PBN export carries: `none`, `optimum`,
+    /// `tricks` or `both`. Absent means `optimum`, which is what `--dd-tags`
+    /// defaults to — so the page and the command line write the same file.
+    ///
+    /// Only ever fills a tag from what is already known. Nothing is solved for
+    /// it, so ticking the box cannot turn a fast run into a slow one.
+    #[serde(default)]
+    dd_tags: Option<String>,
 }
 
 /// Run a script, described by an envelope, and return the report as JSON.
@@ -771,6 +793,14 @@ fn run_envelope(
         None => DealSource::Shuffled,
     };
 
+    // Refused by name rather than quietly defaulted: a page asking for a
+    // spelling this build does not know should hear about it, exactly as a
+    // misspelled setting does.
+    let dd_tags = match s.dd_tags.as_deref() {
+        Some(value) => value.parse::<DdTags>()?,
+        None => DdTags::default(),
+    };
+
     run_script(
         &envelope.script,
         s.seed,
@@ -781,6 +811,7 @@ fn run_envelope(
         s.round_robin,
         &s.params,
         s.measure_seconds,
+        dd_tags,
         on_progress,
         source,
     )
@@ -804,6 +835,7 @@ fn run_script(
     round_robin: bool,
     params: &[String],
     measure_seconds: Option<f64>,
+    dd_tags: DdTags,
     on_progress: Option<js_sys::Function>,
     source: DealSource,
 ) -> Result<String, String> {
@@ -845,6 +877,7 @@ fn run_script(
         dealer: None,
         vulnerability: None,
         seed,
+        dd_tags,
     };
     let mut predeal = FastDealConfig::new();
     for statement in &program.statements {
@@ -1003,7 +1036,7 @@ fn run_script(
     let labels: Vec<String> = report.hand_types.iter().map(|(n, _)| n.clone()).collect();
     let order: Vec<usize> = if report.leveling.is_some() && !labels.is_empty() {
         let mut buckets: Vec<(Option<String>, Vec<usize>)> = Vec::new();
-        for (index, (matched, _)) in page.held.iter().enumerate() {
+        for (index, (matched, _, _)) in page.held.iter().enumerate() {
             let label = matched.map(|i| labels[i].clone());
             match buckets.iter_mut().find(|(name, _)| *name == label) {
                 Some((_, deals)) => deals.push(index),
@@ -1018,9 +1051,9 @@ fn run_script(
     let mut deals = Vec::with_capacity(order.len());
     let mut deal_types = Vec::with_capacity(order.len());
     for (position, index) in order.into_iter().enumerate() {
-        let (matched, deal) = &page.held[index];
+        let (matched, deal, table) = &page.held[index];
         let label = matched.map(|i| labels[i].as_str());
-        deals.push(format.render(deal, position, &output, label));
+        deals.push(format.render(deal, position, &output, label, table.as_ref()));
         deal_types.push(label.map(str::to_string));
     }
 
@@ -1854,6 +1887,7 @@ mod tests {
             false,
             &[],
             None,
+            DdTags::default(),
             None,
             DealSource::Supplied {
                 deals: supplied,
@@ -2049,6 +2083,7 @@ mod tests {
             false,
             &[],
             None,
+            DdTags::default(),
             None,
             DealSource::Shuffled,
         )

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -263,6 +263,17 @@
               <option value="none">None — statistics only</option>
             </select>
           </label>
+          <!-- Only beside PBN, because that is the only format with anywhere to
+               put a table: one line for the tag, or twenty-two for the section
+               PBN 2.1 specifies. Filled from what a deal already knows and
+               never solved for, so this changes what the file holds and never
+               how long the run takes — which is why it is a plain checkbox and
+               not a warning about cost. -->
+          <label v-if="format === 'pbn'" class="check" :title="ddTagsHint">
+            <input v-model="ddTables" type="checkbox" />
+            Double-dummy tables
+          </label>
+
           <!-- Divides Produce among the hand types instead of taking deals as
                they come. It answers the same question as Auto-level below —
                what mix comes out — and only one of them can, which is why the
@@ -452,6 +463,30 @@ const roundRobin = ref(restored?.roundRobin ?? false)
 // truncated run is a worse outcome than a second of waiting.
 const maxGenerate = ref(restored?.maxGenerate ?? 1000000)
 const format = ref(restored?.format || 'oneline')
+
+// Whether a PBN export carries the double-dummy tables its deals arrived with.
+//
+// A boolean here and one of the engine's four words on the wire: the page
+// offers the standard `[OptimumResultTable]` or nothing at all, where the
+// command line can also ask for the Bridge Composer extension. Two controls for
+// an encoding almost nobody chooses between would be two controls to explain.
+//
+// On by default, matching `--dd-tags`: a deal drawn from the pre-solved library
+// knows all twenty cells, and dropping them on the way out would throw away the
+// whole reason for reading from it.
+const ddTables = ref((restored?.ddTags ?? 'optimum') !== 'none')
+const ddTags = computed(() => (ddTables.value ? 'optimum' : 'none'))
+
+const ddTagsHint = computed(() =>
+  ddTables.value
+    ? 'Each deal that already knows its double-dummy table writes it into the file, as the ' +
+      '[OptimumResultTable] section PBN 2.1 specifies. Deals from the pre-solved library all ' +
+      'know theirs; a shuffled deal only knows what the script asked about. Nothing is solved ' +
+      'to fill one in.'
+    : 'No analysis tags, even for deals that know their table. Worth it for a large set nobody ' +
+      'will read the analysis in: the table is twenty-two lines a board, where a whole board is ' +
+      'a few hundred bytes.',
+)
 
 // Where the deals come from: 'random' shuffles them here, as this page always
 // has; 'library' draws them from the published solved-deal library, where every
@@ -802,6 +837,7 @@ watch(
     roundRobin,
     maxGenerate,
     format,
+    ddTables,
     dealSource,
     selectedFile,
     pickerOpen,
@@ -821,6 +857,7 @@ watch(
         roundRobin: roundRobin.value,
         maxGenerate: maxGenerate.value,
         format: format.value,
+        ddTags: ddTags.value,
         dealSource: dealSource.value,
         scenario: selectedFile.value,
         pickerOpen: pickerOpen.value,
@@ -887,6 +924,7 @@ async function onDownload(kind) {
         roundRobin: roundRobinAsked.value,
         maxGenerate: maxGenerate.value,
         format: 'pbn',
+        ddTags: ddTags.value,
         params: paramSpecs.value,
         // Saving re-runs the script, so it has to read from the same place the
         // run on screen did — otherwise the file would hold different deals
@@ -975,6 +1013,7 @@ function currentState() {
     produce: produce.value,
     maxGenerate: maxGenerate.value,
     format: format.value,
+    ddTables: ddTables.value,
     roundRobin: roundRobin.value,
     dealSource: dealSource.value,
     scenario: selectedFile.value,
@@ -1002,6 +1041,7 @@ async function onShare() {
     format: format.value,
     autoLevel: autoLevel.value && hasHandTypes.value,
     roundRobin: roundRobinAsked.value,
+    ddTags: ddTags.value,
     // What the run would send, rather than what has been typed: a value for a
     // parameter the script does not use would not change the run, and should
     // not change the link either.
@@ -1073,6 +1113,7 @@ function applySharedDocument({ source, doc }) {
   produce.value = s.produce
   maxGenerate.value = s.maxGenerate
   format.value = s.format
+  ddTables.value = s.ddTags !== 'none'
   roundRobin.value = s.roundRobin
   dealSource.value = s.dealSource
   newSeedEachRun.value = s.newSeedEachRun
@@ -1119,6 +1160,7 @@ function restorePrevious() {
   produce.value = was.produce
   maxGenerate.value = was.maxGenerate
   format.value = was.format
+  ddTables.value = was.ddTables
   roundRobin.value = was.roundRobin
   dealSource.value = was.dealSource
   selectedFile.value = was.scenario || ''
@@ -1181,6 +1223,7 @@ async function run() {
       roundRobin: roundRobinAsked.value,
       maxGenerate: maxGenerate.value,
       format: format.value,
+      ddTags: ddTags.value,
       params: paramSpecs.value,
       autoLevel: !onLeveled && autoLevel.value && hasHandTypes.value,
       // Left out while the field is still empty, so the engine's own default

--- a/web/src/lib/engine.js
+++ b/web/src/lib/engine.js
@@ -12,6 +12,7 @@ import init, {
   measure_budget_seconds as wasmMeasureBudgetSeconds,
   version as wasmVersion,
 } from '@/wasm/dealer3_wasm.js'
+import { DD_TAGS_DEFAULT } from './envelope.js'
 
 let loading = null
 let loaded = false
@@ -119,6 +120,11 @@ function runInWorker(script, options) {
         format: options.format,
         autoLevel: options.autoLevel,
         roundRobin: options.roundRobin,
+        // Which double-dummy tags a PBN export carries. Filled only from what
+        // a deal already knows — a deal from the pre-solved library knows all
+        // twenty cells — so this changes what a file holds and never how long
+        // a run takes.
+        ddTags: options.ddTags,
         // Seconds to spend characterizing, which is a limit on the pass the
         // reader did not ask for. Deliberately not `maxGenerate`: that bounds
         // the run they did ask for, and one number cannot be set for both.
@@ -227,6 +233,12 @@ export async function generate(
     /// budget for the run that was asked for, and used to cut the measuring
     /// short with seconds of the clock still unspent.
     measureSeconds = undefined,
+    /// Which double-dummy tags a PBN export carries: `optimum` for the
+    /// `[OptimumResultTable]` section PBN 2.1 specifies, or `none`. Filled from
+    /// what a deal already knows — a deal from the pre-solved library knows all
+    /// twenty cells — and never solved for, so this changes what the file holds
+    /// and never how long the run takes.
+    ddTags = DD_TAGS_DEFAULT,
     /// What to put where `$0`-`$9` stand, in `--param`'s own `N=TEXT` spelling.
     /// A parameter left out here falls back to the script's own `# param`
     /// default, and fails the run if it has none.
@@ -254,6 +266,7 @@ export async function generate(
     autoLevel,
     roundRobin,
     measureSeconds,
+    ddTags,
     source,
     params,
     onProgress,

--- a/web/src/lib/envelope.js
+++ b/web/src/lib/envelope.js
@@ -20,6 +20,15 @@
 /// out of date. The engine refuses a version it does not recognise.
 export const ENVELOPE_VERSION = 1
 
+/// What a PBN export carries when nobody has said.
+///
+/// `optimum` is `[OptimumResultTable]`, the encoding PBN 2.1 specifies, and it
+/// is what `--dd-tags` defaults to on the command line — the page and the
+/// terminal write the same file. `none` is the other value this page offers;
+/// the engine also takes `tricks` and `both`.
+export const DD_TAGS_DEFAULT = 'optimum'
+export const DD_TAGS_OFF = 'none'
+
 /**
  * Describe a run as the JSON string `run_json` takes.
  *
@@ -49,6 +58,10 @@ export function runEnvelope(script, options = {}) {
     autoLevel: !!options.autoLevel,
     roundRobin: !!options.roundRobin,
     params: options.params || [],
+    // Which double-dummy tags a PBN export carries. The engine fills them only
+    // from what a deal already knows and never solves to fill one, so this
+    // changes what a file holds and never how long a run takes.
+    ddTags: options.ddTags || DD_TAGS_DEFAULT,
   }
   // Omitted rather than sent as null: the engine reads an absent field as
   // "use the default budget", and `null` would have to mean the same thing in
@@ -108,6 +121,7 @@ export const DOCUMENT_DEFAULTS = Object.freeze({
   autoLevel: false,
   roundRobin: false,
   params: [],
+  ddTags: DD_TAGS_DEFAULT,
   dealSource: 'random',
   newSeedEachRun: false,
   scenario: '',
@@ -139,6 +153,7 @@ export function makeDocument(script, options = {}) {
     autoLevel: !!options.autoLevel,
     roundRobin: !!options.roundRobin,
     params: options.params || [],
+    ddTags: options.ddTags || DD_TAGS_DEFAULT,
     dealSource: options.dealSource === 'library' ? 'library' : 'random',
     newSeedEachRun: !!options.newSeedEachRun,
   }
@@ -200,6 +215,10 @@ export function readDocument(value) {
     newSeedEachRun: from.newSeedEachRun === true,
     scenario: typeof from.scenario === 'string' ? from.scenario : '',
     params: readParams(from.params),
+    // Only the two the page offers. The engine takes `tricks` and `both` as
+    // well, but a value with no control to show it in would arrive invisible
+    // and change a file nobody could see it changing.
+    ddTags: from.ddTags === DD_TAGS_OFF ? DD_TAGS_OFF : DD_TAGS_DEFAULT,
   }
   // Left out rather than defaulted, both of them. An absent seed means the
   // reader rolls one; an absent budget means the engine's own.

--- a/web/src/lib/envelope.test.js
+++ b/web/src/lib/envelope.test.js
@@ -35,6 +35,7 @@ describe('runEnvelope', () => {
     // was not made there fails the run rather than being ignored.
     expect(Object.keys(parsed('condition 1\n', settings).settings).sort()).toEqual([
       'autoLevel',
+      'ddTags',
       'format',
       'maxGenerate',
       'params',
@@ -83,6 +84,7 @@ describe('a document', () => {
     autoLevel: false,
     roundRobin: false,
     params: [],
+    ddTags: 'optimum',
     dealSource: 'library',
     newSeedEachRun: true,
     scenario: 'Sup_X_By_Advancer',
@@ -104,6 +106,7 @@ describe('a document', () => {
     const envelope = JSON.parse(runEnvelope(doc.script, doc.settings))
     expect(Object.keys(envelope.settings).sort()).toEqual([
       'autoLevel',
+      'ddTags',
       'format',
       'maxGenerate',
       'params',
@@ -226,5 +229,59 @@ describe('the formats a document may name', () => {
       (m) => m[1],
     )
     expect(offered).toEqual(DOCUMENT_FORMATS)
+  })
+})
+
+describe('double-dummy tags', () => {
+  it('default to the encoding PBN specifies, as the command line does', () => {
+    // `--dd-tags` defaults to `optimum` too, so a file saved from the page and
+    // one saved from the terminal hold the same thing.
+    const settings = JSON.parse(runEnvelope('c\n', { seed: 1, produce: 1 })).settings
+    expect(settings.ddTags).toBe('optimum')
+  })
+
+  it('read back only the two values the page can show', () => {
+    // The engine also takes `tricks` and `both`. A link carrying one would
+    // arrive with no control to show it in, and would quietly change what the
+    // recipient's next PBN download held.
+    const read = (ddTags) =>
+      readDocument({ v: 1, script: 'c\n', settings: { ddTags } }).settings.ddTags
+    expect(read('none')).toBe('none')
+    expect(read('optimum')).toBe('optimum')
+    expect(read('both')).toBe('optimum')
+    expect(read(undefined)).toBe('optimum')
+  })
+})
+
+describe('what the page sends and what the engine reads', () => {
+  // The bug this exists for: `generate()` takes its options apart into named
+  // parameters and puts them back together for the worker, so a setting added
+  // to the envelope but not to both of those lists is silently dropped — and
+  // the engine, seeing no field, uses its default. The run works. It just
+  // quietly ignores what was asked for, which is how a ticked box wrote
+  // double-dummy tables into a file that was meant not to have them.
+  const source = readFileSync(new URL('./engine.js', import.meta.url), 'utf8')
+  const accepted = source.slice(
+    source.indexOf('export async function generate('),
+    source.indexOf('const message = await runInWorker('),
+  )
+  const forwarded = source.slice(
+    source.indexOf('const message = await runInWorker('),
+    source.indexOf('const raw = JSON.parse(message.raw)'),
+  )
+
+  const settings = Object.keys(
+    JSON.parse(runEnvelope('condition 1\n', { seed: 1, produce: 1, measureSeconds: 5 })).settings,
+  )
+
+  it('finds both halves of the projection to check', () => {
+    expect(accepted.length).toBeGreaterThan(200)
+    expect(forwarded.length).toBeGreaterThan(50)
+    expect(settings.length).toBeGreaterThan(6)
+  })
+
+  it.each(settings)('generate() accepts and forwards %s', (name) => {
+    expect(accepted).toContain(`${name} =`)
+    expect(forwarded).toContain(name)
   })
 })

--- a/web/src/lib/session.js
+++ b/web/src/lib/session.js
@@ -64,6 +64,10 @@ export function loadSession() {
       // so a first visit takes the engine's own number instead of a copy of it
       // kept here — see `defaultMeasureSeconds`.
       measureSeconds: Number.isFinite(v.measureSeconds) ? v.measureSeconds : undefined,
+      // Whether a PBN export carries the double-dummy tables its deals
+      // arrived with. Stored as the engine's own word rather than a boolean,
+      // since the engine takes four values and the page offers two of them.
+      ddTags: v.ddTags === 'none' ? 'none' : 'optimum',
       // What was typed into the script's parameter fields, by parameter
       // number. Restored with the script, since a parameterised scenario is
       // only half itself without them.

--- a/web/src/lib/session.test.js
+++ b/web/src/lib/session.test.js
@@ -22,6 +22,7 @@ const session = {
   maxGenerate: 100000,
   format: 'printall',
   dealSource: 'library',
+  ddTags: 'optimum',
   scenario: 'Weak_2_Bids',
   pickerOpen: true,
   settingsOpen: false,
@@ -182,5 +183,21 @@ describe('the checkbox settings', () => {
     saveSession(session)
     expect(loadSession().autoLevel).toBeUndefined()
     expect(loadSession().newSeedEachRun).toBeUndefined()
+  })
+})
+
+describe('double-dummy tags', () => {
+  it('reads a session saved before the box existed as writing them', () => {
+    // The box is on by default, so a session from before it must not come back
+    // with the tables switched off: a deal from the pre-solved library knows
+    // all twenty cells, and dropping them is the whole reason for reading it.
+    const { ddTags, ...older } = session
+    localStorage.setItem('dealer3:session:v1', JSON.stringify(older))
+    expect(loadSession().ddTags).toBe('optimum')
+  })
+
+  it('keeps an explicit no', () => {
+    localStorage.setItem('dealer3:session:v1', JSON.stringify({ ...session, ddTags: 'none' }))
+    expect(loadSession().ddTags).toBe('none')
   })
 })


### PR DESCRIPTION
Started as a roadmap correction and grew into the feature it was describing. Four commits, each standing on its own.

## 1. Reading a solved library was already done

The top to-do read *"ZRD: read a solved library, and write one"*, and the generated matrix said *"Read and write RP ZRD"*. Reading shipped some time ago:

- `--input-deals` takes a Pavlicek `.zrd`, PBN or one-line, decided by content, with `--input-offset`
- a deal arrives carrying its own `DdTable`, from a ZRD record, a PBN `[DoubleDummyTricks]` or an `[OptimumResultTable]`
- the table travels **with its deal**, not through a shared store, and `dealer-dds/src/memo.rs` records that the 16,384-deal global memo is retired: *"That is gone. Answers now travel with their deal."*

#61's own scope list had six of eight boxes ticked. It is now closed, with its stale *"dealer3 discards PBN tables today"* corrected, and its two remaining boxes — both about writing — moved to #64.

## 2. `-Z` never existed

The switch table listed `-Z FILE`, "Export in RP zrd format", as DealerV2_4's. It is not:

- option string `hmquvVg:p:s:x:C:D:L:M:O:P:R:T:N:E:S:W:X:U:0:…:9:` — no `Z`, and no `case 'Z'` in the source
- its usage message lists no `Z`
- its V2.5.6 user guide and V2.0 README mention `.zrd` only as the library `-L` **reads**, built by Pavlicek's own `xxdd.exe`

Every occurrence of the claim was dealer3 citing itself — the same shape as the `-l`/"DL52" assertion corrected in 4bfcc56, one row over. The row is deleted, along with its repetitions in two hand-kept documents.

**Writing ZRD is not planned.** Nothing to be compatible with, nothing else in this stack reads it, and a `.zrd` of arbitrary filtered deals loses what makes the format meaningful — Pavlicek's library is addressed by ordinal. Any-to-any conversion belongs in bridge-wrangler. Reading these files is worth a great deal; emitting them is worth about nothing.

## 3. `--dd-tags`, on the command line

```
none      no analysis tags at all
optimum   [OptimumResultTable]   -- PBN 2.1 5.7, the default
tricks    [DoubleDummyTricks]    -- the Bridge Composer extension
both      both, as bridge-solver's CLI writes
```

Only for a deal that already knows all twenty cells. **Nothing is solved to fill a tag** — an output format that decided how long a run takes would be a trap. `DealTricks::table()` already answered exactly that question, and its doc comment already said it was what an exporter wants.

The encoding is bridge-encodings' throughout: `dd_table_to_pbn`, `optimum_result_table_header`, `optimum_result_table_rows`. Header and rows come from one place because the `Result` column's width is data-dependent, and a header declaring one width over rows padded to another is what had Bridge Composer rewriting every single-digit table on open and save.

`--interleave` holds its deals aside until the order is known, so it holds the table with them — twenty bytes and `Copy`, against that one path quietly writing PBN without the analysis every other path writes.

## 4. And in the browser, behind a checkbox

**Double-dummy tables**, beside Format, shown only for PBN. On by default, matching the CLI. The page offers the standard section or nothing; the terminal can also ask for the extension. The spellings moved into `FromStr for DdTags` so the two front ends cannot disagree about what `tricks` means.

### The bug this found

`ddTags` reached the envelope, the session and the share link, every unit test passed — and the file still had tables with the box unticked. `generate()` takes its options apart into named parameters and reassembles them for the worker; a setting missing from either list is dropped in silence, the engine sees no field and uses its default, and the run *works* while ignoring what was asked.

Only visible by ticking the box and reading the bytes the download produced. Now guarded by a test that reads `engine.js` and asserts every setting the envelope sends is both accepted and forwarded — verified by removing the line and watching it go red.

## Verification

- `./dev-build.sh test` — 45 test binaries, no failures
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and the same for `wasm/` — clean
- `npm test` — 296 (was 284), `npm run build:all` — clean
- `UPDATE_DOCS=1 ./dev-build.sh test -p dealer` then the same without it, so the committed tables match what the code generates
- By hand: reading the fixture library and writing PBN gives a correct `[OptimumResultTable]`, and `tricks(north, notrump)` averages 7.33333 straight from the `.zrd` and 7.33333 back through both encodings
- In Chromium against the built `dist/`: ticked → table, 1030 bytes; unticked → none, 594

Five new CLI tests and eight new JS tests.

## Worth knowing

Two wasm test helpers call `run_script` with **twelve positional arguments** and broke on the new one — the hazard #106 removed from the public boundary, still living in the tests behind it. Fixed here, but it will bite the next person who adds a setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)