### PR TITLE
Stop a panel squeezing the script pane to nothing on a phone (#119)

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1643,6 +1643,35 @@ input.num-seed { --num-digits: 10; }
   .picker-open { height: auto; flex-direction: row; padding: 6px 10px; }
   .picker-open-label { writing-mode: horizontal-tb; }
   .col-results { border-left: 0; border-top: 1px solid var(--line); }
+
+  /* Stacked, the editor column has a fixed share of the height, and opening a
+     panel in it — settings, the share link — used to take every pixel of the
+     deficit out of the script pane. Its root is `height: 100%; min-height: 0`
+     with no flex of its own, so nothing stopped it at zero: the reader saw the
+     Run row, the panel, and the status strip with no script between them, and
+     the column's overflow was painted over the results below (#119).
+
+     Two rules, and they need each other. The column scrolls, so what does not
+     fit is scrolled to rather than drawn over the next row. And the panes have
+     a floor, so shrinking stops somewhere that still shows a few lines — a
+     scroll container alone was tried first, and the pane collapsed inside it
+     just the same, since `height: 100%` resolves against the scroller's own
+     height and flex still shrinks it to fit.
+
+     The floor is chosen against what the pane gets with nothing open, measured
+     at 390x844 before this change: 152px plain, 82px on the page a shared link
+     lands on (the notice above it), 78px with the Pre-solved warning showing.
+     4rem is 64px — the status strip and about two lines of script — which sits
+     below all three with room to spare. It first went in at 5rem, 80px, which
+     cleared the link's page by two pixels and fell inside the 78: every one of
+     those states would then have scrolled that did not before, and a real
+     phone's font metrics are not a desktop's at phone width. So none of them
+     move; only a panel pushing past the floor starts the column scrolling.
+     Both panes, because the Leveled tab's viewer is built the same way and
+     collapses the same way. */
+  .col-editor { overflow-y: auto; }
+  .col-editor > .editor,
+  .col-editor > .viewer-wrap { min-height: 4rem; }
 }
 
 /* A phone is where someone reads a run, not where they write one — the script


### PR DESCRIPTION
Closes #119.

On a phone, opening settings or the share link used to squeeze the script pane to **0px**, and the column's overflow was painted over the results below. The settings panel did this on `main` before the share panel existed; #118 added a second way in.

## The fix

Two CSS rules, only at stacked widths (≤1000px). They need each other:

- **The column scrolls**, so what doesn't fit is scrolled to instead of being drawn over the next row.
- **Both panes get a floor** (`min-height: 4rem`), so shrinking stops before the pane disappears. A scroll container alone was tried first, as #119 records, and the pane collapsed inside it anyway: `height: 100%` resolves against the scroller's own height, and flex still shrinks it to fit.

The floor covers the script pane and the Leveled tab's viewer, which is built the same way and collapsed the same way. Desktop is untouched.

## Why 4rem and not 5rem

The floor has to sit below what the pane gets with **nothing** open, or states that are fine today would start scrolling. Measured before the change: 152px plain, 82px on the page a shared link lands on, and 78px with the Pre-solved warning showing. 5rem is 80px, which clears the link's page by two pixels and falls inside the 78. 4rem (64px) is below all three with room to spare.

## Before and after

Chromium at 390×844, against the built `dist/`:

| State | Before | After |
|---|---|---|
| Link landing, notice | 82px, no scroll | 82px, no scroll |
| Plain | 152px, no scroll | 152px, no scroll |
| Pre-solved warning | 78px, no scroll | 78px, no scroll |
| Settings open | **0px**, painted over results | **64px**, column scrolls |
| Share open | **0px**, painted over results | **64px**, column scrolls |
| Both open | **0px**, painted over results | **64px**, column scrolls |
| Leveled tab, settings open | collapsed | **64px**, column scrolls |

The page stays 390px wide in every state.

## What this doesn't do

With a panel open, **the script isn't visible without scrolling.** At 203px the Run row and the settings panel fill the column, so the pane sits just below them, one scroll away. Something has to scroll at that height, and keeping the panel you're using on top, with the script under it, seemed the right way round. Before, the script wasn't there at all and the results showed through the panel.

A desktop browser at phone width isn't a phone: iOS inflates text while leaving layout widths alone, which cost two rounds in #116/#117. These numbers establish that the collapse is gone, not exactly how the floor sits on real hardware.

## Verification

- `npm test` passes 296/296, including `css.test.js`: no undefined tokens, and every styled class is worn somewhere.
- `npm run build:all` passes.
- CSS only, so the Rust and wasm gates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)