### PR TITLE
Short links for texting a script: Pages Functions plus KV (#103)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,8 @@ on:
       - 'dealer*/**'
       - 'wasm/**'
       - 'web/**'
+      # The short-link service (#103). Pages deploys these with the site.
+      - 'functions/**'
       - 'Cargo.toml'
       # The levelling guide page inlines this file with `?raw` at build time,
       # so editing the markdown is editing the site. Without this the guide

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ web/public/llms.txt
 
 # Agent worktrees, created inside the repo directory and never part of it.
 .claude/worktrees/
+
+# Local state from `wrangler pages dev`, including its simulated KV
+.wrangler/

--- a/dealer/tests/format_none.rs
+++ b/dealer/tests/format_none.rs
@@ -18,12 +18,18 @@ fn run(script: &str, args: &[&str]) -> (String, String, bool) {
         .stderr(Stdio::piped())
         .spawn()
         .expect("dealer should run");
-    child
+    // A run refused at argument parsing can exit before reading its script, and
+    // the write then meets a closed pipe. That is the refusal the test is after,
+    // not a fault in the harness — and whether it happens is a race, so it
+    // failed on one CI runner in several rather than everywhere.
+    if let Err(e) = child
         .stdin
         .as_mut()
         .expect("stdin")
         .write_all(script.as_bytes())
-        .expect("write");
+    {
+        assert_eq!(e.kind(), std::io::ErrorKind::BrokenPipe, "write: {e}");
+    }
     let out = child.wait_with_output().expect("output");
     (
         String::from_utf8_lossy(&out.stdout).into_owned(),

--- a/functions/30-days/[key].js
+++ b/functions/30-days/[key].js
@@ -1,0 +1,9 @@
+// `GET /30-days/<key>` — the short link people are sent (#103). It hands over
+// to the page, which fetches what the key holds. See `web/src/lib/shortLinks.js`.
+//
+// The directory name is the promise the link makes, and `SHORT_LINK_PATH` in
+// `web/src/lib/shortKey.js` must say the same; a test holds the two together.
+
+import { redirectShortLink } from '../../web/src/lib/shortLinks.js'
+
+export const onRequestGet = ({ params }) => redirectShortLink(params.key)

--- a/functions/api/short/[key].js
+++ b/functions/api/short/[key].js
@@ -1,0 +1,6 @@
+// `GET /api/short/<key>` — what a short link holds (#103). See
+// `web/src/lib/shortLinks.js`.
+
+import { readShortLink } from '../../../web/src/lib/shortLinks.js'
+
+export const onRequestGet = ({ params, env }) => readShortLink(params.key, env.SHORT_LINKS)

--- a/functions/api/short/index.js
+++ b/functions/api/short/index.js
@@ -1,0 +1,6 @@
+// `POST /api/short` — make a short link (#103). The logic, and the reasons for
+// it, are in `web/src/lib/shortLinks.js`; this only hands it the KV binding.
+
+import { createShortLink } from '../../../web/src/lib/shortLinks.js'
+
+export const onRequestPost = ({ request, env }) => createShortLink(request, env.SHORT_LINKS)

--- a/web/README.md
+++ b/web/README.md
@@ -1,7 +1,9 @@
 # dealer3 web
 
 Write and run dealer scripts in the browser. The engine is dealer3 compiled to
-WebAssembly, so nothing — script, deal or keystroke — leaves the machine.
+WebAssembly, so nothing — script, deal or keystroke — leaves the machine. The
+one exception is a short link, which is made only when asked for and says so;
+see [Short links](#short-links).
 
 ## Running it
 
@@ -30,6 +32,8 @@ src/
 │   ├── library.js        the solved-deal library: fetching, caching, wording
 │   ├── envelope.js       the run the engine takes, and the document a link carries
 │   ├── share.js          a document to a URL fragment and back
+│   ├── shortKey.js       what a short link's key looks like, for both ends
+│   ├── shortLinks.js     the short-link service, behind ../functions/
 │   ├── clipboard.js      copying text, with the fallback the platforms need
 │   └── download.js       saving results as PBN or text
 ├── Reference.vue         the language reference page
@@ -160,7 +164,7 @@ Three forms, cheapest first, all of which open the same way:
 |---|---|
 | `#s=<scenario>` | a scenario from the list, unmodified, plus what was changed |
 | `#d=<base64url>` | the document itself, deflated — no network at all |
-| `#k=<key>` | the short-link service (#103), which is not built |
+| `#k=<key>` | a short link's key, fetched from the service below (#103) |
 
 Sharing an untouched scenario needs no encoding at all: the recipient's page
 fetches the same script from the same list, so the link is
@@ -171,8 +175,46 @@ link. That form is `JSON.stringify` → `CompressionStream('deflate-raw')` →
 base64url, native in Safari 16.4, Chrome and Firefox, so no library: 600–900
 bytes of script comes out around 350–550 characters.
 
-`#k=` is recognised and refused with a sentence, rather than opening a page that
-looks as though there was no link. Nothing produces one yet.
+### Short links
+
+A `#d=` link is fine in an email and too long for a text message. For that one
+case the share panel offers **Short link**, which stores the script and gives
+back `bridge-craftwork.com/dealer3/30-days/AB3K9M2P`. It is the only part of the
+page with a back end: Pages Functions in the repo's `functions/`, thin wrappers
+around `lib/shortLinks.js`, holding links in a KV namespace bound in
+`wrangler.jsonc`.
+
+- **What is stored is the long link.** The value under a key is the `#d=`
+  payload, so a short link is an alias for a long one and opens by the same
+  `decodeDocument` and `readDocument`. The service runs both on the way in and
+  refuses what a page could not open. It does not run the parser: someone
+  asking for help with a script that will not parse is a good reason to send
+  one.
+- **Thirty days, fixed, and the link says so.** `expirationTtl` on the put, so
+  Cloudflare deletes it. Not refreshed on read — a sliding expiry would be
+  invisible to the person holding the link, and every refresh would spend a
+  write. Fixed means the page can name the day: the share panel does, and so
+  does the notice a recipient sees on opening one.
+- **Offered, never automatic.** Every short link spends one of the free tier's
+  daily writes, so the button appears only when the long link is over 100
+  characters, and a plain Share still uploads nothing.
+- **Keys** are eight characters of Crockford base32, read leniently (case, `O`
+  for zero, `I` and `L` for one), so a phone's autocorrect does not break one.
+- **Abuse control** is an 8 KB cap on the compressed body, the document having
+  to open, the `Origin` header, and the daily write allowance, which fails
+  closed: a flood costs short links for the rest of the day and nothing else.
+  There is no per-IP limit, because Pages Functions cannot take the rate-limit
+  binding and a KV counter would spend a write per share. A zone rate-limiting
+  rule is where one would go.
+
+`/30-days/<key>` redirects to `/?k=<key>` rather than `/#k=<key>`, because the
+apex proxy does not carry a fragment through a redirect. The page moves the key
+into the fragment on arrival, so there is still one place links are read from.
+
+To run the Functions locally, build the site and then, from the repo root:
+`npx wrangler pages dev --kv SHORT_LINKS`. `pages dev` does not pick the
+binding up from `wrangler.jsonc`, so without `--kv` every short link is refused
+as not set up.
 
 ### What a link carries, and what it does not
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -188,6 +188,23 @@
             :value="shareLink"
             @focus="$event.target.select()"
           />
+          <!-- Offered rather than made: every short link spends one of the
+               day's few writes, and most links are sent where length does
+               not matter. Only when the long one is long enough to be a
+               problem in a text message. -->
+          <button
+            v-if="shareShortOffered"
+            class="shared-restore"
+            :disabled="shareShortPending"
+            :title="`A link short enough to text. It stops working after ${SHORT_LINK_DAYS} days.`"
+            @click="onShareShort"
+          >{{ shareShortPending ? 'Making\u2026' : 'Short link' }}</button>
+          <button
+            v-else-if="shareLong && shareLink !== shareLong"
+            class="shared-dismiss"
+            title="The link that carries the script itself, and never expires"
+            @click="showLongLink"
+          >Long link</button>
           <button class="shared-dismiss" @click="shareLink = ''">Done</button>
           <p class="share-note settings-note">{{ shareNote }}</p>
         </div>
@@ -424,7 +441,17 @@ import { downloadText, resultFilename, statisticsText } from '@/lib/download.js'
 import { loadSession, saveSession } from '@/lib/session.js'
 import { randomSeed } from '@/lib/format.js'
 import { makeDocument, paramValuesFrom } from '@/lib/envelope.js'
-import { parseFragment, resolveFragment, shareFragment, shareUrl } from '@/lib/share.js'
+import {
+  fetchShortLink,
+  parseFragment,
+  requestShortLink,
+  resolveFragment,
+  shareFragment,
+  shareUrl,
+  shortKeyFromQuery,
+  shortLinkUrl,
+} from '@/lib/share.js'
+import { SHORT_LINK_DAYS } from '@/lib/shortKey.js'
 import { copyText } from '@/lib/clipboard.js'
 
 const STARTER = `# Write a dealer script, or pick a scenario on the left.
@@ -808,6 +835,10 @@ watch(leveledScript, (text) => {
 })
 
 onMounted(async () => {
+  // A short link arrives as `?k=<key>` (see `redirectShortLink`). Moved into the
+  // fragment, where every other link is read from and where a reload finds it,
+  // and out of the query, which is otherwise sent with every request.
+  adoptShortKey()
   // First, and not awaited with the rest: a shared script should be on screen
   // while the engine is still loading, exactly as a restored one is.
   openSharedLink()
@@ -980,8 +1011,9 @@ function onPrint() {
 //
 // A link carries the script and the settings in its fragment, so it reaches no
 // server: there is nothing to store, nothing to expire, and nothing logged.
-// `share.js` holds the encoding and the three forms; here is only what the page
-// does with them.
+// The one exception is a short link, made only when asked for, which stores the
+// long link's payload for thirty days (#103). `share.js` holds the encoding and
+// the forms; here is only what the page does with them.
 
 /// The script as the scenario list served it. Share compares against this to
 /// decide whether the script itself has to travel.
@@ -989,6 +1021,19 @@ const pristine = ref({ file: '', text: '' })
 
 /// The link most recently made, shown until it is dismissed.
 const shareLink = ref('')
+/// The long form of it, and the document it holds, kept so a short link can be
+/// made from the same thing and the long one offered back.
+const shareLong = ref('')
+const shareDoc = ref(null)
+const shareShortPending = ref(false)
+/// What the long link's note said, to say again if it is shown again.
+const shareLongNote = ref('')
+/// Past this, a link is a nuisance in a text message and a short one is worth
+/// a write. A scenario's `#s=` link is usually well under it.
+const SHORT_LINK_WORTH = 100
+const shareShortOffered = computed(
+  () => !!shareDoc.value && shareLink.value === shareLong.value && shareLong.value.length > SHORT_LINK_WORTH,
+)
 const shareNote = ref('')
 const shareField = ref(null)
 
@@ -1064,20 +1109,82 @@ async function onShare() {
     shareError.value = e?.message || String(e)
     return
   }
-  shareLink.value = shareUrl(window.location, fragment)
+  shareDoc.value = doc
+  shareLong.value = shareUrl(window.location, fragment)
+  shareLink.value = shareLong.value
   const copied = await copyText(shareLink.value)
   // Short, because the panel it sits in is squeezed on a phone \u2014 which is
   // where a link is most likely to be read.
+  shareLongNote.value = fragment.startsWith('#s=')
+    ? 'It names the scenario and your settings; the script comes from the same list.'
+    : `The whole script is in the link \u2014 ${shareLink.value.length} characters, and ` +
+      'nothing is uploaded.'
   shareNote.value =
-    (copied ? 'Copied. ' : 'The browser refused to copy \u2014 take it from here. ') +
-    (fragment.startsWith('#s=')
-      ? 'It names the scenario and your settings; the script comes from the same list.'
-      : `The whole script is in the link \u2014 ${shareLink.value.length} characters, and ` +
-        'nothing is uploaded.')
-  // Selected, so it can be taken by hand on the platforms where a copy is
-  // refused, which are the platforms this matters on.
+    (copied ? 'Copied. ' : 'The browser refused to copy \u2014 take it from here. ') + shareLongNote.value
+  await selectShareField()
+}
+
+/// A short link for the document just shared. This one IS uploaded, and says so.
+async function onShareShort() {
+  if (!shareDoc.value || shareShortPending.value) return
+  shareShortPending.value = true
+  shareError.value = ''
+  try {
+    const { key, expires } = await requestShortLink(shareDoc.value, { base: window.location.href })
+    shareLink.value = shortLinkUrl(window.location, key)
+    const copied = await copyText(shareLink.value)
+    shareNote.value =
+      (copied ? 'Copied. ' : 'The browser refused to copy \u2014 take it from here. ') +
+      `Short enough to text. The script is stored for it, and the link stops working ` +
+      `${expires ? `on ${formatDay(expires)}` : `after ${SHORT_LINK_DAYS} days`}; the long link never does.`
+    await selectShareField()
+  } catch (e) {
+    shareNote.value = e?.message || String(e)
+  } finally {
+    shareShortPending.value = false
+  }
+}
+
+async function showLongLink() {
+  shareLink.value = shareLong.value
+  const copied = await copyText(shareLink.value)
+  shareNote.value =
+    (copied ? 'Copied. ' : 'The browser refused to copy \u2014 take it from here. ') + shareLongNote.value
+  await selectShareField()
+}
+
+/// Selected, so it can be taken by hand on the platforms where a copy is
+/// refused, which are the platforms this matters on.
+async function selectShareField() {
   await nextTick()
   shareField.value?.select?.()
+}
+
+/// "10 October 2026", in the reader's own words for it.
+function formatDay(iso) {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return date.toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' })
+}
+
+/// `?k=<key>` becomes `#k=<key>`, without navigating.
+function adoptShortKey() {
+  const key = shortKeyFromQuery(window.location.search)
+  if (!key) return
+  const query = new URLSearchParams(window.location.search)
+  query.delete('k')
+  const rest = query.toString()
+  try {
+    window.history.replaceState(
+      null,
+      '',
+      `${window.location.pathname}${rest ? `?${rest}` : ''}#k=${encodeURIComponent(key)}`,
+    )
+  } catch {
+    // Some embeddings refuse it. Setting the hash instead would fire
+    // `hashchange` and open the link a second time, over the first — and the
+    // second opening would find nothing displaced, so the way back would go.
+  }
 }
 
 /// Open whatever the fragment names, and stop. Nothing runs: an unknown script
@@ -1091,6 +1198,7 @@ async function openSharedLink() {
   try {
     const opened = await resolveFragment(window.location.hash, {
       fetchScenario: fetchScenarioScript,
+      fetchShort: (key) => fetchShortLink(key, { base: window.location.href }),
     })
     if (opened) applySharedDocument(opened)
   } catch (e) {
@@ -1098,7 +1206,7 @@ async function openSharedLink() {
   }
 }
 
-function applySharedDocument({ source, doc }) {
+function applySharedDocument({ source, doc, expires }) {
   const s = doc.settings
   // Only worth keeping when there is something to lose. This is the only way
   // back to it: the page has not navigated, so the back button would leave the
@@ -1140,6 +1248,14 @@ function applySharedDocument({ source, doc }) {
   // That nothing has run is the part worth saying: it is the difference between
   // this and every other link, and the reason the page looks idle.
   sharedNotice.value = `Opened a shared script${named}. Nothing has run yet.`
+  // A short link is the one kind that stops working, and the person holding one
+  // is about to bookmark it. The editor keeps the script whatever happens to
+  // the link; Share makes one that lasts.
+  if (source === 'short') {
+    sharedNotice.value +=
+      ` This short link stops working ${expires ? `on ${formatDay(expires)}` : `${SHORT_LINK_DAYS} days after it was made`}` +
+      ' \u2014 to keep a link to it, press Share for one that never expires.'
+  }
 }
 
 /// Put back what the link replaced.

--- a/web/src/lib/share.js
+++ b/web/src/lib/share.js
@@ -17,7 +17,7 @@
 //
 //   #s=<scenario>   a scenario from the list, unmodified, plus what was changed
 //   #d=<base64url>  the document itself, deflated — no network at all
-//   #k=<key>        fetched from the short-link service (#103, not built)
+//   #k=<key>        fetched from the short-link service (#103), `shortLinks.js`
 //
 // All three resolve to the same document, so opening one is one path with
 // three sources rather than three features.
@@ -35,6 +35,7 @@
 // email and still strictly better than sending a PDF nobody can run.
 
 import { DOCUMENT_VERSION, readDocument, settingsDelta } from './envelope.js'
+import { EXPIRED, SHORT_LINK_PATH, normalizeKey } from './shortKey.js'
 
 /// Longer than this and it is not a link anyone made from this page: the whole
 /// point of the `#s=` form is that the big ones are rare. Refusing early keeps
@@ -70,7 +71,9 @@ export function parseFragment(hash) {
   const data = query.get('d')
   if (data) return { kind: 'document', data }
   const key = query.get('k')
-  if (key) return { kind: 'key', key }
+  // Normalised here so a key a phone has lower-cased still opens; one that is
+  // not a key at all is still a short link, just a broken one, and is said so.
+  if (key) return { kind: 'key', key: normalizeKey(key) ?? key }
   return null
 }
 
@@ -81,23 +84,26 @@ export function parseFragment(hash) {
  * without a network, and so the one caller that needs a scenario is the one
  * that supplies the way to get it.
  *
+ * `fetchShort` likewise: it answers `{d, expires}` for a key, the `d` being
+ * exactly what a long link would carry — so a short link opens by the same path
+ * as a `#d=` one, and differs only in knowing when it stops working.
+ *
  * @param {string} hash `location.hash`
- * @param {{fetchScenario: (slug: string) => Promise<string>}} sources
- * @returns {Promise<{source: string, doc: object}|null>}
+ * @param {{fetchScenario?: (slug: string) => Promise<string>,
+ *          fetchShort?: (key: string) => Promise<{d: string, expires: string|null}>}} sources
+ * @returns {Promise<{source: string, doc: object, expires?: string|null}|null>}
  * @throws {Error} with a message meant to be shown
  */
-export async function resolveFragment(hash, { fetchScenario } = {}) {
+export async function resolveFragment(hash, { fetchScenario, fetchShort } = {}) {
   const found = parseFragment(hash)
   if (!found) return null
 
   if (found.kind === 'key') {
-    // Recognised rather than ignored. Nothing produces these yet — the service
-    // behind them is #103 — but a link that arrives from one deserves better
-    // than a page that opens as though there had been no link.
-    throw new Error(
-      'This is a short link, and short links are not available yet. Ask whoever sent it ' +
-        'for the long form — it opens the same script.',
-    )
+    if (typeof fetchShort !== 'function') {
+      throw new Error('This is a short link, and there is no way to open one here.')
+    }
+    const { d, expires = null } = await fetchShort(found.key)
+    return { source: 'short', doc: readDocument(await decodeDocument(d)), expires }
   }
 
   if (found.kind === 'document') {
@@ -153,6 +159,95 @@ export function scenarioFragment(doc) {
     }
   }
   return `#${query.toString()}`
+}
+
+// --- Short links (#103) ---------------------------------------------------
+//
+// The service is `shortLinks.js`, behind `functions/`. These are the page's
+// half: asking for a key, opening one, and the link a key makes.
+
+/**
+ * The short link for a key: `<this page>/30-days/<key>`.
+ *
+ * Built against the page's own directory, so it is `/dealer3/30-days/…` on the
+ * apex and `/30-days/…` on pages.dev, with nothing hard-coded to either.
+ */
+export function shortLinkUrl(location, key) {
+  return new URL(`${SHORT_LINK_PATH}/${key}`, `${location.origin}${location.pathname}`).href
+}
+
+/**
+ * The key a `?k=` names, if it names one.
+ *
+ * A short link arrives as `/?k=<key>` — see `redirectShortLink` for why a query
+ * and not a fragment — and the page moves it into the fragment on arrival, so
+ * there is still one place a link is read from.
+ */
+export function shortKeyFromQuery(search) {
+  const key = new URLSearchParams(String(search || '')).get('k')
+  return key ? key.slice(0, 32) : null
+}
+
+/// Where the service answers, relative to the page — so `/dealer3/api/short`
+/// through the apex and `/api/short` on pages.dev.
+const SERVICE = 'api/short'
+
+/**
+ * Store a document and get its short link's key.
+ *
+ * @param {object} doc a document, from `makeDocument`
+ * @param {{base: string, fetch?: typeof fetch}} options `base` is the page's URL
+ * @returns {Promise<{key: string, expires: string}>}
+ * @throws {Error} with a message meant to be shown
+ */
+export async function requestShortLink(doc, { base, fetch: get = fetch } = {}) {
+  const payload = await encodeDocument(doc)
+  let response
+  try {
+    response = await get(new URL(SERVICE, base).href, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: payload,
+    })
+  } catch {
+    throw new Error('Could not reach the short-link service. The long link works without it.')
+  }
+  const body = await readJson(response)
+  if (response.ok && body?.key) return { key: body.key, expires: body.expires ?? null }
+  throw new Error(
+    body?.error ||
+      // A static host with no service behind it — a local build, say — answers
+      // 404 or 405 with a page, not with JSON.
+      'Short links are not available from this copy of the page. The long link works without them.',
+  )
+}
+
+/**
+ * What a short link's key holds. Shaped to be passed as `fetchShort`.
+ *
+ * @param {string} key
+ * @param {{base: string, fetch?: typeof fetch}} options
+ * @returns {Promise<{d: string, expires: string|null}>}
+ * @throws {Error} with a message meant to be shown
+ */
+export async function fetchShortLink(key, { base, fetch: get = fetch } = {}) {
+  let response
+  try {
+    response = await get(new URL(`${SERVICE}/${encodeURIComponent(key)}`, base).href)
+  } catch {
+    throw new Error('Could not reach the short-link service to open this link. Try again shortly.')
+  }
+  const body = await readJson(response)
+  if (response.ok && typeof body?.d === 'string') return { d: body.d, expires: body.expires ?? null }
+  throw new Error(response.status === 404 ? body?.error || EXPIRED : body?.error || 'This short link could not be opened.')
+}
+
+async function readJson(response) {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
 }
 
 /** The whole link: this page, wherever it is being served from, plus the fragment. */

--- a/web/src/lib/share.test.js
+++ b/web/src/lib/share.test.js
@@ -190,7 +190,8 @@ describe('a scenario nobody changed', () => {
 })
 
 describe('a link that is not what it claims', () => {
-  it('says a short link cannot be opened yet, rather than opening nothing', async () => {
+  it('says a short link cannot be opened without the service, rather than opening nothing', async () => {
+    // Opening one for real is in shortLinks.test.js, against the service.
     await expect(open('#k=Ab3x9')).rejects.toThrow(/short link/i)
   })
 

--- a/web/src/lib/shortKey.js
+++ b/web/src/lib/shortKey.js
@@ -1,0 +1,55 @@
+// What a short link looks like — the part both ends need.
+//
+// The page reads keys out of links and builds the link from a key; the service
+// in `shortLinks.js` makes the keys. Kept apart from both so neither has to
+// import the other.
+
+/// How long a link lasts. It is in the URL as well — `/30-days/<key>` — so
+/// changing this means changing that path, and the old links' path with it.
+export const SHORT_LINK_DAYS = 30
+
+/// The path segment a short link lives under. It says how long the link lasts
+/// before anybody opens it: someone about to bookmark one is the person who
+/// most needs to know, and a word in the URL reaches them first.
+export const SHORT_LINK_PATH = `${SHORT_LINK_DAYS}-days`
+
+/// Crockford's base32: no I, L, O or U, so nothing a phone's font or a
+/// person's reading of it can confuse.
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+
+/// 32^8, about 10^12. At a thousand links a day a collision is not a real
+/// prospect, and the service reads before it writes anyway.
+export const KEY_LENGTH = 8
+
+/// Said when a key holds nothing. KV cannot tell an expired key from one that
+/// never existed, and nor can this; expiry is the likely one.
+export const EXPIRED =
+  `This short link has expired, or never existed. Short links last ${SHORT_LINK_DAYS} days — ` +
+  'ask whoever sent it for a new one, or for the long link, which never expires.'
+
+/** A fresh key. 256 is a multiple of 32, so masking a byte is unbiased. */
+export function newKey(random = (bytes) => crypto.getRandomValues(bytes)) {
+  const bytes = random(new Uint8Array(KEY_LENGTH))
+  let key = ''
+  for (const byte of bytes) key += ALPHABET[byte & 31]
+  return key
+}
+
+/**
+ * A key as somebody might have typed or received it, made canonical — or null.
+ *
+ * Crockford's decoding rules: case does not matter, `O` is zero, `I` and `L`
+ * are one, and hyphens are ignored. A phone that capitalises the first letter
+ * or a person reading a key aloud should not break a link.
+ *
+ * @param {string} text
+ * @returns {string|null}
+ */
+export function normalizeKey(text) {
+  const key = String(text || '')
+    .toUpperCase()
+    .replace(/-/g, '')
+    .replace(/O/g, '0')
+    .replace(/[IL]/g, '1')
+  return key.length === KEY_LENGTH && [...key].every((c) => ALPHABET.includes(c)) ? key : null
+}

--- a/web/src/lib/shortLinks.js
+++ b/web/src/lib/shortLinks.js
@@ -1,0 +1,191 @@
+// Short links, for sending a script by text message (#103).
+//
+// A `#d=` link carries its own script and needs no server, but it runs to
+// 350-550 characters: fine in an email, too long for a text. This is the one
+// case that needs a service, and this file is that service — the Pages
+// Functions under `functions/` are thin wrappers that hand it their KV binding,
+// so everything here is testable without Cloudflare.
+//
+// ## What is stored is the long link
+//
+// The value under a key is the `#d=` payload, exactly as the long link carries
+// it: the document, deflated and base64url'd. A short link is therefore an
+// alias for a long one and nothing more, opened by the same `decodeDocument`
+// and `readDocument` as every other link — and checked by them on the way in,
+// so the service refuses anything the page could not open. Compressed, the
+// 8 KB cap below holds around 25 KB of script, which covers the largest of
+// the PBS scenarios with room left over.
+//
+// ## Thirty days, fixed
+//
+// `expirationTtl` on the put, so Cloudflare deletes it and there is no cleanup
+// to write. Deliberately NOT refreshed on read: these are meant to be opened
+// within the week they were sent, a sliding expiry would be invisible to the
+// person holding one, and re-putting on every read would spend the free tier's
+// scarce write allowance on reads. Fixed means the page can name the day a link
+// stops working, which is the thing a recipient can actually plan around.
+//
+// ## Abuse control
+//
+// An unauthenticated write endpoint is a pastebin. What bounds it here: the
+// body cap, the document having to open, the `Origin` check, and the free
+// tier's daily write allowance, which fails closed — a flood costs short links
+// for the rest of the day and nothing else, because the long link needs no
+// service. Per-IP limiting is not here: Pages Functions cannot take the
+// rate-limit binding, and a KV counter would spend a write per share on the very
+// allowance it was protecting. A zone rate-limiting rule is the place for it.
+
+import { decodeDocument, encodeDocument } from './share.js'
+import { readDocument } from './envelope.js'
+import { EXPIRED, SHORT_LINK_DAYS, newKey, normalizeKey } from './shortKey.js'
+
+const TTL_SECONDS = SHORT_LINK_DAYS * 24 * 60 * 60
+
+/// The largest body accepted: the `d` payload, which is already compressed.
+export const MAX_BODY_BYTES = 8 * 1024
+
+/// Where a write may come from. The apex, where the page lives, and its own
+/// Pages addresses — production and the per-branch previews — so a preview
+/// deploy can be tried end to end. `wrangler pages dev` serves on localhost.
+const ALLOWED_ORIGINS = [
+  /^https:\/\/bridge-craftwork\.com$/,
+  /^https:\/\/([a-z0-9-]+\.)?dealer3\.pages\.dev$/,
+  /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/,
+]
+
+/** Whether a write from this `Origin` is one this page made. */
+export function originAllowed(origin) {
+  return !!origin && ALLOWED_ORIGINS.some((pattern) => pattern.test(origin))
+}
+
+/**
+ * `POST /api/short` — store a `d` payload, and answer with its key.
+ *
+ * @param {Request} request the body is the `#d=` payload, as text
+ * @param {KVNamespace} kv
+ * @param {{now?: () => number, key?: () => string}} options for tests
+ * @returns {Promise<Response>}
+ */
+export async function createShortLink(request, kv, { now = Date.now, key = newKey } = {}) {
+  if (!originAllowed(request.headers.get('origin'))) {
+    return refuse(403, 'Short links can only be made from the dealer3 page.')
+  }
+
+  // Read with a budget rather than trusting Content-Length, which the client
+  // supplies.
+  const body = await readCapped(request, MAX_BODY_BYTES)
+  if (body == null) {
+    return refuse(
+      413,
+      'This script is too large for a short link. The long link carries it in full, and ' +
+        'never expires.',
+    )
+  }
+
+  // The same two checks a recipient's page makes, so nothing is stored that
+  // could not be opened. Re-encoded from what they return, so what is kept is
+  // the document as this version reads it and not whatever else arrived with it.
+  let payload
+  try {
+    payload = await encodeDocument(readDocument(await decodeDocument(body.trim())))
+  } catch (e) {
+    return refuse(400, e?.message || String(e))
+  }
+
+  // Said apart from the allowance running out, which it would otherwise be
+  // reported as: a deploy that lost its binding looks exactly like a busy day.
+  if (!kv) return refuse(503, 'Short links are not set up on this copy of the page.')
+
+  const expires = new Date(now() + TTL_SECONDS * 1000).toISOString()
+  try {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const candidate = key()
+      if ((await kv.get(candidate)) != null) continue
+      await kv.put(candidate, payload, { expirationTtl: TTL_SECONDS, metadata: { expires } })
+      return json(201, { key: candidate, expires })
+    }
+  } catch (e) {
+    // On the free tier this is the day's write allowance running out, far more
+    // often than it is anything else. Logged, so the dashboard can say which.
+    console.error('short link: KV refused the write', e?.message || e)
+    return refuse(
+      503,
+      'Short links are unavailable just now — most likely used up for today. The long link ' +
+        'works, and never expires.',
+    )
+  }
+  return refuse(503, 'Could not find a free short link. Try again.')
+}
+
+/**
+ * `GET /api/short/<key>` — the `d` payload a key holds, and when it stops.
+ *
+ * @param {string} rawKey as it appeared in the path
+ * @param {KVNamespace} kv
+ * @returns {Promise<Response>}
+ */
+export async function readShortLink(rawKey, kv) {
+  const key = normalizeKey(rawKey)
+  if (!key) return refuse(404, EXPIRED)
+  if (!kv) return refuse(503, 'Short links are not set up on this copy of the page.')
+  const { value, metadata } = await kv.getWithMetadata(key)
+  // KV cannot tell an expired key from one that never existed, and nor can
+  // this. Expiry is the likely one.
+  if (value == null) return refuse(404, EXPIRED)
+  return json(200, { d: value, expires: metadata?.expires ?? null })
+}
+
+/**
+ * `GET /30-days/<key>` — the link people are sent. Hands over to the page.
+ *
+ * To `/?k=<key>` rather than `/#k=<key>`: the apex proxy maps a redirect back
+ * into its own path space and does not carry a fragment through, so a `#k=`
+ * would arrive as a page with no link in it. An eight-character key in a query
+ * string reaches no rule that a script would; the page moves it into the
+ * fragment on arrival, where every other link lives.
+ *
+ * @param {string} rawKey
+ * @returns {Response}
+ */
+export function redirectShortLink(rawKey) {
+  const key = normalizeKey(rawKey) ?? encodeURIComponent(String(rawKey || '').slice(0, 32))
+  return new Response(null, {
+    status: 302,
+    headers: { location: `/?k=${key}`, 'cache-control': 'no-store' },
+  })
+}
+
+async function readCapped(request, limit) {
+  if (!request.body) return ''
+  const reader = request.body.getReader()
+  const chunks = []
+  let total = 0
+  for (;;) {
+    const { value, done } = await reader.read()
+    if (done) break
+    total += value.length
+    if (total > limit) {
+      await reader.cancel()
+      return null
+    }
+    chunks.push(value)
+  }
+  const all = new Uint8Array(total)
+  let at = 0
+  for (const chunk of chunks) {
+    all.set(chunk, at)
+    at += chunk.length
+  }
+  return new TextDecoder().decode(all)
+}
+
+function json(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
+  })
+}
+
+function refuse(status, error) {
+  return json(status, { error })
+}

--- a/web/src/lib/shortLinks.test.js
+++ b/web/src/lib/shortLinks.test.js
@@ -1,0 +1,323 @@
+// Short links (#103), both ends at once.
+//
+// The page's half (`share.js`) is driven against the service's half
+// (`shortLinks.js`) through a `fetch` that routes to the handlers the Pages
+// Functions call, and an in-memory KV that records what was asked of it. So a
+// link is made and opened exactly as it would be, with nothing but Cloudflare
+// itself left out.
+
+import { describe, it, expect } from 'vitest'
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import {
+  createShortLink,
+  readShortLink,
+  redirectShortLink,
+  originAllowed,
+  MAX_BODY_BYTES,
+} from './shortLinks.js'
+import { EXPIRED, KEY_LENGTH, SHORT_LINK_PATH, newKey, normalizeKey } from './shortKey.js'
+import {
+  encodeDocument,
+  fetchShortLink,
+  parseFragment,
+  requestShortLink,
+  resolveFragment,
+  shortKeyFromQuery,
+  shortLinkUrl,
+} from './share.js'
+import { makeDocument } from './envelope.js'
+
+const SCRIPT = `# Somebody wants help with this one
+condition hcp(north) >= 15 && shape(north, any 4333 + any 4432)
+action printoneline
+`
+
+const doc = makeDocument(SCRIPT, {
+  seed: 8391,
+  produce: 20,
+  maxGenerate: 1000000,
+  format: 'oneline',
+  dealSource: 'random',
+})
+
+const ORIGIN = 'https://bridge-craftwork.com'
+const PAGE = `${ORIGIN}/dealer3/`
+const THIRTY_DAYS = 30 * 24 * 60 * 60
+
+/// Workers KV, as far as this service uses it, with a log of every call — the
+/// writes are the scarce allowance, so what is written is worth asserting on.
+function memoryKv({ failPuts = false } = {}) {
+  const store = new Map()
+  const log = []
+  return {
+    store,
+    log,
+    async get(key) {
+      log.push(['get', key])
+      return store.get(key)?.value ?? null
+    },
+    async getWithMetadata(key) {
+      log.push(['getWithMetadata', key])
+      const hit = store.get(key)
+      return { value: hit?.value ?? null, metadata: hit?.metadata ?? null }
+    },
+    async put(key, value, options) {
+      log.push(['put', key, options])
+      if (failPuts) throw new Error('KV put() limit exceeded for the day.')
+      store.set(key, { value, metadata: options?.metadata ?? null })
+    },
+  }
+}
+
+/// The Pages routes, as `fetch` — what `functions/` does, without Pages.
+function service(kv, { origin = ORIGIN, key } = {}) {
+  return async (url, init = {}) => {
+    const { pathname } = new URL(url)
+    const route = pathname.replace(/^\/dealer3/, '')
+    if (route === '/api/short' && init.method === 'POST') {
+      const request = new Request(url, { ...init, headers: { ...init.headers, origin } })
+      return createShortLink(request, kv, key ? { key } : {})
+    }
+    const read = route.match(/^\/api\/short\/([^/]+)$/)
+    if (read) return readShortLink(decodeURIComponent(read[1]), kv)
+    return new Response('<!doctype html>not found', { status: 404 })
+  }
+}
+
+const post = (body, headers = { origin: ORIGIN }) =>
+  new Request(`${PAGE}api/short`, { method: 'POST', headers, body })
+
+describe('a short link, made and opened', () => {
+  it('opens the same script and settings it was made from', async () => {
+    const kv = memoryKv()
+    const fetch = service(kv)
+    const { key } = await requestShortLink(doc, { base: PAGE, fetch })
+    expect(key).toHaveLength(KEY_LENGTH)
+
+    const opened = await resolveFragment(`#k=${key}`, {
+      fetchShort: (k) => fetchShortLink(k, { base: PAGE, fetch }),
+    })
+    expect(opened.source).toBe('short')
+    expect(opened.doc.script).toBe(SCRIPT)
+    expect(opened.doc.settings.seed).toBe(8391)
+  })
+
+  it('stores exactly what a long link would carry', async () => {
+    // The whole design: a short link is an alias for a `#d=` one.
+    const kv = memoryKv()
+    const { key } = await requestShortLink(doc, { base: PAGE, fetch: service(kv) })
+    const stored = kv.store.get(key).value
+    const opened = await resolveFragment(`#d=${stored}`)
+    expect(opened.doc).toEqual((await resolveFragment(`#d=${await encodeDocument(doc)}`)).doc)
+  })
+
+  it('shares a script that does not parse, which may be why it is being sent', async () => {
+    const broken = makeDocument('condition hcp(north >= ', { seed: 1, produce: 1, maxGenerate: 1, format: 'oneline' })
+    const kv = memoryKv()
+    const { key } = await requestShortLink(broken, { base: PAGE, fetch: service(kv) })
+    const opened = await resolveFragment(`#k=${key}`, {
+      fetchShort: (k) => fetchShortLink(k, { base: PAGE, fetch: service(kv) }),
+    })
+    expect(opened.doc.script).toBe('condition hcp(north >= ')
+  })
+
+  it('opens a key a phone has lower-cased', async () => {
+    const kv = memoryKv()
+    const fetch = service(kv)
+    const { key } = await requestShortLink(doc, { base: PAGE, fetch })
+    const opened = await resolveFragment(`#k=${key.toLowerCase()}`, {
+      fetchShort: (k) => fetchShortLink(k, { base: PAGE, fetch }),
+    })
+    expect(opened.doc.script).toBe(SCRIPT)
+  })
+})
+
+describe('thirty days, fixed', () => {
+  it('expires thirty days after it was made, and says when', async () => {
+    const kv = memoryKv()
+    const now = Date.UTC(2026, 8, 10, 12)
+    const response = await createShortLink(post(await encodeDocument(doc)), kv, { now: () => now })
+    expect(response.status).toBe(201)
+    const { key, expires } = await response.json()
+    expect(expires).toBe('2026-10-10T12:00:00.000Z')
+
+    const [, , options] = kv.log.find(([op]) => op === 'put')
+    expect(options.expirationTtl).toBe(THIRTY_DAYS)
+
+    const read = await (await readShortLink(key, kv)).json()
+    expect(read.expires).toBe(expires)
+  })
+
+  it('writes nothing when a link is read', async () => {
+    // Deliberately not a sliding expiry: re-putting on read would spend the
+    // scarce write allowance on the plentiful operation.
+    const kv = memoryKv()
+    const { key } = await (await createShortLink(post(await encodeDocument(doc)), kv)).json()
+    const writes = kv.log.filter(([op]) => op === 'put').length
+    for (let i = 0; i < 5; i++) await readShortLink(key, kv)
+    expect(kv.log.filter(([op]) => op === 'put').length).toBe(writes)
+  })
+
+  it('says an unknown key has expired, through the page', async () => {
+    const fetch = service(memoryKv())
+    await expect(
+      resolveFragment('#k=ZZZZZZZZ', { fetchShort: (k) => fetchShortLink(k, { base: PAGE, fetch }) }),
+    ).rejects.toThrow(EXPIRED)
+  })
+
+  it('says a key that is not a key has expired, rather than something went wrong', async () => {
+    const response = await readShortLink('not-a-key!', memoryKv())
+    expect(response.status).toBe(404)
+    expect((await response.json()).error).toBe(EXPIRED)
+  })
+})
+
+describe('what the service refuses', () => {
+  it('refuses a write from another site', async () => {
+    const kv = memoryKv()
+    const response = await createShortLink(
+      post(await encodeDocument(doc), { origin: 'https://example.com' }),
+      kv,
+    )
+    expect(response.status).toBe(403)
+    expect(kv.log.filter(([op]) => op === 'put')).toHaveLength(0)
+  })
+
+  it('refuses a write with no origin at all', async () => {
+    const response = await createShortLink(post(await encodeDocument(doc), {}), memoryKv())
+    expect(response.status).toBe(403)
+  })
+
+  it('takes the apex, pages.dev, its previews and a local wrangler', () => {
+    expect(originAllowed('https://bridge-craftwork.com')).toBe(true)
+    expect(originAllowed('https://dealer3.pages.dev')).toBe(true)
+    expect(originAllowed('https://short-links-103.dealer3.pages.dev')).toBe(true)
+    expect(originAllowed('http://localhost:8788')).toBe(true)
+    expect(originAllowed('https://bridge-craftwork.com.evil.example')).toBe(false)
+    expect(originAllowed('https://notdealer3.pages.dev')).toBe(false)
+    expect(originAllowed('http://bridge-craftwork.com')).toBe(false)
+  })
+
+  it('refuses a body over the cap, before reading all of it', async () => {
+    const kv = memoryKv()
+    const response = await createShortLink(post('A'.repeat(MAX_BODY_BYTES + 1)), kv)
+    expect(response.status).toBe(413)
+    expect((await response.json()).error).toMatch(/long link/)
+  })
+
+  it('refuses what a page could not open', async () => {
+    for (const body of ['', 'not base64!', 'AAAA', await encodeText('{"v":1}')]) {
+      const kv = memoryKv()
+      const response = await createShortLink(post(body), kv)
+      expect(response.status, body).toBe(400)
+      expect(kv.log.filter(([op]) => op === 'put')).toHaveLength(0)
+    }
+  })
+
+  it('stores the document as this version reads it, not what else arrived', async () => {
+    const kv = memoryKv()
+    const payload = await encodeText(
+      JSON.stringify({ ...doc, settings: { ...doc.settings, pickerOpen: true }, extra: 'x'.repeat(100) }),
+    )
+    const { key } = await (await createShortLink(post(payload), kv)).json()
+    const opened = await resolveFragment(`#d=${kv.store.get(key).value}`)
+    expect(opened.doc.settings).not.toHaveProperty('pickerOpen')
+    expect(kv.store.get(key).value.length).toBeLessThan(payload.length)
+  })
+
+  it('says short links are used up when the write allowance is', async () => {
+    const response = await createShortLink(post(await encodeDocument(doc)), memoryKv({ failPuts: true }))
+    expect(response.status).toBe(503)
+    expect((await response.json()).error).toMatch(/used up for today.*long link/s)
+  })
+
+  it('says a missing binding is a missing binding, not a busy day', async () => {
+    const response = await createShortLink(post(await encodeDocument(doc)), undefined)
+    expect(response.status).toBe(503)
+    expect((await response.json()).error).toMatch(/not set up/)
+    expect((await (await readShortLink('AB3K9M2P', undefined)).json()).error).toMatch(/not set up/)
+  })
+
+  it('reaches the page as a sentence', async () => {
+    const fetch = service(memoryKv({ failPuts: true }))
+    await expect(requestShortLink(doc, { base: PAGE, fetch })).rejects.toThrow(/used up for today/)
+  })
+
+  it('says so, from a copy of the page with no service behind it', async () => {
+    const fetch = async () => new Response('<!doctype html>', { status: 405 })
+    await expect(requestShortLink(doc, { base: PAGE, fetch })).rejects.toThrow(/not available/)
+  })
+
+  it('draws again on a collision, and never overwrites', async () => {
+    const kv = memoryKv()
+    const keys = ['AAAAAAAA', 'AAAAAAAA', 'BBBBBBBB']
+    const key = () => keys.shift()
+    const first = await (await createShortLink(post(await encodeDocument(doc)), kv, { key })).json()
+    const second = await (await createShortLink(post(await encodeDocument(doc)), kv, { key })).json()
+    expect([first.key, second.key]).toEqual(['AAAAAAAA', 'BBBBBBBB'])
+  })
+})
+
+describe('keys', () => {
+  it('are eight characters of Crockford base32', () => {
+    for (let i = 0; i < 200; i++) expect(newKey()).toMatch(/^[0-9A-HJKMNP-TV-Z]{8}$/)
+  })
+
+  it('read the way Crockford says they should', () => {
+    expect(normalizeKey('ab3k9m2p')).toBe('AB3K9M2P')
+    expect(normalizeKey('AB3K-9M2P')).toBe('AB3K9M2P')
+    expect(normalizeKey('O1IL0000')).toBe('01110000')
+    expect(normalizeKey('AB3K9M2')).toBeNull()
+    expect(normalizeKey('AB3K9M2U')).toBeNull()
+    expect(normalizeKey('')).toBeNull()
+  })
+
+  it('reach the page from the query and back into the fragment', () => {
+    expect(shortKeyFromQuery('?k=AB3K9M2P')).toBe('AB3K9M2P')
+    expect(shortKeyFromQuery('?other=1')).toBeNull()
+    expect(parseFragment('#k=ab3k9m2p')).toEqual({ kind: 'key', key: 'AB3K9M2P' })
+  })
+})
+
+describe('the link people are sent', () => {
+  it('says how long it lasts, and lives under the page on either host', () => {
+    expect(shortLinkUrl({ origin: ORIGIN, pathname: '/dealer3/' }, 'AB3K9M2P')).toBe(
+      'https://bridge-craftwork.com/dealer3/30-days/AB3K9M2P',
+    )
+    expect(shortLinkUrl({ origin: 'https://dealer3.pages.dev', pathname: '/' }, 'AB3K9M2P')).toBe(
+      'https://dealer3.pages.dev/30-days/AB3K9M2P',
+    )
+    expect(shortLinkUrl({ origin: ORIGIN, pathname: '/dealer3/index.html' }, 'AB3K9M2P')).toBe(
+      'https://bridge-craftwork.com/dealer3/30-days/AB3K9M2P',
+    )
+  })
+
+  it('is short enough to text', () => {
+    expect(`${ORIGIN}/dealer3/${SHORT_LINK_PATH}/AB3K9M2P`.length).toBeLessThanOrEqual(60)
+  })
+
+  it('is served by a Function at the path the page builds', () => {
+    // The directory name and the constant are one promise, made twice.
+    const route = new URL(`../../../functions/${SHORT_LINK_PATH}/[key].js`, import.meta.url)
+    expect(existsSync(fileURLToPath(route))).toBe(true)
+  })
+
+  it('hands over to the page with the key in the query', () => {
+    const response = redirectShortLink('ab3k9m2p')
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/?k=AB3K9M2P')
+  })
+
+  it('passes a broken key through, so the page can say it has expired', () => {
+    expect(redirectShortLink('<script>').headers.get('location')).toBe('/?k=%3Cscript%3E')
+  })
+})
+
+/// A document as `#d=` would carry it, from JSON text rather than an object,
+/// for payloads `encodeDocument` would never make.
+async function encodeText(json) {
+  const stream = new Blob([json]).stream().pipeThrough(new CompressionStream('deflate-raw'))
+  const bytes = new Uint8Array(await new Response(stream).arrayBuffer())
+  return btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,8 +1,10 @@
 // Cloudflare Pages configuration.
 //
-// The site is a static build: the engine runs in the visitor's browser, so there
-// is nothing server-side to deploy. Everything the deploy needs lives here
-// rather than in dashboard settings, so a hosting change is a reviewable diff.
+// The site is a static build: the engine runs in the visitor's browser. The one
+// thing server-side is the short-link service (#103) — Pages Functions under
+// `functions/`, holding links in the KV namespace below. Everything the deploy
+// needs lives here rather than in dashboard settings, so a hosting change is a
+// reviewable diff.
 //
 // Deploy with `npx wrangler pages deploy` after `npm --prefix web run build:all`.
 //
@@ -15,5 +17,17 @@
 
   // Vite writes here. `web/public/` is copied in verbatim, which is how
   // `_headers` reaches the root of the deploy.
-  "pages_build_output_dir": "web/dist"
+  "pages_build_output_dir": "web/dist",
+
+  // Short links, for sending a script by text message. Each is the `#d=`
+  // payload of a long link, kept for thirty days by `expirationTtl` and then
+  // deleted by Cloudflare — nothing here cleans up. See
+  // web/src/lib/shortLinks.js. Created with
+  // `wrangler kv namespace create DEALER3_SHORT_LINKS`.
+  "kv_namespaces": [
+    {
+      "binding": "SHORT_LINKS",
+      "id": "9572ffba399749d6af78ca3fa11c1fcd"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #103.

The share panel offers **Short link** when the long link is over 100 characters: `bridge-craftwork.com/dealer3/30-days/AB3K9M2P`, stored in KV for a fixed 30 days.

- Stores the `#d=` payload, so a short link is an alias for a long one and is validated by the same `decodeDocument`/`readDocument` the page uses. No parse check — a broken script is a fine thing to send for help.
- Fixed TTL, not refreshed on read: no writes spent on reads, and the page can name the expiry date — in the share panel and in the notice a recipient sees.
- Abuse control: 8 KB cap, document must open, `Origin` check, and the daily write allowance failing closed. No per-IP limit (Pages Functions can't take the rate-limit binding; a KV counter would spend a write per share).
- `/30-days/<key>` → `/?k=<key>`, because the apex proxy drops a fragment on redirect; the page moves it into `#k=`.

KV namespace `DEALER3_SHORT_LINKS` created and bound in `wrangler.jsonc`. Verified end to end on a preview deploy against the real namespace. **This merge is the first CI deploy with a KV binding**, so it also tests whether `CLOUDFLARE_API_TOKEN` has the permission for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)