### PR TITLE
--stats-json: report level_types for a scenario that levels on them

### DIFF
--- a/dealer-run/src/lib.rs
+++ b/dealer-run/src/lib.rs
@@ -725,6 +725,15 @@ impl<'a> RunAccumulator<'a> {
         &self.leveling_counts
     }
 
+    /// Whether the script declares a levelling decomposition of its own.
+    ///
+    /// False says the levelling categories *are* the hand types, so the two
+    /// sets of counts are the same numbers under the same names, and a caller
+    /// reporting both would print each twice.
+    pub fn levels_on_level_types(&self) -> bool {
+        !self.level_type_names.is_empty()
+    }
+
     /// What was measured, in the form the levelling arithmetic reads.
     ///
     /// `generated` is the caller's: this counts what the condition accepted and

--- a/dealer-run/src/run.rs
+++ b/dealer-run/src/run.rs
@@ -190,6 +190,13 @@ pub struct RunReport {
     pub hit_limit: bool,
     /// The script's hand types and how many produced deals matched each.
     pub hand_types: Vec<(String, usize)>,
+    /// The categories the keeps were computed over, and how many produced deals
+    /// matched each. Empty unless the script declares `LevelType_` variables:
+    /// without them the levelling categories are the hand types above.
+    ///
+    /// This is what says a levelled run delivered its mix, when the two
+    /// decompositions differ — `hand_types` then counts something else.
+    pub level_types: Vec<(String, usize)>,
     /// What a round-robin run was aiming at, when it was one: the count every
     /// hand type is owed, and how many deals were left over for a partial round
     /// at the end. Against `hand_types` it says which types came up short.
@@ -982,6 +989,9 @@ struct Pass {
     generated: usize,
     measurement: dealer_level::Measurement,
     hand_types: Vec<(String, usize)>,
+    /// The levelling categories and their counts, empty unless the script
+    /// declares a decomposition of its own.
+    level_types: Vec<(String, usize)>,
     joint: Vec<Vec<usize>>,
     stats: Stats,
     retained: Retained,
@@ -1497,6 +1507,18 @@ fn run_pass(
         .cloned()
         .zip(accumulator.hand_type_counts().iter().copied())
         .collect();
+    // Empty when the levelling categories are the hand types: the same counts
+    // under the same names, and a caller would only print them twice.
+    let level_types: Vec<(String, usize)> = if accumulator.levels_on_level_types() {
+        accumulator
+            .leveling_labels()
+            .iter()
+            .cloned()
+            .zip(accumulator.leveling_counts().iter().copied())
+            .collect()
+    } else {
+        Vec::new()
+    };
     let joint = measurement.joint.clone();
     Ok(Pass {
         hit_limit: produced < opts.produce && generated >= opts.max_generate,
@@ -1504,6 +1526,7 @@ fn run_pass(
         generated,
         measurement,
         hand_types,
+        level_types,
         joint,
         stats: accumulator.finish(),
         retained,
@@ -1605,6 +1628,7 @@ pub fn run(script: &str, opts: RunOptions, host: &mut dyn RunHost) -> Result<Run
             generated: pass.generated,
             hit_limit: pass.hit_limit,
             hand_types: pass.hand_types,
+            level_types: pass.level_types,
             round_robin,
             stats: pass.stats,
             leveling: None,
@@ -1711,6 +1735,10 @@ pub fn run(script: &str, opts: RunOptions, host: &mut dyn RunHost) -> Result<Run
             .as_ref()
             .map(|p| p.hand_types.clone())
             .unwrap_or_else(|| characterizing.hand_types.clone()),
+        level_types: producing
+            .as_ref()
+            .map(|p| p.level_types.clone())
+            .unwrap_or_else(|| characterizing.level_types.clone()),
         round_robin,
         stats: match producing {
             Some(ref p) => p.stats.clone(),

--- a/dealer/src/main.rs
+++ b/dealer/src/main.rs
@@ -2046,6 +2046,9 @@ fn main() {
         }
         let hand_type_counts: Vec<usize> =
             report.hand_types.iter().map(|(_, count)| *count).collect();
+        // Labelled already, and empty unless the script levels on a
+        // decomposition of its own.
+        let level_types: Vec<(String, usize)> = report.level_types.clone();
         let averages = report.stats.averages.clone();
         let frequencies = report.stats.frequencies.clone();
 
@@ -2214,6 +2217,29 @@ fn main() {
                 out.push_str("  ");
             }
             out.push_str("],\n");
+
+            // The categories the keeps were computed over, when they are not
+            // the hand types. Checking a levelling means checking these: the
+            // hand types then group the deals for presentation and say nothing
+            // about what was levelled. Absent when the two are the same.
+            if !level_types.is_empty() {
+                out.push_str("  \"level_types\": [");
+                for (i, (label, count)) in level_types.iter().enumerate() {
+                    let share = if produced > 0 {
+                        *count as f64 / produced as f64
+                    } else {
+                        0.0
+                    };
+                    out.push_str(if i == 0 { "\n" } else { ",\n" });
+                    out.push_str(&format!(
+                        "    {{ \"name\": {}, \"produced\": {}, \"share\": {} }}",
+                        json_string(label),
+                        count,
+                        json_number(share)
+                    ));
+                }
+                out.push_str("\n  ],\n");
+            }
 
             out.push_str("  \"averages\": [");
             for (i, average) in averages.iter().enumerate() {

--- a/dealer/tests/stats_json.rs
+++ b/dealer/tests/stats_json.rs
@@ -140,6 +140,50 @@ fn awkward_labels_survive() {
     assert_eq!(v["averages"][0]["label"], label);
 }
 
+/// A scenario that levels on `LevelType_` is checked against *those* counts:
+/// its hand types group the deals for presentation and say nothing about what
+/// the keeps were computed over. Reporting only the hand types leaves a caller
+/// comparing the mix table against names that are not there.
+#[test]
+fn a_scenario_that_levels_on_level_types_reports_them() {
+    let script = "\
+HandType_Low = hcp(north) <= 11
+HandType_High = hcp(north) >= 12
+LevelType_A = hcp(north) <= 9
+LevelType_B = hcp(north) >= 10 and hcp(north) <= 11
+LevelType_C = hcp(north) >= 12
+condition 1
+";
+    let v = json(&["-q", "--stats-json", "-p", "300", "-s", "3"], script);
+    let hand = v["hand_types"].as_array().expect("hand_types");
+    let level = v["level_types"].as_array().expect("level_types");
+    assert_eq!(hand.len(), 2);
+    assert_eq!(level.len(), 3);
+    assert_eq!(level[0]["name"], "A");
+    assert_eq!(level[2]["name"], "C");
+    // Each decomposition partitions the deals on its own.
+    for types in [hand, level] {
+        let produced: u64 = types
+            .iter()
+            .map(|t| t["produced"].as_u64().expect("produced"))
+            .sum();
+        assert_eq!(produced, 300);
+    }
+}
+
+/// Absent, not empty, when the two are the same: the levelling categories are
+/// then the hand types, and printing them twice invites a reader to look for a
+/// difference that cannot be there.
+#[test]
+fn level_types_are_left_out_when_they_are_the_hand_types() {
+    let v = json(
+        &["-q", "--stats-json", "-p", "50", "-s", "1"],
+        "HandType_Low = hcp(north) <= 11\nHandType_High = hcp(north) >= 12\ncondition 1\n",
+    );
+    assert_eq!(v["hand_types"].as_array().expect("hand_types").len(), 2);
+    assert!(v.get("level_types").is_none());
+}
+
 #[test]
 fn a_script_with_no_statistics_still_gives_an_object() {
     let v = json(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`--stats-json` reports `level_types` for a scenario that levels on them.**
+  It carries the same shape as `hand_types` (`name`, `produced`, `share`), and
+  the array is left out when a scenario declares no `LevelType_`. Checking a
+  levelling means comparing the mix against the categories the keeps were
+  computed over. When a scenario declares `LevelType_`, those are not its hand
+  types, and the JSON used to report only the hand types. A build step comparing
+  the generated file's mix table with `hand_types` found none of the names, and
+  read every category as never dealt. Found on Practice-Bidding-Scenarios
+  `NT_Ladder`, which groups by five HCP bands and levels on each HCP.
 - **A solved-deal library is read from an offset, and only as far as the run
   needs** (#65). It used to be read whole into memory before the run started,
   which for the published 241 MB library is 10,485,760 deals whether the script

--- a/docs/leveling-guide.md
+++ b/docs/leveling-guide.md
@@ -513,6 +513,15 @@ a text table, and `hand_types` means a scenario needs no `average` statement per
 type to be told what it produced. Pair it with `-q` for a stdout that is nothing
 but JSON.
 
+A scenario that levels on `LevelType_` gets a second array, `level_types`, in
+the same shape — and **that is the one to check**. The keeps were computed over
+those categories, and they are what the generated file's mix table names.
+`hand_types` then answers a different question, the bands the deals are grouped
+by, and will not match the mix: check both, but expect the mix only from the
+level types. The array is absent, not empty, when a scenario declares no level
+types, because its levelling categories are then its hand types and the two
+would be the same counts under the same names.
+
 **10,000 produced is a good default** for this check — about ±1 point for
 anything from three bands to ten, and a second or two.
 


### PR DESCRIPTION
A scenario can group its deals by one decomposition (`HandType_`) and level them on another (`LevelType_`). This is the guide's "when levelling and presenting want different categories". The keeps and the generated file's mix table are over the **level types**, but `--stats-json` reported only `hand_types`. A build step checking the mix found none of the names and read every category as dealt 0%.

Found on Practice-Bidding-Scenarios `NT_Ladder` (bridge-craftwork/Practice-Bidding-Scenarios#336). It groups by five HCP bands and levels on each HCP with shares 2:2:3:3:2. Its pipeline's `level` step wrote a correct file and then failed its own check:

```
    12               mix   6.7%   dealt   0.0%
    ...
Error: level: a hand type was dealt 10.0% away from its mix (allowed 2%)
```

## Change
The run already counted both decompositions; the counts just stopped at the accumulator.
- `RunAccumulator::levels_on_level_types()` says whether the script declares its own decomposition.
- `RunReport` carries `level_types` beside `hand_types` on both the plain and the levelled path.
- `--stats-json` emits `level_types` in the same shape as `hand_types` (`name`, `produced`, `share`). The array is **left out** when a scenario declares no `LevelType_`, because its levelling categories are then its hand types, the same counts under the same names.

## Tested
- Two new tests in `dealer/tests/stats_json.rs`:
  - a scenario grouping by two hand types and levelling on three level types reports both, and each partitions the produced deals;
  - a scenario with hand types only has no `level_types` key.
- `cargo test --release` passes in full.
- On `NT_Ladder`'s regenerated leveled file, 3,000 deals: `hand_types` five bands at 18.9–20.8%; `level_types` thirteen values at 5.5–7.6% (target 6.7%) and 9.7–10.5% (target 10%).
- `Drury` (hand types only): no `level_types` key, output otherwise unchanged.

Docs: the leveling guide's "Verifying the result" section says which array to check. CHANGELOG entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
